### PR TITLE
Branch abraham

### DIFF
--- a/04332_Tempelhof.csv
+++ b/04332_Tempelhof.csv
@@ -37,7 +37,7 @@ WS26	Hinger unse Hus stehn drei scheene Äppelbeme mett rude Äppels.
 WS27	Könnt ihr nicht en Ogenblick uf uns wuordden, denn gohn wy mett euch.
 WS28	J deofft nicht sonne Kinderreien trüwen. (Mak nich sine Flusen)
 WS29	Use Berge sind (Nicht zu übersetzen) (Ein echter Märker kennt keine Berge.)
-WS30	Wie vĕlle Pfund Worst und wie vĕlle Brod wollt ÿ hawen.
+WS30	Wie vĕlle Pfund Worst und wie vĕlle Brod wollt ÿ hawen?
 WS31	Jik verstohe jau nich, ÿ müßt een bitzken ludder spreken.
 WS32	Hĕbt y nich een Stück wieße (wite) Seepe for mei auf/up myn Tisch gefungen?
 WS33	Syn Brodder woll sich zwee scheene neue Hüser in jaueon Guoarden baun.

--- a/06213_Sondershausen.csv
+++ b/06213_Sondershausen.csv
@@ -18,8 +18,8 @@ WS07	Ä̆ ißt dĕ Eier immer ohne Sōlz unn Pfähell affer.
 WS08	Dĕ Füße thun¯  mich sihre wih, ich glaube, ich haaoh sĕ därch jgelaufen.
 WS09	Ich bä̆nn bĭ dr Frau hell a gewast unn haaoh’s éhr jgesāht, unn sĕ sāhte, sĕ wullt’s ou éhrer Tochtr sāh.
 WS10	Ich wäll’s au nich mīh wädder thu!
-WS11	Ich schlōh dich klīch mä̆t͜t de Kochlöffl  ĭm dĕ Ūhren, du Affe!
-WS12	Wū gĭst͜ dĕ hä̆nn, sŭnn͜ mĕ mä̆tt dich gīh?
+WS11	Ich schlōh dich klīch mä̆t͡t de Kochlöffl  ĭm dĕ Ūhren, du Affe!
+WS12	Wū gĭst͡ dĕ hä̆nn, sŭnn͜ mĕ mä̆tt dich gīh?
 WS13	‘s͜ sinn helles a schlajte Zītn!
 WS14	Mĭnn liebes Kind, blĭpp hier ungen stīh, dĕ bīsen Géuse bīßen dich tūdt.
 WS15	Du hä̆st hīte am méhrschtn jelarnt unn du bist ārtg hell a gewast; du dérfst īhr heim gih wie dĕ Annern.
@@ -28,7 +28,7 @@ WS17	Gīh, sĭnk su gūt unn sack dinner  hell a Schwaster, sĕ sillte dĕ Kleid
 WS18	Héttst dĕ éhn jekannt! Do wére’s annerscht jekom¯en unn ä̆s théte bésser ümm éhn stīh.
 WS19	hell a War hätt mich mĭnn Korb mä̆tt Fleisch jgestolln?
 WS20	Ä̆ that sū, als hétten sé éhn zŭm hell a Draschen bestéllt; sĕ hann͜‘s ăbbr hell a salbr jethŏnn.
-WS21	hell a Wahn hätt͜ ĕ dĕ nä͜ie Geschichte erza͡oahlt?
+WS21	hell a Wahn hätt͡ ĕ dĕ nä͜ie Geschichte erza͡oahlt?
 WS22	Mĕ muß lūht kréhle, sünnst verstĭtt hĕ uns nĭch.
 WS23	Mĕ sinn müde unn hann Dŏrscht.
 WS24	Wie mĕ géster Ābbĕnd zĕrück kaa͡͡omen, dō lagen dĕ Annern schŭnn zĕ Bétt unn waa͡oren fést binn Schlōfen.
@@ -47,4 +47,4 @@ WS36	Was sitzen do fä̆rr Végelchen ūbe ŭff de Mṻhrchen?
 WS37	Dĕ Būren hotten fünf Ocksen unn nīn Kä̆͡ĭwĕ unn zwelf Schéfchen fä̆rr͜ ‘s <(vor das)> Dorf jgebrōcht, dī wulltn sĕ verkaufe.
 WS38	Dĕ Līte sinn hīte a͜oalle drussen ŭff de hell a Falle un schnīten <(mähen.)>
 WS39	Gĭck nur, dr brūne Hund dĭtt dich nischt.
-WS40	Ich bä̆nn mä̆tt͜ n <(den)> Līten do hingene <(hinten)> ä̆bbr dĕ Wā̈sen ins Korn gefa͜oaren.
+WS40	Ich bä̆nn mä̆tt͡ n <(den)> Līten do hingene <(hinten)> ä̆bbr dĕ Wā̈sen ins Korn gefa͜oaren.

--- a/06213_Sondershausen.csv
+++ b/06213_Sondershausen.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	In Winner flilegen dĕ trocknen Bl[é]tter därch dĕ Luft rĭmm.
 WS02	's hīet glīch uff zĕ schnä͜ĭen, nāchten wä̆rd’s hell a Watter wä̆dder bĕsser.
-WS03	Thŭk Kulln in͜de Ūben, daß dĕ Mälch bōlĕ zĕ kochen ānfängt.
+WS03	Thŭk Kulln in͡de Ūben, daß dĕ Mälch bōlĕ zĕ kochen ānfängt.
 WS04	Dr kute ōhle Maaonn ä̆s mä̆tt de hell a Fähre därch’s Īhs j gebrochen unn ins kōhle Wasser jefalln.
 WS05	Ä̆̆ ä̆s fäer vier oddr sax hell a Wochen j gestorbn.
 WS06	[O]s͡Fīhr waaor sĕ heis, dĕ Kūchen sinn ungen gaa͡onz schwaa͡orz jgebrannt.
@@ -19,7 +19,7 @@ WS08	Dĕ Füße thun¯  mich sihre wih, ich glaube, ich haaoh sĕ därch jgelauf
 WS09	Ich bä̆nn bĭ dr Frau hell a gewast unn haaoh’s éhr jgesāht, unn sĕ sāhte, sĕ wullt’s ou éhrer Tochtr sāh.
 WS10	Ich wäll’s au nich mīh wädder thu!
 WS11	Ich schlōh dich klīch mä̆t͡t de Kochlöffl  ĭm dĕ Ūhren, du Affe!
-WS12	Wū gĭst͡ dĕ hä̆nn, sŭnn͜ mĕ mä̆tt dich gīh?
+WS12	Wū gĭst͡ dĕ hä̆nn, sŭnn͡ mĕ mä̆tt dich gīh?
 WS13	‘s͡ sinn helles a schlajte Zītn!
 WS14	Mĭnn liebes Kind, blĭpp hier ungen stīh, dĕ bīsen Géuse bīßen dich tūdt.
 WS15	Du hä̆st hīte am méhrschtn jelarnt unn du bist ārtg hell a gewast; du dérfst īhr heim gih wie dĕ Annern.
@@ -27,7 +27,7 @@ WS16	Du bĭst năch nĭch grūß jenungk, änne Flasche Wīhn ūszutrinken, du m
 WS17	Gīh, sĭnk su gūt unn sack dinner  hell a Schwaster, sĕ sillte dĕ Kleider fä̆rr éhre Muttr fä̆rtg nīh unn mä̆tt dr Börschte reine mache.
 WS18	Héttst dĕ éhn jekannt! Do wére’s annerscht jekom¯en unn ä̆s théte bésser ümm éhn stīh.
 WS19	hell a War hätt mich mĭnn Korb mä̆tt Fleisch jgestolln?
-WS20	Ä̆ that sū, als hétten sé éhn zŭm hell a Draschen bestéllt; sĕ hann͜‘s ăbbr hell a salbr jethŏnn.
+WS20	Ä̆ that sū, als hétten sé éhn zŭm hell a Draschen bestéllt; sĕ hann͡‘s ăbbr hell a salbr jethŏnn.
 WS21	hell a Wahn hätt͡ ĕ dĕ nä͜ie Geschichte erza͡oahlt?
 WS22	Mĕ muß lūht kréhle, sünnst verstĭtt hĕ uns nĭch.
 WS23	Mĕ sinn müde unn hann Dŏrscht.
@@ -41,7 +41,7 @@ WS30	Wie väle Fund Wŏrscht unn wie vā̈l Brūt wullt dī hell a hāh?
 WS31	Ich verstīh ŭch nich, dī müßt ä̆n bischen lūter hell a sprache.
 WS32	Hāht dī kein Stückchen wĭsse Seifen färr mich ŭff mĭnn Dĭsche gefungen <(kein= mich ä)>
 WS33	Sĭnn Bruder wäll sich zwei schīne nä̆͜iĕ Hisser in ūren Gōrten baue.
-WS34	Das Wort kam͜ n <(n=ihm)> von hell a Hărzen!
+WS34	Das Wort kam͡ n <(n=ihm)> von hell a Hărzen!
 WS35	Das wa͡oar hell a racht von Sé <(ihnen)>!
 WS36	Was sitzen do fä̆rr Végelchen ūbe ŭff de Mǖhrchen?
 WS37	Dĕ Būren hotten fünf Ocksen unn nīn Kä̆͡ĭwĕ unn zwelf Schéfchen fä̆rr͡ ‘s <(vor das)> Dorf jgebrōcht, dī wulltn sĕ verkaufe.

--- a/06213_Sondershausen.csv
+++ b/06213_Sondershausen.csv
@@ -9,7 +9,7 @@ Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
 WS01	In Winner flilegen dĕ trocknen Bl[é]tter därch dĕ Luft rĭmm.
-WS02	's hīet glīch uff zĕ schnä͜ĭen, nāchten wä̆rd’s hell a Watter wä̆dder bĕsser.
+WS02	's hīet glīch uff zĕ schnä͡ĭen, nāchten wä̆rd’s hell a Watter wä̆dder bĕsser.
 WS03	Thŭk Kulln in͡de Ūben, daß dĕ Mälch bōlĕ zĕ kochen ānfängt.
 WS04	Dr kute ōhle Maaonn ä̆s mä̆tt de hell a Fähre därch’s Īhs j gebrochen unn ins kōhle Wasser jefalln.
 WS05	Ä̆̆ ä̆s fäer vier oddr sax hell a Wochen j gestorbn.
@@ -28,23 +28,23 @@ WS17	Gīh, sĭnk su gūt unn sack dinner  hell a Schwaster, sĕ sillte dĕ Kleid
 WS18	Héttst dĕ éhn jekannt! Do wére’s annerscht jekom¯en unn ä̆s théte bésser ümm éhn stīh.
 WS19	hell a War hätt mich mĭnn Korb mä̆tt Fleisch jgestolln?
 WS20	Ä̆ that sū, als hétten sé éhn zŭm hell a Draschen bestéllt; sĕ hann͡‘s ăbbr hell a salbr jethŏnn.
-WS21	hell a Wahn hätt͡ ĕ dĕ nä͜ie Geschichte erza͡oahlt?
+WS21	hell a Wahn hätt͡ ĕ dĕ nä͡ie Geschichte erza͡oahlt?
 WS22	Mĕ muß lūht kréhle, sünnst verstĭtt hĕ uns nĭch.
 WS23	Mĕ sinn müde unn hann Dŏrscht.
-WS24	Wie mĕ géster Ābbĕnd zĕrück kaa͡͡omen, dō lagen dĕ Annern schŭnn zĕ Bétt unn waa͡oren fést binn Schlōfen.
-WS25	Dr Schnī ä̆s dĭsse Naaocht bī uns lā̈h jgebläbbn, hell a abbr hīte Morjgen ä̆s͡ ĕ jgeschmulzen.
+WS24	Wie mĕ géster Ābbĕnd zĕrück kaa͡omen, dō lagen dĕ Annern schŭnn zĕ Bétt unn waa͡oren fést binn Schlōfen.
+WS25	Dr Schnī ä̆s dĭsse Naaocht bī uns lǟh jgebläbbn, hell a abbr hīte Morjgen ä̆s͡ ĕ jgeschmulzen.
 WS26	Hinger unsen Hūse stīnn Appelbeimchen mä̆tt rūthen Éppelchen.
 WS27	Kinnt dih nich năch ä̆n Au’nblickchen</Mählchen,Wihlchen,Bischen)> uff uns wōhrte, na͡oachen gīhn m¯i mä̆tt ech.
-WS28	Dīe dörft nich sulche Kingerä͜ien trībe!
+WS28	Dīe dörft nich sulche Kingerä͡ien trībe!
 WS29	Unsere hell a Barje sinn nich sihre hūch, ūre sinn väle hö̆cher.
-WS30	Wie väle Fund Wŏrscht unn wie vā̈l Brūt wullt dī hell a hāh?
+WS30	Wie väle Fund Wŏrscht unn wie vǟl Brūt wullt dī hell a hāh?
 WS31	Ich verstīh ŭch nich, dī müßt ä̆n bischen lūter hell a sprache.
 WS32	Hāht dī kein Stückchen wĭsse Seifen färr mich ŭff mĭnn Dĭsche gefungen <(kein= mich ä)>
-WS33	Sĭnn Bruder wäll sich zwei schīne nä̆͜iĕ Hisser in ūren Gōrten baue.
+WS33	Sĭnn Bruder wäll sich zwei schīne nä̆͡iĕ Hisser in ūren Gōrten baue.
 WS34	Das Wort kam͡ n <(n=ihm)> von hell a Hărzen!
 WS35	Das wa͡oar hell a racht von Sé <(ihnen)>!
 WS36	Was sitzen do fä̆rr Végelchen ūbe ŭff de Mǖhrchen?
 WS37	Dĕ Būren hotten fünf Ocksen unn nīn Kä̆͡ĭwĕ unn zwelf Schéfchen fä̆rr͡ ‘s <(vor das)> Dorf jgebrōcht, dī wulltn sĕ verkaufe.
-WS38	Dĕ Līte sinn hīte a͜oalle drussen ŭff de hell a Falle un schnīten <(mähen.)>
+WS38	Dĕ Līte sinn hīte a͡oalle drussen ŭff de hell a Falle un schnīten <(mähen.)>
 WS39	Gĭck nur, dr brūne Hund dĭtt dich nischt.
-WS40	Ich bä̆nn mä̆tt͡ n <(den)> Līten do hingene <(hinten)> ä̆bbr dĕ Wā̈sen ins Korn gefa͜oaren.
+WS40	Ich bä̆nn mä̆tt͡ n <(den)> Līten do hingene <(hinten)> ä̆bbr dĕ Wǟsen ins Korn gefa͡oaren.

--- a/06213_Sondershausen.csv
+++ b/06213_Sondershausen.csv
@@ -13,14 +13,14 @@ WS02	's hīet glīch uff zĕ schnä͜ĭen, nāchten wä̆rd’s hell a Watter w�
 WS03	Thŭk Kulln in͜de Ūben, daß dĕ Mälch bōlĕ zĕ kochen ānfängt.
 WS04	Dr kute ōhle Maaonn ä̆s mä̆tt de hell a Fähre därch’s Īhs j gebrochen unn ins kōhle Wasser jefalln.
 WS05	Ä̆̆ ä̆s fäer vier oddr sax hell a Wochen j gestorbn.
-WS06	[O]s͜Fīhr waaor sĕ heis, dĕ Kūchen sinn ungen gaa͡onz schwaa͡orz jgebrannt.
+WS06	[O]s͡Fīhr waaor sĕ heis, dĕ Kūchen sinn ungen gaa͡onz schwaa͡orz jgebrannt.
 WS07	Ä̆ ißt dĕ Eier immer ohne Sōlz unn Pfähell affer.
 WS08	Dĕ Füße thun¯  mich sihre wih, ich glaube, ich haaoh sĕ därch jgelaufen.
 WS09	Ich bä̆nn bĭ dr Frau hell a gewast unn haaoh’s éhr jgesāht, unn sĕ sāhte, sĕ wullt’s ou éhrer Tochtr sāh.
 WS10	Ich wäll’s au nich mīh wädder thu!
 WS11	Ich schlōh dich klīch mä̆t͡t de Kochlöffl  ĭm dĕ Ūhren, du Affe!
 WS12	Wū gĭst͡ dĕ hä̆nn, sŭnn͜ mĕ mä̆tt dich gīh?
-WS13	‘s͜ sinn helles a schlajte Zītn!
+WS13	‘s͡ sinn helles a schlajte Zītn!
 WS14	Mĭnn liebes Kind, blĭpp hier ungen stīh, dĕ bīsen Géuse bīßen dich tūdt.
 WS15	Du hä̆st hīte am méhrschtn jelarnt unn du bist ārtg hell a gewast; du dérfst īhr heim gih wie dĕ Annern.
 WS16	Du bĭst năch nĭch grūß jenungk, änne Flasche Wīhn ūszutrinken, du mußt é̆rscht năch än Ènge wackse unn grisser helles a ware.
@@ -32,7 +32,7 @@ WS21	hell a Wahn hätt͡ ĕ dĕ nä͜ie Geschichte erza͡oahlt?
 WS22	Mĕ muß lūht kréhle, sünnst verstĭtt hĕ uns nĭch.
 WS23	Mĕ sinn müde unn hann Dŏrscht.
 WS24	Wie mĕ géster Ābbĕnd zĕrück kaa͡͡omen, dō lagen dĕ Annern schŭnn zĕ Bétt unn waa͡oren fést binn Schlōfen.
-WS25	Dr Schnī ä̆s dĭsse Naaocht bī uns lā̈h jgebläbbn, hell a abbr hīte Morjgen ä̆s͜ ĕ jgeschmulzen.
+WS25	Dr Schnī ä̆s dĭsse Naaocht bī uns lā̈h jgebläbbn, hell a abbr hīte Morjgen ä̆s͡ ĕ jgeschmulzen.
 WS26	Hinger unsen Hūse stīnn Appelbeimchen mä̆tt rūthen Éppelchen.
 WS27	Kinnt dih nich năch ä̆n Au’nblickchen</Mählchen,Wihlchen,Bischen)> uff uns wōhrte, na͡oachen gīhn m¯i mä̆tt ech.
 WS28	Dīe dörft nich sulche Kingerä͜ien trībe!
@@ -43,8 +43,8 @@ WS32	Hāht dī kein Stückchen wĭsse Seifen färr mich ŭff mĭnn Dĭsche gefun
 WS33	Sĭnn Bruder wäll sich zwei schīne nä̆͜iĕ Hisser in ūren Gōrten baue.
 WS34	Das Wort kam͜ n <(n=ihm)> von hell a Hărzen!
 WS35	Das wa͡oar hell a racht von Sé <(ihnen)>!
-WS36	Was sitzen do fä̆rr Végelchen ūbe ŭff de Mṻhrchen?
-WS37	Dĕ Būren hotten fünf Ocksen unn nīn Kä̆͡ĭwĕ unn zwelf Schéfchen fä̆rr͜ ‘s <(vor das)> Dorf jgebrōcht, dī wulltn sĕ verkaufe.
+WS36	Was sitzen do fä̆rr Végelchen ūbe ŭff de Mǖhrchen?
+WS37	Dĕ Būren hotten fünf Ocksen unn nīn Kä̆͡ĭwĕ unn zwelf Schéfchen fä̆rr͡ ‘s <(vor das)> Dorf jgebrōcht, dī wulltn sĕ verkaufe.
 WS38	Dĕ Līte sinn hīte a͜oalle drussen ŭff de hell a Falle un schnīten <(mähen.)>
 WS39	Gĭck nur, dr brūne Hund dĭtt dich nischt.
 WS40	Ich bä̆nn mä̆tt͡ n <(den)> Līten do hingene <(hinten)> ä̆bbr dĕ Wā̈sen ins Korn gefa͜oaren.

--- a/06504_Eisleben.csv
+++ b/06504_Eisleben.csv
@@ -15,7 +15,7 @@ WS04	Där jute, olle Mann is’ metten Fähre dorch’s Eis gebrochen un’ in�
 WS05	Ä is’ farr vier odder säcks Wochen gestorben.
 WS06	S’ Feier war su häß, de Kuchen sin je ungne janz schwarz gebrennt!
 WS07	Ä frißt de Eier immer ohne Sōlz un Fäffer.
-WS08	De Fiehße thun mich wieh, ich gl(ō̠͡u)be, ich habbese <(hawwese)> dorch gela̠͡͡ufen <(mehr a)>
+WS08	De Fiehße thun mich wieh, ich gl(ō̠͡u)be, ich habbese <(hawwese)> dorch gela̠͡ufen <(mehr a)>
 WS09	Ich bin bei dr Fraue gewäsen un habbeser gesaht, un se sahte, se wulles au ehrer Tochter sahn.
 WS10	Ich will’s au nich mieh wedder thun!
 WS11	Ich schlohe dich glei metten K(o)chleffel um de Uhren, du Affe.

--- a/09746_Kobylagora.csv
+++ b/09746_Kobylagora.csv
@@ -34,7 +34,7 @@ WS21	Wemen hat er die neue Geſchichte derzeilt?
 WS22	Man müß hoih ſchrain, ſonſt verſtait ers nicht.
 WS23	Wir ſind müüd und darſt üns.
 WS24	Als wir geſter Awend zurückgekümmen, ſo ſennen ſchoen die Anderen im Bett gelegen, ünd hoben feſt geſchlofen.
-WS25	Der Schnai iſt bai üns die Nacht liegen geblieben, aber ha̅nt in der früh iſt er wieder zergangen.
+WS25	Der Schnai iſt bai üns die Nacht liegen geblieben, aber hānt in der früh iſt er wieder zergangen.
 WS26	Hinter ünſer Hous ſtehn drai ſchaine Bäumlēch mit roite Äpelech.
 WS27	Kön̄t ihr niſcht noch an Oigenblik ouf üns warten, dai gahn wir mit züſam̄en.
 WS28	Ihr müßt Euch niſcht ſo kindernariſch machen.

--- a/09746_Kobylagora.csv
+++ b/09746_Kobylagora.csv
@@ -15,8 +15,8 @@ WS02	Es hört bald üf zu ſchneien, da werden wir ſchain Wetter haan.
 WS03	Thü rein die Koilen in den Oiwen, die Milich ſoll bald kochen.
 WS04	Der güte alte Mann iſt durch den Aaz mit dem Pfeerd gebrochen in kalten Waſſer ran gefallen.
 WS05	Er iſt vor vier oder ſechs Wochen geſtorben.
-WS06	Dues Fahr wur zu heiß, die Küechen iſt ünten verbren̅t.
-WS07	Er eßt die Eier im̅er ohne Salz u. Pfeffer.
+WS06	Dues Fahr wur zu heiß, die Küechen iſt ünten verbren̄t.
+WS07	Er eßt die Eier im̄er ohne Salz u. Pfeffer.
 WS08	Die Füß thün mir ſehr weih, ich mein ich hab mer ſie durchgeloffen.
 WS09	Ich bin bei der Frau geweſen u ich hob’ es ihr geſugt, u. ſie hat geſugt, ſie hats auch gewellt ihrer Tochte ſogen.
 WS10	Ich will es auch niſcht mehr thün.
@@ -27,7 +27,7 @@ WS14	Maan lieb Kind, blaab ünten ſtain, die baiſe Gänſe baaßen diech tojd.
 WS15	Dü hoſt haet am meiſten gelernt und biſt orntlich geweſen, dü mögſt frürer haim gain wie die andere.
 WS16	Dü biſt niſcht groiß genüng, üm ain Flaſch’ Waan auszetrinken, dü müßt noch a Bißel größr wachſen.
 WS17	Gai, ſa ſo güt und ſog dān Schweſter, ſie hat geſelt der Mutter die Kleider fartik naen ün mit da Barſcht rain machen.
-WS18	Häſt du ihn gekennt, hätt es anders geküm̅en, ünd es hätte ihm beſser geſtannen.
+WS18	Häſt du ihn gekennt, hätt es anders geküm̄en, ünd es hätte ihm beſser geſtannen.
 WS19	Wer hat mir main Koreb mit dem Fleiſh geſtohlen?
 WS20	Er haite ſo gethün, daß er hot gewellt zum dreſchen beſtellen, er hots allein gethün.
 WS21	Wemen hat er die neue Geſchichte derzeilt?
@@ -36,7 +36,7 @@ WS23	Wir ſind müüd und darſt üns.
 WS24	Als wir geſter Awend zurückgekümmen, ſo ſennen ſchoen die Anderen im Bett gelegen, ünd hoben feſt geſchlofen.
 WS25	Der Schnai iſt bai üns die Nacht liegen geblieben, aber ha̅nt in der früh iſt er wieder zergangen.
 WS26	Hinter ünſer Hous ſtehn drai ſchaine Bäumlēch mit roite Äpelech.
-WS27	Kön̅t ihr niſcht noch an Oigenblik ouf üns warten, dai gahn wir mit züſam̅en.
+WS27	Kön̄t ihr niſcht noch an Oigenblik ouf üns warten, dai gahn wir mit züſam̄en.
 WS28	Ihr müßt Euch niſcht ſo kindernariſch machen.
 WS29	Ünſer Barge ſind nicht ſehr hoich, Enkern ſind höcher.
 WS30	Wie viel Fünd Worſt ünd wie viel Broid wilt ihr hoben?

--- a/10235_Clotten.csv
+++ b/10235_Clotten.csv
@@ -13,7 +13,7 @@ WS02	E˘t hiert geleich of zä schniä, da wierd dat Wärrer wider bässer.
 WS03	Doh Kolle in da Owä, dat de Melech bahl o͡af ze koche fängt.
 WS04	Dä gore alde Mahn ös met dem Pährt durich ’et Ëis gebroch un en dat kald Wasser gefahl.
 WS05	Äh ös fier veer orer sechs Wochä gestorwä.
-WS06	Dat Feier wȯȧr ä su has, die Kooche sei jo unne janz schwoarz verbrannt.
+WS06	Dat Feier wȯår ä su has, die Kooche sei jo unne janz schwoarz verbrannt.
 WS07	Äh eßt die Aier immer oahne Salz und Päffer.
 WS08	Die Fehß dehmer a su wieh, ech gelaf, ech han se derich gelahf.
 WS09	Êch sėin bėi där Fraa gewehst un hoann et’r gesoht, un sėi soht, sie wollet och ihrer Dochder soa.
@@ -26,7 +26,7 @@ WS15	Dau hoß haut am maßt geliart un beß oardig gewäßt, dau doarfs freher h
 WS16	Dau beß noch nit gruß jenooch, im ’n Flasch Wėin auszedrinke, dau moß derescht noch ä Enn woase un grießer währe.
 WS17	Jank, sėi su gohd un soh dėiner Schwäster, sėi soll die Klärer fier eier Modder färdig nähe un met d’r Bihschd rähn mache.
 WS18	Häs dau n kennd! da wä?et aneschder kumme, un et däht besser im e stah.
-WS19	Ber (hät) hȯȧt mer meine Koref med Flahsch gestohl?
+WS19	Ber (hät) hȯåt mer meine Koref med Flahsch gestohl?
 WS20	Äh dohcht e su, als härrense ime zum Dräsche bestalt, se hoanet awer selwer jedoh.
 WS21	Bem hod’n die nėi Geschicht verzelld?
 WS22	Ma mohs laut schrein’, soß verstäd’n ’s net.

--- a/10504_Orlen.csv
+++ b/10504_Orlen.csv
@@ -40,7 +40,7 @@ WS29	Ŭß Barjĕ sinn nit oark hūch, oiĕr säïn fill hieher.
 WS30	Wёivill Pund Worscht ’n Brut wollt’r hōn? <(wie franz. on)>
 WS31	Ich verschtien oich nit, ’r mißt ĕ bische härter schwetze.
 WS32	hott’r kan <(franz. quand)> Stückelche weiß Saaf fer mich ŭff meim Disch gĕfunnĕ.
-WS33	Sein <(e wie franz. en)> Broŭrĕ will sich zwaa schēn̆e noie hoiser in oierm Goarte bauĕ.
+WS33	Sein <(e wie franz. en)> Broŭrĕ will sich zwaa schēňe noie hoiser in oierm Goarte bauĕ.
 WS34	Deß Wort kōm ’m aus’m Hărz.
 WS35	Doas <(wie engl. what)> woar recht von ’n.
 WS36	Woas sitze dō uwwe fēr Vielcher uff’m Meuerche?

--- a/10504_Orlen.csv
+++ b/10504_Orlen.csv
@@ -27,7 +27,7 @@ WS16	Du bist noch nit gruß gēnunk, emm ĕ Flasch Wăin aussĕtrinkĕ, du mußt
 WS17	Gieh, sei su gout en so͡a deiner Schwest’r sĕ soll die Klaarĕ fer euer Motter fertig nehĕ un met d’r Berscht sauwer mache.
 WS18	hest’n gekennt! dan <(franz. dans)> wersch annerscht kommĕ u’s deht besser em’n schten.
 WS19	Wār hot m’r mäïn Korb met Flāsch gêstohln?
-WS20	Êr doaht su, als herre s’n zom dresche bĕschtellt, sĕ houns o͡͡awer selwer gedon <(wie franz. dont)>.
+WS20	Êr doaht su, als herre s’n zom dresche bĕschtellt, sĕ houns o͡awer selwer gedon <(wie franz. dont)>.
 WS21	Wêm hôrre die noi Geschicht verziehlt?
 WS22	M’r muß hŏart kräïsche, sost verschtierĕ ahm nit.
 WS23	M’r sin muid enn honn Dorscht.

--- a/10504_Orlen.csv
+++ b/10504_Orlen.csv
@@ -31,20 +31,20 @@ WS20	Êr doaht su, als herre s’n zom dresche bĕschtellt, sĕ houns o͡awer se
 WS21	Wêm hôrre die noi Geschicht verziehlt?
 WS22	M’r muß hŏart kräïsche, sost verschtierĕ ahm nit.
 WS23	M’r sin muid enn honn Dorscht.
-WS24	Wёï m’r gester Owend ham kome, do honn die annern schon <(wie franz. on)> em Bett gê̂̄lēhĕ enn woarn fest ĕngĕschlōfĕ.
+WS24	Wëï m’r gester Owend ham kome, do honn die annern schon <(wie franz. on)> em Bett gê̂̄lēhĕ enn woarn fest ĕngĕschlōfĕ.
 WS25	D’r Schnie iß die No͡cht bei uß laie blĭ̆ewe, oawer hoit morjend iß ĕ geschmolze.
 WS26	henner uß’m haŭs stehn drei schene Eppelbēmch’r met rure Eppelch’r.
 WS27	Kunnt ’r nit noch en Āgeblick uff uß woarte, dan <(franz. dans)> gehe m’r met oich.
 WS28	Ǟr derft suh kan <(franz. quand)> Kinneriĕ treiwĕ.
 WS29	Ŭß Barjĕ sinn nit oark hūch, oiĕr säïn fill hieher.
-WS30	Wёivill Pund Worscht ’n Brut wollt’r hōn? <(wie franz. on)>
+WS30	Wëivill Pund Worscht ’n Brut wollt’r hōn? <(wie franz. on)>
 WS31	Ich verschtien oich nit, ’r mißt ĕ bische härter schwetze.
 WS32	hott’r kan <(franz. quand)> Stückelche weiß Saaf fer mich ŭff meim Disch gĕfunnĕ.
 WS33	Sein <(e wie franz. en)> Broŭrĕ will sich zwaa schēňe noie hoiser in oierm Goarte bauĕ.
 WS34	Deß Wort kōm ’m aus’m Hărz.
 WS35	Doas <(wie engl. what)> woar recht von ’n.
 WS36	Woas sitze dō uwwe fēr Vielcher uff’m Meuerche?
-WS37	Die Bauern harre fenf Okse en noi Kui un zwelf Schefcher fersch Dorf bracht, dёï wolltĕ sĕ v’rkaafe.
-WS38	Dёï Loit sein hoit all drauß uff’m Feld en mehĕ.
+WS37	Die Bauern harre fenf Okse en noi Kui un zwelf Schefcher fersch Dorf bracht, dëï wolltĕ sĕ v’rkaafe.
+WS38	Dëï Loit sein hoit all drauß uff’m Feld en mehĕ.
 WS39	Gieh nōr d’r braun hund dout d’r niks.
 WS40	Ich senn met de Loit dō henne iwwer die Wiß ens Korn gefoarn.

--- a/11618_Stadtlauringen.csv
+++ b/11618_Stadtlauringen.csv
@@ -13,7 +13,7 @@ WS02	A̅us höĕrt gleich auf zer‘ schnein, nochert würd as Watter witter bes
 WS03	Thua Koll’n nein’n Oufe, äs die Milich bal on̆ ze koche fengt.
 WS04	Der guate alte Mon̆ is mit’n Gaul durch’s Eis gebroche und in äs kalt Woasser g’falle.
 WS05	Äer is vor vier oder sechs Wochä g’storbe.
-WS06	Die Ku̅cha senn jo unte ganz schwatz g’brännt.
+WS06	Die Kūcha senn jo unte ganz schwatz g’brännt.
 WS07	Äer ißt die Är ümmer ohne Salz und Pföffer.
 WS08	Die Fü͡äß thoen mär wäh, ich gläb, ich ho sä dourchgälafa.
 WS09	Ich bin bei derr Fra g’wast, un hos are g’sogt, un sie sögt, sie will’s a ire Tochter sog.

--- a/11618_Stadtlauringen.csv
+++ b/11618_Stadtlauringen.csv
@@ -10,8 +10,8 @@ Anmerkungen: ''
 ...
 WS01	Im Winter fliege die truckene Blä͡iter in der Luft rümm.
 WS02	A̅us höĕrt gleich auf zer‘ schnein, nochert würd as Watter witter besser.
-WS03	Thua Koll’n nein’n Oufe, äs die Milich bal on̆ ze koche fengt.
-WS04	Der guate alte Mon̆ is mit’n Gaul durch’s Eis gebroche und in äs kalt Woasser g’falle.
+WS03	Thua Koll’n nein’n Oufe, äs die Milich bal oň ze koche fengt.
+WS04	Der guate alte Moň is mit’n Gaul durch’s Eis gebroche und in äs kalt Woasser g’falle.
 WS05	Äer is vor vier oder sechs Wochä g’storbe.
 WS06	Die Kūcha senn jo unte ganz schwatz g’brännt.
 WS07	Äer ißt die Är ümmer ohne Salz und Pföffer.

--- a/11618_Stadtlauringen.csv
+++ b/11618_Stadtlauringen.csv
@@ -9,7 +9,7 @@ Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
 WS01	Im Winter fliege die truckene Blä͡iter in der Luft rümm.
-WS02	A̅us höĕrt gleich auf zer‘ schnein, nochert würd as Watter witter besser.
+WS02	Āus höĕrt gleich auf zer‘ schnein, nochert würd as Watter witter besser.
 WS03	Thua Koll’n nein’n Oufe, äs die Milich bal oň ze koche fengt.
 WS04	Der guate alte Moň is mit’n Gaul durch’s Eis gebroche und in äs kalt Woasser g’falle.
 WS05	Äer is vor vier oder sechs Wochä g’storbe.

--- a/11855_Hof.csv
+++ b/11855_Hof.csv
@@ -21,7 +21,7 @@ WS10	Ic̬h wi̬lls a̠ nim̬mär wi̬tt[ü̬]r tâ̠!
 WS11	Ic̬h ha̬u dä̬r gleich in̬ Ko̬chlö̬ffl ân̬ die (Kopf) O̠h̠rn, du Â̠ff!
 WS12	Wo̠ ge̠hsta̬ hi̠, sol̬lmä̬r mi̬t di̬r g̠eh?
 WS13	Izt̬ sän̬n o̬ppä̬r schlä̬chta̬ Ze̠i̠tn!
-WS14	Me̬i gu̠ts Kin̬d, bleib do̠ hun̬tn st̠e̠h, die be̠sn Gän̬s be̠ißn di[h] to̠t.
+WS14	Me̬i gu̠ts Kin̬d, bleib do̠ hun̬tn st͡eh, die be̠sn Gän̬s be̠ißn di[h] to̠t.
 WS15	Du ho̬st he̠i̠t âm̬ ma̬stn ge̬le(?)r̬nt und bi̬st brâ̠v gewe̠sn, du dä̬rfst e̠h̠ra̬ ha̠mge̠h wie die ân̬när̬n.
 WS16	Du bi̬st nu̬ch ne̬tt gro̠ß ge̬nu̬g, da̬ß da̬ a̬ Flâ̬schn We̠in au̬strinkn kâ̬st, du mu̬ßt er̬scht nu̬ch a̬ wä̬ng wâ̬chsn und gre̬ssä̬r wär̬n.
 WS17	Ge̠h bi̬ so̬ gu̠t und so̠gs de̠inä̬r Schw̬estä̬r, sie so̬ll die Kla̠dä̬r fä̬r ei̬är Mu̬ttä̬r fä̬rti̬g mâ̬chn, und mi̬ttä̬r Bär̬schte ausbä̬rschtn.

--- a/11855_Hof.csv
+++ b/11855_Hof.csv
@@ -29,7 +29,7 @@ WS18	He̬st na̬ gekän̬t! nu̬chär̬t wä̠rsch ân̬nä̬rsch kum̬ma̬ und 
 WS19	Wä̠r ho̬tt mä̬r mein Kâ̬rb mi̬t Fleisch gschto̠h̠ln?
 WS20	Ä̠r ho̬tt so̠ gethâ̠, wi̠e wä̬nnsä̬nna̬ zu̬m Drä̬schn be̬ste̬llt ham̬m, sie ham̬ms o̠bä̬r sä̬lwä̬r ge̬thâ̠.
 WS21	Wä̠m ho̬ttä̬r die ne̠ia̬ Gschi̬cht dä̬rze̠h̠lt?
-WS22	Mä̬rr mu̬s la̠u̠t schre̠ia̬, sun̠nst vä̬rste̠h̠t ä̬r a̬n ne̬tt.
+WS22	Mä̬rr mu̬s la̠u̠t schre̠ia̬, sun͡nst vä̬rste̠h̠t ä̬r a̬n ne̬tt.
 WS23	Mi̠r sän̬n mi̠e̠t und han̬en Dâ̬rscht
 WS24	Wi̠e mä̬r ge̬stä̬rn za Âh̠m̠t ha̠m̠ kum̬m[a] sän̬n, do̠ sän̬n die ânn̬är̬n scha̬ in̬ Be̬tt ga̬le̠gn und ha̬[mn] scha̬ fe̬st gschlo̠fn.
 WS25	Dä̬r Schne̠e iß̬ heit nâ̬cht bu̬ un̬s lie̠ng gebli̠e̠m, obä̬r heit ze̬fr̠i̠ i̬ßä̬r gschm̠o̠lzn.

--- a/11855_Hof.csv
+++ b/11855_Hof.csv
@@ -8,21 +8,21 @@ Transliterationsprojekt: REDE
 Transliterent: Philipp Spang
 Anmerkungen: <^ bedeutet tiefer a; außerdem immer hohes a.>
 ...
-WS01	In̬ Win̬tär̬ fli̠e̠ng die tru̬kn̬a Blä̬ttä̬r in̬ de̬r Lu̬ft run̬n[e].
-WS02	Izt̬ he̠r̠ts gleich auf za̬ schne̬ia̬, nu̬chär̬t wä̬rtt iß̬ Wä̬ttä̬r wi̬ttä̬r be̬ssä̬r.
-WS03	Tu̬ Ko̠hln in̬ O̠fn, d̬aß die Mi̬lli̬ch bâ̬ld zû ko̬chn â̠fängt.
+WS01	In̬ Win̬tär̬ fli͜eng die tru̬kn̬a Blä̬ttä̬r in̬ de̬r Lu̬ft run̬n[e].
+WS02	Izt̬ he͜rts gleich auf za̬ schne̬ia̬, nu̬chär̬t wä̬rtt iß̬ Wä̬ttä̬r wi̬ttä̬r be̬ssä̬r.
+WS03	Tu̬ Ko͜hln in̬ O̠fn, d̬aß die Mi̬lli̬ch bâ̬ld zû ko̬chn â̠fängt.
 WS04	Där gu̠ta̬ â̬lta Mâ̠ iß̬ mit̬tn Pfä̠r dârchs Eis gebro̬chn und in̬s kâ̬lta̬ Wâ̬ssär gfâ̬lln.
 WS05	Ä̠r iß̬ fâ̬r vier o̬ttä̬r se̬chs Wo̬chn gschtâ̬rm.
 WS06	Iß̬ Fu̬iä̬r wâ̠r zu sta̬rk, die Ku̠ng sän̬n ja̬ un̬tn gâ̬nz schwa̬rz gä brä̬nn.
 WS07	Er iß̬t die Eiä̬r â̬lla̬mo̬ll oh̠na̬ Sâ̬lz und Pfä̬ffä̬r.
-WS08	Die Fi̠a̠s tâm̬mä̬r we̠h, i̬ch gla̠b, ich ho̬pp mä̬rscha̬ a̠u̠fgelo̬ffn.
-WS09	Ich bi̬ bu̬ dö̠[re̬] Fr̠a̠ ge̬we̠s'n und hö̬ppä̬r e̬sch gso̠gt und si̠e ho̬tt gso̠gt, sie wil̬ls a̠ i̠hrä̬r To̬chtä̬r so̠g̠n.
+WS08	Die Fi͜as tâm̬mä̬r we̠h, i̬ch gla̠b, ich ho̬pp mä̬rscha̬ a͜ufgelo̬ffn.
+WS09	Ich bi̬ bu̬ dö̠[re̬] Fr͜a ge̬we̠s'n und hö̬ppä̬r e̬sch gso̠gt und si̠e ho̬tt gso̠gt, sie wil̬ls a̠ i̠hrä̬r To̬chtä̬r so̠g̠n.
 WS10	Ic̬h wi̬lls a̠ nim̬mär wi̬tt[ü̬]r tâ̠!
-WS11	Ic̬h ha̬u dä̬r gleich in̬ Ko̬chlö̬ffl ân̬ die (Kopf) O̠h̠rn, du Â̠ff!
+WS11	Ic̬h ha̬u dä̬r gleich in̬ Ko̬chlö̬ffl ân̬ die (Kopf) O͜hrn, du Â̠ff!
 WS12	Wo̠ ge̠hsta̬ hi̠, sol̬lmä̬r mi̬t di̬r g̠eh?
-WS13	Izt̬ sän̬n o̬ppä̬r schlä̬chta̬ Ze̠i̠tn!
+WS13	Izt̬ sän̬n o̬ppä̬r schlä̬chta̬ Ze͜itn!
 WS14	Me̬i gu̠ts Kin̬d, bleib do̠ hun̬tn st͡eh, die be̠sn Gän̬s be̠ißn di[h] to̠t.
-WS15	Du ho̬st he̠i̠t âm̬ ma̬stn ge̬le(?)r̬nt und bi̬st brâ̠v gewe̠sn, du dä̬rfst e̠h̠ra̬ ha̠mge̠h wie die ân̬när̬n.
+WS15	Du ho̬st he͜it âm̬ ma̬stn ge̬le(?)r̬nt und bi̬st brâ̠v gewe̠sn, du dä̬rfst e͜hra̬ ha̠mge̠h wie die ân̬när̬n.
 WS16	Du bi̬st nu̬ch ne̬tt gro̠ß ge̬nu̬g, da̬ß da̬ a̬ Flâ̬schn We̠in au̬strinkn kâ̬st, du mu̬ßt er̬scht nu̬ch a̬ wä̬ng wâ̬chsn und gre̬ssä̬r wär̬n.
 WS17	Ge̠h bi̬ so̬ gu̠t und so̠gs de̠inä̬r Schw̬estä̬r, sie so̬ll die Kla̠dä̬r fä̬r ei̬är Mu̬ttä̬r fä̬rti̬g mâ̬chn, und mi̬ttä̬r Bär̬schte ausbä̬rschtn.
 WS18	He̬st na̬ gekän̬t! nu̬chär̬t wä̠rsch ân̬nä̬rsch kum̬ma̬ und e̬s stän̬gä̬t be̬ssä̬r mi̬t ih̠n.
@@ -32,19 +32,19 @@ WS21	Wä̠m ho̬ttä̬r die ne̠ia̬ Gschi̬cht dä̬rze̠h̠lt?
 WS22	Mä̬rr mu̬s la̠u̠t schre̠ia̬, sun͡nst vä̬rste̠h̠t ä̬r a̬n ne̬tt.
 WS23	Mi̠r sän̬n mi̠e̠t und han̬en Dâ̬rscht
 WS24	Wi̠e mä̬r ge̬stä̬rn za Âh̠m̠t ha̠m̠ kum̬m[a] sän̬n, do̠ sän̬n die ânn̬är̬n scha̬ in̬ Be̬tt ga̬le̠gn und ha̬[mn] scha̬ fe̬st gschlo̠fn.
-WS25	Dä̬r Schne̠e iß̬ heit nâ̬cht bu̬ un̬s lie̠ng gebli̠e̠m, obä̬r heit ze̬fr̠i̠ i̬ßä̬r gschm̠o̠lzn.
+WS25	Dä̬r Schne̠e iß̬ heit nâ̬cht bu̬ un̬s lie̠ng gebli̠e̠m, obä̬r heit ze̬fr̠i̠ i̬ßä̬r gschm͜olzn.
 WS26	Hin̬tä̬r un̬sär̬n Ha̠us stä̬nga̬ dre̬i sche̬na̬ Epfä̬lba̠mla̬ mit ro̠tn Ep̬fä̬llä̬n.
 WS27	Känn̬tä̬r ne̬tt nu̬cha̬wä̬ng â̬ff un̬s war̬tn, nu̬chär̬t (nachher) gä̬nga̬ wä̬r mit e̠i̠ch.
 WS28	Ih̠r dä̬rft ne̬tt s[o̠] kin̬di̬sch sa̠.
 WS29	Un̬sä̬ra̬ Ba̬rg sä̬nn ne̬tt se̠hr ho̠ch, eiä̬ra̬ sä̬nn vi̬ll hö̬chä̬r.
 WS30	Wi̠e vi̬ll Pfun̬d Wâ̬rscht und wi̠e vi̬ll Bro̠t wo̬lltä̬r ho̠m̠.
 WS31	Ich ve̬rste̠h e̠i̠ch ne̬tt, ihr mi̬ßt a̬ wängla̬ (wenig) lau̠tä̬r re̠d̠n.
-WS32	Hab̬tä̬r ka̬ Sti̬ckla̬ we̠ißa̬ Sa̠f̠n fä̬r mi̠ch â̬ff me̠in Ti̬sch gfu̬nna̬?
+WS32	Hab̬tä̬r ka̬ Sti̬ckla̬ we̠ißa̬ Sa͜fn fä̬r mi̠ch â̬ff me̠in Ti̬sch gfu̬nna̬?
 WS33	Se̬i Bru̠dä̬r wi̬ll si̬ch zw̠a sche̠na̬, ne̬ia̬ He̬isä̬r in ei̬är̬n Ga̬rtn ba̬ua̬.
 WS34	Da̬ß Wâ̬rt iß̬ na̬ vu̬n Hä̬rzn ku̬mma̬.
 WS35	De̬ß wâ̠r rä̬cht vu̬n i̠h̠nä̬n!.
 WS36	Wo̬s sit̬zn do̠ fä̬r Ve̠gä̬lla̬ om̠ â̬ff dä̬[nn] Me̠iä̬rla̬?
-WS37	Die Ba̠uä̬rn ham̬m fü̬mf O̬chsn und ne̠in Ki̠h und zwe̬lf Scho̠f (Sche̠fla̬) vo̠rsch Dâ̠rf gebrâ̬cht kâ̬tt (gehabt), die wol̬ltn sa̬ värk[a̠]f̠n.
+WS37	Die Ba̠uä̬rn ham̬m fü̬mf O̬chsn und ne̠in Ki̠h und zwe̬lf Scho̠f (Sche̠fla̬) vo̠rsch Dâ̠rf gebrâ̬cht kâ̬tt (gehabt), die wol̬ltn sa̬ värk[a͜]fn.
 WS38	Die Le̠it sän̬n heit â̬lla̬ drau̠ßn â̬ffn Fä̬lt und me̠ha̬.
 WS39	Ge̠h nä̬rr, der bra̠una̬ Hu̬nd tut̬tä̬r ni̬ks.
 WS40	Ic̬h bi̬ mi̬t dän̬n Le̠i̠tna̬ do̠ hin̬tn i̠b̠ä̬r die Wi̠e̠sn in̬s Kâ̬rn gfâhrn.

--- a/11855_Hof.csv
+++ b/11855_Hof.csv
@@ -15,7 +15,7 @@ WS04	Där gu̠ta̬ â̬lta Mâ̠ iß̬ mit̬tn Pfä̠r dârchs Eis gebro̬chn un
 WS05	Ä̠r iß̬ fâ̬r vier o̬ttä̬r se̬chs Wo̬chn gschtâ̬rm.
 WS06	Iß̬ Fu̬iä̬r wâ̠r zu sta̬rk, die Ku̠ng sän̬n ja̬ un̬tn gâ̬nz schwa̬rz gä brä̬nn.
 WS07	Er iß̬t die Eiä̬r â̬lla̬mo̬ll oh̠na̬ Sâ̬lz und Pfä̬ffä̬r.
-WS08	Die Fi͡as tâm̬mä̬r we̠h, i̬ch gla̠b, ich ho̬pp mä̬rscha̬ a͜ufgelo̬ffn.
+WS08	Die Fi͡as tâm̬mä̬r we̠h, i̬ch gla̠b, ich ho̬pp mä̬rscha̬ a͡ufgelo̬ffn.
 WS09	Ich bi̬ bu̬ dö̠[re̬] Fr͡a ge̬we̠s'n und hö̬ppä̬r e̬sch gso̠gt und si̠e ho̬tt gso̠gt, sie wil̬ls a̠ i̠hrä̬r To̬chtä̬r so̠g̠n.
 WS10	Ic̬h wi̬lls a̠ nim̬mär wi̬tt[ü̬]r tâ̠!
 WS11	Ic̬h ha̬u dä̬r gleich in̬ Ko̬chlö̬ffl ân̬ die (Kopf) O͡hrn, du Â̠ff!
@@ -39,12 +39,12 @@ WS28	Ih̠r dä̬rft ne̬tt s[o̠] kin̬di̬sch sa̠.
 WS29	Un̬sä̬ra̬ Ba̬rg sä̬nn ne̬tt se̠hr ho̠ch, eiä̬ra̬ sä̬nn vi̬ll hö̬chä̬r.
 WS30	Wi̠e vi̬ll Pfun̬d Wâ̬rscht und wi̠e vi̬ll Bro̠t wo̬lltä̬r ho̠m̠.
 WS31	Ich ve̬rste̠h e̠i̠ch ne̬tt, ihr mi̬ßt a̬ wängla̬ (wenig) lau̠tä̬r re̠d̠n.
-WS32	Hab̬tä̬r ka̬ Sti̬ckla̬ we̠ißa̬ Sa͜fn fä̬r mi̠ch â̬ff me̠in Ti̬sch gfu̬nna̬?
+WS32	Ha̬btä̬r ka̬ Sti̬ckla̬ we̠ißa̬ Sa͡fn fä̬r mi̠ch â̬ff me̠in Ti̬sch gfu̬nna̬?
 WS33	Se̬i Bru̠dä̬r wi̬ll si̬ch zw̠a sche̠na̬, ne̬ia̬ He̬isä̬r in ei̬är̬n Ga̬rtn ba̬ua̬.
 WS34	Da̬ß Wâ̬rt iß̬ na̬ vu̬n Hä̬rzn ku̬mma̬.
 WS35	De̬ß wâ̠r rä̬cht vu̬n i̠h̠nä̬n!.
 WS36	Wo̬s sit̬zn do̠ fä̬r Ve̠gä̬lla̬ om̠ â̬ff dä̬[nn] Me̠iä̬rla̬?
-WS37	Die Ba̠uä̬rn ham̬m fü̬mf O̬chsn und ne̠in Ki̠h und zwe̬lf Scho̠f (Sche̠fla̬) vo̠rsch Dâ̠rf gebrâ̬cht kâ̬tt (gehabt), die wol̬ltn sa̬ värk[a͜]fn.
+WS37	Die Ba̠uä̬rn ham̬m fü̬mf O̬chsn und ne̠in Ki̠h und zwe̬lf Scho̠f (Sche̠fla̬) vo̠rsch Dâ̠rf gebrâ̬cht kâ̬tt (gehabt), die wol̬ltn sa̬ värk[a͡]fn.
 WS38	Die Le̠it sän̬n heit â̬lla̬ drau̠ßn â̬ffn Fä̬lt und me̠ha̬.
 WS39	Ge̠h nä̬rr, der bra̠una̬ Hu̬nd tut̬tä̬r ni̬ks.
 WS40	Ic̬h bi̬ mi̬t dän̬n Le̠i̠tna̬ do̠ hin̬tn i̠b̠ä̬r die Wi̠e̠sn in̬s Kâ̬rn gfâhrn.

--- a/11855_Hof.csv
+++ b/11855_Hof.csv
@@ -8,21 +8,21 @@ Transliterationsprojekt: REDE
 Transliterent: Philipp Spang
 Anmerkungen: <^ bedeutet tiefer a; außerdem immer hohes a.>
 ...
-WS01	In̬ Win̬tär̬ fli͜eng die tru̬kn̬a Blä̬ttä̬r in̬ de̬r Lu̬ft run̬n[e].
-WS02	Izt̬ he͜rts gleich auf za̬ schne̬ia̬, nu̬chär̬t wä̬rtt iß̬ Wä̬ttä̬r wi̬ttä̬r be̬ssä̬r.
-WS03	Tu̬ Ko͜hln in̬ O̠fn, d̬aß die Mi̬lli̬ch bâ̬ld zû ko̬chn â̠fängt.
+WS01	In̬ Win̬tär̬ fli͡eng die tru̬kn̬a Blä̬ttä̬r in̬ de̬r Lu̬ft run̬n[e].
+WS02	Izt̬ he͡rts gleich auf za̬ schne̬ia̬, nu̬chär̬t wä̬rtt iß̬ Wä̬ttä̬r wi̬ttä̬r be̬ssä̬r.
+WS03	Tu̬ Ko͡hln in̬ O̠fn, d̬aß die Mi̬lli̬ch bâ̬ld zû ko̬chn â̠fängt.
 WS04	Där gu̠ta̬ â̬lta Mâ̠ iß̬ mit̬tn Pfä̠r dârchs Eis gebro̬chn und in̬s kâ̬lta̬ Wâ̬ssär gfâ̬lln.
 WS05	Ä̠r iß̬ fâ̬r vier o̬ttä̬r se̬chs Wo̬chn gschtâ̬rm.
 WS06	Iß̬ Fu̬iä̬r wâ̠r zu sta̬rk, die Ku̠ng sän̬n ja̬ un̬tn gâ̬nz schwa̬rz gä brä̬nn.
 WS07	Er iß̬t die Eiä̬r â̬lla̬mo̬ll oh̠na̬ Sâ̬lz und Pfä̬ffä̬r.
-WS08	Die Fi͜as tâm̬mä̬r we̠h, i̬ch gla̠b, ich ho̬pp mä̬rscha̬ a͜ufgelo̬ffn.
-WS09	Ich bi̬ bu̬ dö̠[re̬] Fr͜a ge̬we̠s'n und hö̬ppä̬r e̬sch gso̠gt und si̠e ho̬tt gso̠gt, sie wil̬ls a̠ i̠hrä̬r To̬chtä̬r so̠g̠n.
+WS08	Die Fi͡as tâm̬mä̬r we̠h, i̬ch gla̠b, ich ho̬pp mä̬rscha̬ a͜ufgelo̬ffn.
+WS09	Ich bi̬ bu̬ dö̠[re̬] Fr͡a ge̬we̠s'n und hö̬ppä̬r e̬sch gso̠gt und si̠e ho̬tt gso̠gt, sie wil̬ls a̠ i̠hrä̬r To̬chtä̬r so̠g̠n.
 WS10	Ic̬h wi̬lls a̠ nim̬mär wi̬tt[ü̬]r tâ̠!
-WS11	Ic̬h ha̬u dä̬r gleich in̬ Ko̬chlö̬ffl ân̬ die (Kopf) O͜hrn, du Â̠ff!
+WS11	Ic̬h ha̬u dä̬r gleich in̬ Ko̬chlö̬ffl ân̬ die (Kopf) O͡hrn, du Â̠ff!
 WS12	Wo̠ ge̠hsta̬ hi̠, sol̬lmä̬r mi̬t di̬r g̠eh?
-WS13	Izt̬ sän̬n o̬ppä̬r schlä̬chta̬ Ze͜itn!
+WS13	Izt̬ sän̬n o̬ppä̬r schlä̬chta̬ Ze͡itn!
 WS14	Me̬i gu̠ts Kin̬d, bleib do̠ hun̬tn st͡eh, die be̠sn Gän̬s be̠ißn di[h] to̠t.
-WS15	Du ho̬st he͜it âm̬ ma̬stn ge̬le(?)r̬nt und bi̬st brâ̠v gewe̠sn, du dä̬rfst e͜hra̬ ha̠mge̠h wie die ân̬när̬n.
+WS15	Du ho̬st he͡it âm̬ ma̬stn ge̬le(?)r̬nt und bi̬st brâ̠v gewe̠sn, du dä̬rfst e͡hra̬ ha̠mge̠h wie die ân̬när̬n.
 WS16	Du bi̬st nu̬ch ne̬tt gro̠ß ge̬nu̬g, da̬ß da̬ a̬ Flâ̬schn We̠in au̬strinkn kâ̬st, du mu̬ßt er̬scht nu̬ch a̬ wä̬ng wâ̬chsn und gre̬ssä̬r wär̬n.
 WS17	Ge̠h bi̬ so̬ gu̠t und so̠gs de̠inä̬r Schw̬estä̬r, sie so̬ll die Kla̠dä̬r fä̬r ei̬är Mu̬ttä̬r fä̬rti̬g mâ̬chn, und mi̬ttä̬r Bär̬schte ausbä̬rschtn.
 WS18	He̬st na̬ gekän̬t! nu̬chär̬t wä̠rsch ân̬nä̬rsch kum̬ma̬ und e̬s stän̬gä̬t be̬ssä̬r mi̬t ih̠n.
@@ -32,7 +32,7 @@ WS21	Wä̠m ho̬ttä̬r die ne̠ia̬ Gschi̬cht dä̬rze̠h̠lt?
 WS22	Mä̬rr mu̬s la̠u̠t schre̠ia̬, sun͡nst vä̬rste̠h̠t ä̬r a̬n ne̬tt.
 WS23	Mi̠r sän̬n mi̠e̠t und han̬en Dâ̬rscht
 WS24	Wi̠e mä̬r ge̬stä̬rn za Âh̠m̠t ha̠m̠ kum̬m[a] sän̬n, do̠ sän̬n die ânn̬är̬n scha̬ in̬ Be̬tt ga̬le̠gn und ha̬[mn] scha̬ fe̬st gschlo̠fn.
-WS25	Dä̬r Schne̠e iß̬ heit nâ̬cht bu̬ un̬s lie̠ng gebli̠e̠m, obä̬r heit ze̬fr̠i̠ i̬ßä̬r gschm͜olzn.
+WS25	Dä̬r Schne̠e iß̬ heit nâ̬cht bu̬ un̬s lie̠ng gebli̠e̠m, obä̬r heit ze̬fr͡i i̬ßä̬r gschm͡olzn.
 WS26	Hin̬tä̬r un̬sär̬n Ha̠us stä̬nga̬ dre̬i sche̬na̬ Epfä̬lba̠mla̬ mit ro̠tn Ep̬fä̬llä̬n.
 WS27	Känn̬tä̬r ne̬tt nu̬cha̬wä̬ng â̬ff un̬s war̬tn, nu̬chär̬t (nachher) gä̬nga̬ wä̬r mit e̠i̠ch.
 WS28	Ih̠r dä̬rft ne̬tt s[o̠] kin̬di̬sch sa̠.

--- a/13082_Rodewisch.csv
+++ b/13082_Rodewisch.csv
@@ -10,41 +10,41 @@ Anmerkungen: ''
 ...
 WS01	Ne Winter flieng de druck’n Bletter in d’r Luft rim.
 WS02	’Shärt geleich auf zu schneiă, nochn wards Wätt’r wieder bess’r.
-WS03	Thu Ku͜oln nein U͜of’n, daß de Mililch ball ă z’kuch’n fängt.
-WS04	D’r gu͜ote olle Mo͜u is mit’n Pfär dorchs Eis gebroch’n un neis kalle Wass’r g’fall’n.
+WS03	Thu Ku͡oln nein U͡of’n, daß de Mililch ball ă z’kuch’n fängt.
+WS04	D’r gu͡ote olle Mo͜u is mit’n Pfär dorchs Eis gebroch’n un neis kalle Wass’r g’fall’n.
 WS05	Err͜ is vor vier ober sechs Woch’n gestorm.
 WS06	’SFeier war zu hăß, de Kung sei ja unt’n ganz schwarz gebrännt.
-WS07	Err ißt de Eier immer u͜ohne Salz un Pfäff’r.
-WS08	De Füß thummer su͜ă weh, iech glăb ich ha͜se dorch geloff’n.
+WS07	Err ißt de Eier immer u͡ohne Salz un Pfäff’r.
+WS08	De Füß thummer su͡ă weh, iech glăb ich ha͜se dorch geloff’n.
 WS09	Iech bin bä͜ re Frah gewehn un ho͜ersch g’sogt, un sie hott g’sogt, se wolts ihrer Tochter song.
 WS10	Iech wills ă nimmer wieder thun.
 WS11	Iech schlo͜ă diech geleich mit’n Kochlöff’l im dr Uhon, du Ăff.
 WS12	Wo͜ă gehst’n  hie, soll͜ mer mi͜ët ge͜ă.
 WS13	S’sei schlechte Zeit’n.
-WS14	Mei liebs Kind, blei dunt’n stie͜ă, de bie͜ës’n Gäns beiß’n diech sindst tu͜odt.
+WS14	Mei liebs Kind, blei dunt’n stie͜ă, de bie͜ës’n Gäns beiß’n diech sindst tu͡odt.
 WS15	Du host heit s’meste gelärnt, un bist ă o͜ărtig gewehn, du kast eher hăm gie͜ë  wie de Annern.
-WS16	Du bist no͜ănt gru͜oß genungk, im͜ ă Flasch Wei auszetrink’n, du mußt ärscht noch ä Bill wachs’n un greß’r wärn.
-WS17	Bin zăgu͜ot un sogs deiner Schwestr, se sell de Klăder färr de Muttr färtig nehe un mit d’r Berscht ră machn.
+WS16	Du bist no͜ănt gru͡oß genungk, im͜ ă Flasch Wei auszetrink’n, du mußt ärscht noch ä Bill wachs’n un greß’r wärn.
+WS17	Bin zăgu͡ot un sogs deiner Schwestr, se sell de Klăder färr de Muttr färtig nehe un mit d’r Berscht ră machn.
 WS18	Hest’n gekannt, noch wärsch annersch kummă uns ’thett bess’r mit’n stiehă.
-WS19	Wär hott͜ mrrn Korb mit Flahsch gestuhln? - (gemaust).
+WS19	Wär hott͡ mrrn Korb mit Flahsch gestuhln? - (gemaust).
 WS20	Err hoht gethoă als hett’n͜ s’n zin Drăsch’n bestellt, hăms ober selber getho͜ă.
 WS21	Wäm hott’rn die neiă Geschicht d’rzehlt?
 WS22	M’r sei müh un hamm ă Dorscht.
 WS23	M’r muß laut schreiă, sinst verstieht er ăn nett.
 WS24	Wăll m’r gest’r Omd hăm kame, warn de Annern langk ze Bett und longn fest in Schlof.
 WS25	Dr Schnee is die Nacht be uns liegg gebliem, aber heit frih is’r zeschmolzn.
-WS26	Hinnr unnern Haus stennă drei schie͜ănă Epfelbăhm mit ru͜otn Epfeln.
+WS26	Hinnr unnern Haus stennă drei schie͜ănă Epfelbăhm mit ru͡otn Epfeln.
 WS27	Kennt’r nett noch ă Bill ăff uns warn, noch gämm’r mit Eich.
 WS28	Ihr dărft kă sette Kinnerei treim.
-WS29	Unnere Bărg sei nett sähr hu͜och, eiere sei viel hecher.
-WS30	Wieviel Pfund Worscht un wieviel Bru͜od wett’rn hohm?
+WS29	Unnere Bărg sei nett sähr hu͡och, eiere sei viel hecher.
+WS30	Wieviel Pfund Worscht un wieviel Bru͡od wett’rn hohm?
 WS31	Iech verstieh eich nett, ihr mißt’s ă Bill laut’r song.
 WS32	Hatt’r kă Stück weiße Săf v’r miech ăff măn Tisch gefunnă?
 WS33	Sei Brudr will sich zwee schiene neiă Heiser, nein eiern Gart’n baun.
 WS34	Des Wort ko͜ăm ihm v’rn Hărzn.
 WS35	Des war recht v’r Eich.
-WS36	Wu͜os sitzn dă vr Vegelă ub’n ăff denn Meierlă.
-WS37	De Baur’n hamm fimf Ochsn un nei Kieh un zwelf Schefle vorsch Dorf gebacht, des wolt’n͜se verku͜ăfn.
+WS36	Wu͡os sitzn dă vr Vegelă ub’n ăff denn Meierlă.
+WS37	De Baur’n hamm fimf Ochsn un nei Kieh un zwelf Schefle vorsch Dorf gebacht, des wolt’n͜se verku͡ăfn.
 WS38	De Leit sei heit alle daun Feld un haue.
 WS39	Gie͜ë nähr d’r braune Hund tutt d’r nischt.
 WS40	Iech bie͜ë mit’n Leit’n do hint’n über de Wies noch Korn gefo͜ărn.

--- a/13082_Rodewisch.csv
+++ b/13082_Rodewisch.csv
@@ -19,15 +19,15 @@ WS08	De Füß thummer su͡ă weh, iech glăb ich ha͜se dorch geloff’n.
 WS09	Iech bin bä͜ re Frah gewehn un ho͡ersch g’sogt, un sie hott g’sogt, se wolts ihrer Tochter song.
 WS10	Iech wills ă nimmer wieder thun.
 WS11	Iech schlo͡ă diech geleich mit’n Kochlöff’l im dr Uhon, du Ăff.
-WS12	Wo͡ă gehst’n  hie, soll͜ mer mi͜ët ge͜ă.
+WS12	Wo͡ă gehst’n  hie, soll͡ mer mi͡ët ge͜ă.
 WS13	S’sei schlechte Zeit’n.
 WS14	Mei liebs Kind, blei dunt’n stie͜ă, de bie͜ës’n Gäns beiß’n diech sindst tu͡odt.
 WS15	Du host heit s’meste gelärnt, un bist ă o͡ărtig gewehn, du kast eher hăm gie͜ë  wie de Annern.
-WS16	Du bist no͡ănt gru͡oß genungk, im͜ ă Flasch Wei auszetrink’n, du mußt ärscht noch ä Bill wachs’n un greß’r wärn.
+WS16	Du bist no͡ănt gru͡oß genungk, im͡ ă Flasch Wei auszetrink’n, du mußt ärscht noch ä Bill wachs’n un greß’r wärn.
 WS17	Bin zăgu͡ot un sogs deiner Schwestr, se sell de Klăder färr de Muttr färtig nehe un mit d’r Berscht ră machn.
 WS18	Hest’n gekannt, noch wärsch annersch kummă uns ’thett bess’r mit’n stiehă.
 WS19	Wär hott͡ mrrn Korb mit Flahsch gestuhln? - (gemaust).
-WS20	Err hoht gethoă als hett’n͜ s’n zin Drăsch’n bestellt, hăms ober selber getho͡ă.
+WS20	Err hoht gethoă als hett’n͡ s’n zin Drăsch’n bestellt, hăms ober selber getho͡ă.
 WS21	Wäm hott’rn die neiă Geschicht d’rzehlt?
 WS22	M’r sei müh un hamm ă Dorscht.
 WS23	M’r muß laut schreiă, sinst verstieht er ăn nett.
@@ -44,7 +44,7 @@ WS33	Sei Brudr will sich zwee schiene neiă Heiser, nein eiern Gart’n baun.
 WS34	Des Wort ko͡ăm ihm v’rn Hărzn.
 WS35	Des war recht v’r Eich.
 WS36	Wu͡os sitzn dă vr Vegelă ub’n ăff denn Meierlă.
-WS37	De Baur’n hamm fimf Ochsn un nei Kieh un zwelf Schefle vorsch Dorf gebacht, des wolt’n͜se verku͡ăfn.
+WS37	De Baur’n hamm fimf Ochsn un nei Kieh un zwelf Schefle vorsch Dorf gebacht, des wolt’n͡se verku͡ăfn.
 WS38	De Leit sei heit alle daun Feld un haue.
 WS39	Gie͜ë nähr d’r braune Hund tutt d’r nischt.
 WS40	Iech bie͜ë mit’n Leit’n do hint’n über de Wies noch Korn gefo͡ărn.

--- a/13082_Rodewisch.csv
+++ b/13082_Rodewisch.csv
@@ -11,23 +11,23 @@ Anmerkungen: ''
 WS01	Ne Winter flieng de druck’n Bletter in d’r Luft rim.
 WS02	’Shärt geleich auf zu schneiă, nochn wards Wätt’r wieder bess’r.
 WS03	Thu Ku͡oln nein U͡of’n, daß de Mililch ball ă z’kuch’n fängt.
-WS04	D’r gu͡ote olle Mo͜u is mit’n Pfär dorchs Eis gebroch’n un neis kalle Wass’r g’fall’n.
-WS05	Err͜ is vor vier ober sechs Woch’n gestorm.
+WS04	D’r gu͡ote olle Mo͡u is mit’n Pfär dorchs Eis gebroch’n un neis kalle Wass’r g’fall’n.
+WS05	Err͡ is vor vier ober sechs Woch’n gestorm.
 WS06	’SFeier war zu hăß, de Kung sei ja unt’n ganz schwarz gebrännt.
 WS07	Err ißt de Eier immer u͡ohne Salz un Pfäff’r.
 WS08	De Füß thummer su͡ă weh, iech glăb ich ha͜se dorch geloff’n.
-WS09	Iech bin bä͜ re Frah gewehn un ho͜ersch g’sogt, un sie hott g’sogt, se wolts ihrer Tochter song.
+WS09	Iech bin bä͜ re Frah gewehn un ho͡ersch g’sogt, un sie hott g’sogt, se wolts ihrer Tochter song.
 WS10	Iech wills ă nimmer wieder thun.
-WS11	Iech schlo͜ă diech geleich mit’n Kochlöff’l im dr Uhon, du Ăff.
-WS12	Wo͜ă gehst’n  hie, soll͜ mer mi͜ët ge͜ă.
+WS11	Iech schlo͡ă diech geleich mit’n Kochlöff’l im dr Uhon, du Ăff.
+WS12	Wo͡ă gehst’n  hie, soll͜ mer mi͜ët ge͜ă.
 WS13	S’sei schlechte Zeit’n.
 WS14	Mei liebs Kind, blei dunt’n stie͜ă, de bie͜ës’n Gäns beiß’n diech sindst tu͡odt.
-WS15	Du host heit s’meste gelärnt, un bist ă o͜ărtig gewehn, du kast eher hăm gie͜ë  wie de Annern.
-WS16	Du bist no͜ănt gru͡oß genungk, im͜ ă Flasch Wei auszetrink’n, du mußt ärscht noch ä Bill wachs’n un greß’r wärn.
+WS15	Du host heit s’meste gelärnt, un bist ă o͡ărtig gewehn, du kast eher hăm gie͜ë  wie de Annern.
+WS16	Du bist no͡ănt gru͡oß genungk, im͜ ă Flasch Wei auszetrink’n, du mußt ärscht noch ä Bill wachs’n un greß’r wärn.
 WS17	Bin zăgu͡ot un sogs deiner Schwestr, se sell de Klăder färr de Muttr färtig nehe un mit d’r Berscht ră machn.
 WS18	Hest’n gekannt, noch wärsch annersch kummă uns ’thett bess’r mit’n stiehă.
 WS19	Wär hott͡ mrrn Korb mit Flahsch gestuhln? - (gemaust).
-WS20	Err hoht gethoă als hett’n͜ s’n zin Drăsch’n bestellt, hăms ober selber getho͜ă.
+WS20	Err hoht gethoă als hett’n͜ s’n zin Drăsch’n bestellt, hăms ober selber getho͡ă.
 WS21	Wäm hott’rn die neiă Geschicht d’rzehlt?
 WS22	M’r sei müh un hamm ă Dorscht.
 WS23	M’r muß laut schreiă, sinst verstieht er ăn nett.
@@ -41,10 +41,10 @@ WS30	Wieviel Pfund Worscht un wieviel Bru͡od wett’rn hohm?
 WS31	Iech verstieh eich nett, ihr mißt’s ă Bill laut’r song.
 WS32	Hatt’r kă Stück weiße Săf v’r miech ăff măn Tisch gefunnă?
 WS33	Sei Brudr will sich zwee schiene neiă Heiser, nein eiern Gart’n baun.
-WS34	Des Wort ko͜ăm ihm v’rn Hărzn.
+WS34	Des Wort ko͡ăm ihm v’rn Hărzn.
 WS35	Des war recht v’r Eich.
 WS36	Wu͡os sitzn dă vr Vegelă ub’n ăff denn Meierlă.
 WS37	De Baur’n hamm fimf Ochsn un nei Kieh un zwelf Schefle vorsch Dorf gebacht, des wolt’n͜se verku͡ăfn.
 WS38	De Leit sei heit alle daun Feld un haue.
 WS39	Gie͜ë nähr d’r braune Hund tutt d’r nischt.
-WS40	Iech bie͜ë mit’n Leit’n do hint’n über de Wies noch Korn gefo͜ărn.
+WS40	Iech bie͜ë mit’n Leit’n do hint’n über de Wies noch Korn gefo͡ărn.

--- a/13082_Rodewisch.csv
+++ b/13082_Rodewisch.csv
@@ -19,10 +19,10 @@ WS08	De Füß thummer su͡ă weh, iech glăb ich ha͜se dorch geloff’n.
 WS09	Iech bin bä͜ re Frah gewehn un ho͡ersch g’sogt, un sie hott g’sogt, se wolts ihrer Tochter song.
 WS10	Iech wills ă nimmer wieder thun.
 WS11	Iech schlo͡ă diech geleich mit’n Kochlöff’l im dr Uhon, du Ăff.
-WS12	Wo͡ă gehst’n  hie, soll͡ mer mi͡ët ge͜ă.
+WS12	Wo͡ă gehst’n  hie, soll͡ mer mi͡ët ge͡ă.
 WS13	S’sei schlechte Zeit’n.
-WS14	Mei liebs Kind, blei dunt’n stie͜ă, de bie͜ës’n Gäns beiß’n diech sindst tu͡odt.
-WS15	Du host heit s’meste gelärnt, un bist ă o͡ărtig gewehn, du kast eher hăm gie͜ë  wie de Annern.
+WS14	Mei liebs Kind, blei dunt’n stie͡ă, de bie͡ës’n Gäns beiß’n diech sindst tu͡odt.
+WS15	Du host heit s’meste gelärnt, un bist ă o͡ărtig gewehn, du kast eher hăm gie͡ë  wie de Annern.
 WS16	Du bist no͡ănt gru͡oß genungk, im͡ ă Flasch Wei auszetrink’n, du mußt ärscht noch ä Bill wachs’n un greß’r wärn.
 WS17	Bin zăgu͡ot un sogs deiner Schwestr, se sell de Klăder färr de Muttr färtig nehe un mit d’r Berscht ră machn.
 WS18	Hest’n gekannt, noch wärsch annersch kummă uns ’thett bess’r mit’n stiehă.
@@ -33,7 +33,7 @@ WS22	M’r sei müh un hamm ă Dorscht.
 WS23	M’r muß laut schreiă, sinst verstieht er ăn nett.
 WS24	Wăll m’r gest’r Omd hăm kame, warn de Annern langk ze Bett und longn fest in Schlof.
 WS25	Dr Schnee is die Nacht be uns liegg gebliem, aber heit frih is’r zeschmolzn.
-WS26	Hinnr unnern Haus stennă drei schie͜ănă Epfelbăhm mit ru͡otn Epfeln.
+WS26	Hinnr unnern Haus stennă drei schie͡ănă Epfelbăhm mit ru͡otn Epfeln.
 WS27	Kennt’r nett noch ă Bill ăff uns warn, noch gämm’r mit Eich.
 WS28	Ihr dărft kă sette Kinnerei treim.
 WS29	Unnere Bărg sei nett sähr hu͡och, eiere sei viel hecher.
@@ -46,5 +46,5 @@ WS35	Des war recht v’r Eich.
 WS36	Wu͡os sitzn dă vr Vegelă ub’n ăff denn Meierlă.
 WS37	De Baur’n hamm fimf Ochsn un nei Kieh un zwelf Schefle vorsch Dorf gebacht, des wolt’n͡se verku͡ăfn.
 WS38	De Leit sei heit alle daun Feld un haue.
-WS39	Gie͜ë nähr d’r braune Hund tutt d’r nischt.
-WS40	Iech bie͜ë mit’n Leit’n do hint’n über de Wies noch Korn gefo͡ărn.
+WS39	Gie͡ë nähr d’r braune Hund tutt d’r nischt.
+WS40	Iech bie͡ë mit’n Leit’n do hint’n über de Wies noch Korn gefo͡ărn.

--- a/13082_Rodewisch.csv
+++ b/13082_Rodewisch.csv
@@ -15,8 +15,8 @@ WS04	D’r gu͡ote olle Mo͡u is mit’n Pfär dorchs Eis gebroch’n un neis ka
 WS05	Err͡ is vor vier ober sechs Woch’n gestorm.
 WS06	’SFeier war zu hăß, de Kung sei ja unt’n ganz schwarz gebrännt.
 WS07	Err ißt de Eier immer u͡ohne Salz un Pfäff’r.
-WS08	De Füß thummer su͡ă weh, iech glăb ich ha͜se dorch geloff’n.
-WS09	Iech bin bä͜ re Frah gewehn un ho͡ersch g’sogt, un sie hott g’sogt, se wolts ihrer Tochter song.
+WS08	De Füß thummer su͡ă weh, iech glăb ich ha͡se dorch geloff’n.
+WS09	Iech bin bä͡ re Frah gewehn un ho͡ersch g’sogt, un sie hott g’sogt, se wolts ihrer Tochter song.
 WS10	Iech wills ă nimmer wieder thun.
 WS11	Iech schlo͡ă diech geleich mit’n Kochlöff’l im dr Uhon, du Ăff.
 WS12	Wo͡ă gehst’n  hie, soll͡ mer mi͡ët ge͡ă.

--- a/13448_Ölsnitz.csv
+++ b/13448_Ölsnitz.csv
@@ -18,7 +18,7 @@ WS07	Ar ißt de Ei’r immer uhne Salz unn Pfaff’r.
 WS08	De Fiß thun mer sähr wieh, ich glob, ich hob se dorchgelafen.
 WS09	Ich bih bei dr Fra gewasen unn hob ers gesat, unn se sat, se wollts a ihrer Tuchter sa.
 WS10	Ich will’s a nich meh wiedr thu.
-WS11	Ich scho͜a dich glei mit’n Kuchläff’l im de Uhr’n du Aff!
+WS11	Ich scho͡a dich glei mit’n Kuchläff’l im de Uhr’n du Aff!
 WS12	Wu gist’n hie, sullin mer mit’r gieh?
 WS13	’Sei schlachte Zeit’n!
 WS14	Mei liebes Kind, bleib do drunt’n schtie, die biesen Gens beiß’n dich tut.
@@ -32,7 +32,7 @@ WS21	Wenn hot’r dä die neie Geschicht’ erzehlt?
 WS22	Mr muß laut schreie, siest verstiht’r uns nich.
 WS23	Wir sei mihd unn hom Dorrscht.
 WS24	Wie mer gestern Ohmd zerrick kahme, do long die annern schuh im Bett unn wahrn fest im schloffen.
-WS25	De Schnee is de Nacht bei uns lieng gebliem, ober dan Morng is’r geschmo͜ulzen.
+WS25	De Schnee is de Nacht bei uns lieng gebliem, ober dan Morng is’r geschmo͡ulzen.
 WS26	Hi[m]er unnern Haus stinne drei schiene Äppelbäm mit ruthen Appeln.
 WS27	Kennt ihr net noch än Angblick off uns wart’n, dann ginne mir mit eich.
 WS28	Ihr därft ne siche Kinnerei treim.
@@ -42,7 +42,7 @@ WS31	Ich verstieh aich nich, ihr mißt e bissel laut’r schprach’n.
 WS32	Hat ihr ka Stick’l weiße Säf’ f[o]r mich uff mein’n Tisch gefung?
 WS33	Sei Bruder will sich zwee schiene naie Haiser in eirn Goart’n baun.
 WS34	Dos Wort kom ihn von Harz’n
-WS35	Dos wo͜ar racht von ihn’n.
+WS35	Dos wo͡ar racht von ihn’n.
 WS36	Wos sitzen do fer Vögelle uhn uf’n Mäuerle?
 WS37	De Bauern hotten finf Ochsen unn nei Küh’ unn zwölf Schäfle forsch Dorf gebracht, de wollt’n se verkafen.
 WS38	De Leit sei heit olle draußen uff’n Fald unn ha’n.

--- a/14724_Monsheim.csv
+++ b/14724_Monsheim.csv
@@ -47,4 +47,4 @@ WS36	Waß sitzen do vor Völger owe uf dem Mäuerche?
 WS37	Die Baure hen fünf Ochsen un neu Kühe un zwölf Schäfcher vors Dorf gebrung, die wollten s verkaafe.
 WS38	Die Leute sein heit all draus uff’m Feld un mähe.
 WS39	Geh nor, der braune Hund tut d’r nicks.
-WS40	Ich sein mit de Leut do hin̅e üwer die Wiß ens Korn gefahre.
+WS40	Ich sein mit de Leut do hin̄e üwer die Wiß ens Korn gefahre.

--- a/14788_Hilscheid.csv
+++ b/14788_Hilscheid.csv
@@ -8,30 +8,30 @@ Transliterationsprojekt: REDE
 Transliterent: Herrgen
 Anmerkungen: ''
 ...
-WS01	Eăm Wěnda fle⃰{e mit einem Asterisk oben}je deï trocke Blerra durch die L[o]ft ’erem.
-WS02	Ett heért gläich of se schneeě, dann weard dat Werra namme besser.
-WS03	Deï Kohle eăn dě Owe, dat dei Melich [hortig] onfeingt se koche.
-WS04	Dä goure ale Mann eăß meăt děm Päö̌{ö mit einem Kürzungsbogen}rd eăn dat kal Waser gefall ; ä war durich dett Aeï̌{ï mit Kürzungsbogen}s gebroch.
-WS05	Ae eaß vir via orra sěchs Wȯche gesturwe.
-WS06	Datt Fäier war se häs, deï Kŏche sein jo eénně ganz schworz vabrannt.
+WS01	Eăm Wĕnda fle⃰{e mit einem Asterisk oben}je deï trocke Blerra durch die L[o]ft ’erem.
+WS02	Ett heért gläich of se schneeĕ, dann weard dat Werra namme besser.
+WS03	Deï Kohle eăn dĕ Owe, dat dei Melich [hortig] onfeingt se koche.
+WS04	Dä goure ale Mann eăß meăt dĕm Päö̌{ö mit einem Kürzungsbogen}rd eăn dat kal Waser gefall ; ä war durich dett Aeï̌{ï mit Kürzungsbogen}s gebroch.
+WS05	Ae eaß vir via orra sĕchs Wȯche gesturwe.
+WS06	Datt Fäier war se häs, deï Kŏche sein jo eénnĕ ganz schworz vabrannt.
 WS07	Ae eéßt deï Aier emmea{a steht über dem e}r ȯne Salz onn Peffer.
-WS08	Deï Feïs deïměr eso weh, äich gläwe, eïch honn se durich gelohf.
-WS09	Aeïch sein bäi der Frauh gewäst ann honn ett ’r gesooht, onn säi hott gesoht, säi wŏllt e̊tt och ihra Dogdar soon.
-WS10	Aeïch well ’e̊tt och net meéh doun.
-WS11	Aeïch schleen D’r gläich meăt děm Köchläăffel emm deï Ore, dŏu Aff!
-WS12	Woo gähst Du hinn, sellě ma meăt děr gehn.
+WS08	Deï Feïs deïmĕr eso weh, äich gläwe, eïch honn se durich gelohf.
+WS09	Aeïch sein bäi der Frauh gewäst ann honn ett ’r gesooht, onn säi hott gesoht, säi wŏllt ėtt och ihra Dogdar soon.
+WS10	Aeïch well ’ėtt och net meéh doun.
+WS11	Aeïch schleen D’r gläich meăt dĕm Köchläăffel emm deï Ore, dŏu Aff!
+WS12	Woo gähst Du hinn, sellĕ ma meăt dĕr gehn.
 WS13	Ett sein schlecht Zeire!
 WS14	Mei leïf Kaand, bleiw l’hei eènne stohn, deï bees Gäns bäiße däich dot.
 WS15	Dou host haut om mäste gelehrt onn beaß ourtig gewäst, dou derfs freïer heim gohn weï deï Annere.
 WS16	Dou beaß nach nett groaß genoch, em ’n Flasch Wein oussetreéïnke, dou möß d’rerscht noch’n Enn wose onn gr[o]aßer wäre.
-WS17	Geh, sei ěso gout onn soh ett deiner Schwester, se soällt deï Klära fir aier Modder fěrtig něhe onn meaat d’r Berscht sauwer mage.
+WS17	Geh, sei ĕso gout onn soh ett deiner Schwester, se soällt deï Klära fir aier Modder fĕrtig nĕhe onn meaat d’r Berscht sauwer mage.
 WS18	Hätt’st Dau ’n kannt, dann wer ett amigdăr kömm, onn ett deht besser em’n stoohn.
 WS19	Wäar hott m’r meine Körf meat Fläsch gestoll?
 WS20	Er horr’e so gedohn, als härren se’n zȯm Dräasche bestallt; se honn et äwer säalwa gedohn.
 WS21	Wemm horr’ä deï nau Geschicht vazeéllt?
-WS22	Ma moß h[o]rt schreiě, soaßt vearstährn us nett.
+WS22	Ma moß h[o]rt schreiĕ, soaßt vearstährn us nett.
 WS23	M’r sein m[e]ïd onn honn Doorscht.
-WS24	Weéï m’r geéstărOwend sěreèck sein kömm, do honn deï Annere schonn năm Bäăt geläh.
+WS24	Weéï m’r geéstărOwend sĕreèck sein kömm, do honn deï Annere schonn năm Bäăt geläh.
 WS25	Dä Schnee eăß diß Nog(sch)d{sch steht in Klammern über dem g} bei us leije bliewe, äwa d’Morje naß ’n geschmo[a]lz.
 WS26	Hennar us’m Haus stehn dreï scheene Abelbäamcher meăt rore Aeapelch[a]r
 WS27	Kennt d’r net’n Au’ebleck off us worde, dann geh’m’r merr ’ich.
@@ -40,11 +40,11 @@ WS29	Uhs Berig sein nerr eso heég, äiar sei vill heéja.
 WS30	Weï vill Poănnd Woorscht onn weï vill Brood weéllt d’r honn?
 WS31	Aeich vastehn ich nett, dir meßt e Beßche horter sprooche.
 WS32	Hätt d’r kei Steckelche weïß Säf fir mäich off meim Deésch foann?
-WS33	Seině Broura well sich zwä scheene naue Heiser eăn äirem Goorde baue.
+WS33	Seinĕ Broura well sich zwä scheene naue Heiser eăn äirem Goorde baue.
 WS34	Datt Woord kam ’m von Herze.
-WS35	Datt war Regd von Inně.
-WS36	Watt setze fir Veelchar l’ oben eff děm Meierche.
-WS37	Deï Bauere honn fenf Ochse onn nein Keïh onn zwelf Schäfcher für d’t Doorf brochd, deï woallt’n sě verkäfe.
+WS35	Datt war Regd von Innĕ.
+WS36	Watt setze fir Veelchar l’ oben eff dĕm Meierche.
+WS37	Deï Bauere honn fenf Ochse onn nein Keïh onn zwelf Schäfcher für d’t Doorf brochd, deï woallt’n sĕ verkäfe.
 WS38	Dei Leit sein haut all daus off d’m Feald onn mehe.
-WS39	Geh nimmě, dä braune Hoănd dät d’r näischt.
+WS39	Geh nimmĕ, dä braune Hoănd dät d’r näischt.
 WS40	Aeich sein meăt dä Leire lo Hea{a steht über dem e}nne iwer deï Wies ean d’tt Kohr gefohr.

--- a/14788_Hilscheid.csv
+++ b/14788_Hilscheid.csv
@@ -12,13 +12,13 @@ WS01	Eăm Wěnda fle⃰{e mit einem Asterisk oben}je deï trocke Blerra durch di
 WS02	Ett heért gläich of se schneeě, dann weard dat Werra namme besser.
 WS03	Deï Kohle eăn dě Owe, dat dei Melich [hortig] onfeingt se koche.
 WS04	Dä goure ale Mann eăß meăt děm Päö̌{ö mit einem Kürzungsbogen}rd eăn dat kal Waser gefall ; ä war durich dett Aeï̌{ï mit Kürzungsbogen}s gebroch.
-WS05	Ae eaß vir via orra sěchs Wo̊che gesturwe.
-WS06	Datt Fäier war se häs, deï Kǒche sein jo eénně ganz schworz vabrannt.
-WS07	Ae eéßt deï Aier emmea{a steht über dem e}r o̊ne Salz onn Peffer.
+WS05	Ae eaß vir via orra sěchs Wȯche gesturwe.
+WS06	Datt Fäier war se häs, deï Kŏche sein jo eénně ganz schworz vabrannt.
+WS07	Ae eéßt deï Aier emmea{a steht über dem e}r ȯne Salz onn Peffer.
 WS08	Deï Feïs deïměr eso weh, äich gläwe, eïch honn se durich gelohf.
-WS09	Aeïch sein bäi der Frauh gewäst ann honn ett ’r gesooht, onn säi hott gesoht, säi wǒllt e̊tt och ihra Dogdar soon.
+WS09	Aeïch sein bäi der Frauh gewäst ann honn ett ’r gesooht, onn säi hott gesoht, säi wŏllt e̊tt och ihra Dogdar soon.
 WS10	Aeïch well ’e̊tt och net meéh doun.
-WS11	Aeïch schleen D’r gläich meăt děm Köchläăffel emm deï Ore, dǒu Aff!
+WS11	Aeïch schleen D’r gläich meăt děm Köchläăffel emm deï Ore, dŏu Aff!
 WS12	Woo gähst Du hinn, sellě ma meăt děr gehn.
 WS13	Ett sein schlecht Zeire!
 WS14	Mei leïf Kaand, bleiw l’hei eènne stohn, deï bees Gäns bäiße däich dot.
@@ -27,7 +27,7 @@ WS16	Dou beaß nach nett groaß genoch, em ’n Flasch Wein oussetreéïnke, dou
 WS17	Geh, sei ěso gout onn soh ett deiner Schwester, se soällt deï Klära fir aier Modder fěrtig něhe onn meaat d’r Berscht sauwer mage.
 WS18	Hätt’st Dau ’n kannt, dann wer ett amigdăr kömm, onn ett deht besser em’n stoohn.
 WS19	Wäar hott m’r meine Körf meat Fläsch gestoll?
-WS20	Er horr’e so gedohn, als härren se’n zo̊m Dräasche bestallt; se honn et äwer säalwa gedohn.
+WS20	Er horr’e so gedohn, als härren se’n zȯm Dräasche bestallt; se honn et äwer säalwa gedohn.
 WS21	Wemm horr’ä deï nau Geschicht vazeéllt?
 WS22	Ma moß h[o]rt schreiě, soaßt vearstährn us nett.
 WS23	M’r sein m[e]ïd onn honn Doorscht.

--- a/14804_Niederbrombach.csv
+++ b/14804_Niederbrombach.csv
@@ -27,8 +27,8 @@ WS16	Dou bischt noch net groß genug, im ä Flasch’ Wein oussedrinkä, Dou mus
 WS17	Geh, sei so gut un sa’ ďĕner Schwäschder, sie sollt’ die Kläärer fir ouer Mutter <(fast o)> firdig naèhä un mit <(fast e)> der Bürscht rein maihä.
 WS18	Hättscht Dou’n gekannt! dann wär et annerscht kom, un et dät besser im’n stehn.
 WS19	Wer hat m’r mĕenä Korb mit Fleisch gestohl’?
-WS20	Er daat so, s’härre sä ihn z’dreschä bestellt; sie hǎn et awer selbscht gedohn.
-WS21	Wem hǎr’r die nou Geschiegt verzielt?
+WS20	Er daat so, s’härre sä ihn z’dreschä bestellt; sie hăn et awer selbscht gedohn.
+WS21	Wem hăr’r die nou Geschiegt verzielt?
 WS22	M’r muß lout schreiä, sonscht verschtehr’ ’r us nit <(i faßt e)>
 WS23	M’r sin <(i fast e)> mid, un han Durscht.
 WS24	As m’r geschter Owet särick <(i fast e)> kamä, da lagä die schon se Bett un warä fescht am schlofä.
@@ -37,7 +37,7 @@ WS26	Hinner(e) urem Hous schtehn drei scheene Apelbämcher mit rore Äpelcher.
 WS27	Könnt <(ö = reines e)> ’r not noch ä Aueblickchä of us wardä, dann gehn m’r mǐr ouch.
 WS28	Dir dirft nit <(net)> solche Kinnerei[e] treiwä.
 WS29	Uus Berg’ sin nit sehr hoch, die ourä sin viel höer.
-WS30	Wie viel Pund <(u ähnlich o)> Wurscht un wieviel Brod welt’r hǎn?
+WS30	Wie viel Pund <(u ähnlich o)> Wurscht un wieviel Brod welt’r hăn?
 WS31	Eich verschtehn ouch nit, d’r mißt ä bischen <(i = e)> louder sprechä.
 WS32	Hat’r kein Stickchä weiß’ Seif’ for meich of mei’m Disch fon.
 WS33	Sei’ Brurer will sich zwei schöne Häuser <(fast ei)> in ourem Gartä bouä.

--- a/14804_Niederbrombach.csv
+++ b/14804_Niederbrombach.csv
@@ -24,9 +24,9 @@ WS13	Et sin schleegde Zeirä!
 WS14	Mei liew Kind, bleiw hie eene schtehn, die besä Gäns beißä Deich dood.
 WS15	Dou hascht hout am mehschtä geleert un bischt ardig gewescht, dou därfscht frier noh Hous <(heim)> gehn als die Annere.
 WS16	Dou bischt noch net groß genug, im ä Flasch’ Wein oussedrinkä, Dou muscht erscht noch än En waasä un grerer werä.
-WS17	Geh, sei so gut un sa’ ďěner Schwäschder, sie sollt’ die Kläärer fir ouer Mutter <(fast o)> firdig naèhä un mit <(fast e)> der Bürscht rein maihä.
+WS17	Geh, sei so gut un sa’ ďĕner Schwäschder, sie sollt’ die Kläärer fir ouer Mutter <(fast o)> firdig naèhä un mit <(fast e)> der Bürscht rein maihä.
 WS18	Hättscht Dou’n gekannt! dann wär et annerscht kom, un et dät besser im’n stehn.
-WS19	Wer hat m’r měenä Korb mit Fleisch gestohl’?
+WS19	Wer hat m’r mĕenä Korb mit Fleisch gestohl’?
 WS20	Er daat so, s’härre sä ihn z’dreschä bestellt; sie hǎn et awer selbscht gedohn.
 WS21	Wem hǎr’r die nou Geschiegt verzielt?
 WS22	M’r muß lout schreiä, sonscht verschtehr’ ’r us nit <(i faßt e)>

--- a/14804_Niederbrombach.csv
+++ b/14804_Niederbrombach.csv
@@ -26,7 +26,7 @@ WS15	Dou hascht hout am mehschtä geleert un bischt ardig gewescht, dou därfsch
 WS16	Dou bischt noch net groß genug, im ä Flasch’ Wein oussedrinkä, Dou muscht erscht noch än En waasä un grerer werä.
 WS17	Geh, sei so gut un sa’ ďěner Schwäschder, sie sollt’ die Kläärer fir ouer Mutter <(fast o)> firdig naèhä un mit <(fast e)> der Bürscht rein maihä.
 WS18	Hättscht Dou’n gekannt! dann wär et annerscht kom, un et dät besser im’n stehn.
-WS19	Wer hat m’r m̌ěenä Korb mit Fleisch gestohl’?
+WS19	Wer hat m’r měenä Korb mit Fleisch gestohl’?
 WS20	Er daat so, s’härre sä ihn z’dreschä bestellt; sie hǎn et awer selbscht gedohn.
 WS21	Wem hǎr’r die nou Geschiegt verzielt?
 WS22	M’r muß lout schreiä, sonscht verschtehr’ ’r us nit <(i faßt e)>

--- a/15260_Mettendorf.csv
+++ b/15260_Mettendorf.csv
@@ -23,9 +23,9 @@ WS12	Wor gehst de hin, solle mr mat dr gon.
 WS13	Et senn schlecht Zëiten!
 WS14	Mëi lew Kand, bleiw hei ennen ston, di bis Gäns bëißen dich dugt.
 WS15	Dou hos hett am mästen gelert a bas artig gewest, dou dorfs freher häm gon als de aner.
-WS16	Dou bas noch net gruß genug, um en Flasch Wëin őuszedranken, dou moß discht noch en Enn woßen a grißer gen.
+WS16	Dou bas noch net gruß genug, um en Flasch Wëin öuszedranken, dou moß discht noch en Enn woßen a grißer gen.
 WS17	Gih, sov esu gut a so denger Schwester, sëi soll d’Klader fir eir Mam ferdig nihen an mat der Biescht ranlich machen.
-WS18	Häts dőu hen kant! da wär et anischter kommen, an et deht besser om hen ston.
+WS18	Häts döu hen kant! da wär et anischter kommen, an et deht besser om hen ston.
 WS19	Wen hot mr mëi Korv mat Fläsch gesto(u)hlen?
 WS20	Hen däht esu, als hätten sëi hen zom Dreschen bestalt, sëi hon et ewer selwer gedon.
 WS21	Wem hot hen die nei Geschicht erziëhlt?

--- a/15274_Moetsch.csv
+++ b/15274_Moetsch.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Amm Wanter flehen trochen Bläder an der Loft herum.
 WS02	Et hirt gleich ob zu schneien, dan gett et Wäder besser.
 WS03	Du Kohlen an den Owen, datt die Mellich gloïch koocht.
-WS04	Dän guoden allen {˙˙ über e und/oder n} Man aß matt däm Pärd durchet Eis gebrooch un an datt kahl Waaßer gefahl.
+WS04	Dän guoden allën Man aß matt däm Pärd durchet Eis gebrooch un an datt kahl Waaßer gefahl.
 WS05	Hän aß fir ver baß sechs Wochen gestorwen.
 WS06	Datt Feuer woor su woorm, datt die Kuochen innen ganz schworz bebrant senn.
 WS07	Hän eßt die Aier immer oohnen Saalz un Päfer.

--- a/15351_Daxweiler.csv
+++ b/15351_Daxweiler.csv
@@ -11,12 +11,12 @@ Anmerkungen: ''
 WS01	Im Winter fliege die trockne Blärrer durch die Luft herum.
 WS02	Es hert gleich uff zu schnee, dann wird das Werrer wirre besser.
 WS03	Duh Kuhle in de Uwe, daß die Milich bald anfängt zu koche.
-WS04	Der gure alte Mann ist mit dem Gaul durch’s Eis gebroch un̅ in das kalt Wasser gefall.
+WS04	Der gure alte Mann ist mit dem Gaul durch’s Eis gebroch un̄ in das kalt Wasser gefall.
 WS05	Er is’ vor vier ore sechs Woche gestorb.
-WS06	Das Feier war zu häß, die Kuche sind jo unne ganz schwarz gebren̅t.
+WS06	Das Feier war zu häß, die Kuche sind jo unne ganz schwarz gebren̄t.
 WS07	Er ischt die Aier immer ohne Salz und Peffer.
 WS08	Die Fies duhn mer sehr weh, ich glaab ich hann se durchgelaaf.
-WS09	Ich sein bei der Fraa gewescht un han̅s ihr gesaht, unn sie saht, sie wollt es aag ehrer Tochter sahn.
+WS09	Ich sein bei der Fraa gewescht un han̄s ihr gesaht, unn sie saht, sie wollt es aag ehrer Tochter sahn.
 WS10	Ich wills aag nit mehr wirrer duhn.
 WS11	Ich schlahn dehr gleich mirem Kochleffel hinner die Ohre, du Affe.
 WS12	Wo gehst Du hin, solle mer met der gehen?
@@ -41,7 +41,7 @@ WS30	Wieviel pund Worscht un wieviel Brod wollt’r honn.
 WS31	Ich verstehn eich nit, (ihr) [d]er mißt’n bischen härter plaurere.
 WS32	Hott der ke Stickelche weiß Sef vor mich uff meim Disch gefunn.
 WS33	Sei Bruer will sich zwe schene neie Haiser in eirem Garte baue.
-WS34	Das Wort is’m vum Herze kom̅.
+WS34	Das Wort is’m vum Herze kom̄.
 WS35	Das war recht vunn eich.
 WS36	Was sitze do vor Vehlcher uwe uffdem Meierche.
 WS37	Die Baure harre finnef Ochse unn nein Kieh unn zwelef Schefcher vors Dorf bracht, die wollte sie verkaafe.

--- a/15365_Bingen-am-Rhein.csv
+++ b/15365_Bingen-am-Rhein.csv
@@ -23,7 +23,7 @@ WS12	Wo gēscht dĕ hi͡n, solle mĕr mit dĕr ge͡hn.
 WS13	Es se͡in schlechte Zeite.
 WS14	Mein lieb Kind, bleib do unne ste͡hn, die bēse Gäns beiße dich dodt.
 WS15	Du hoscht am meischte gelernt unn bischt aartig gewese, Du derfscht früher hä͡m ge͡hn als die Annere.
-WS16	Du bischt noch nitt groß genug, um ě Flasch Wein auszudrinke, du muscht erscht noch ě End wachse unn größend we.
+WS16	Du bischt noch nitt groß genug, um ĕ Flasch Wein auszudrinke, du muscht erscht noch ĕ End wachse unn größend we.
 WS17	Geh, sei so gut unn saa deiner Schwester, sie soll die Kläder for ihr Mutter fertig nähe, unn mit de Berscht sauwer mache.
 WS18	Hescht D’ĕn gekennt! dann wērsch annerscht komme unn’s dhät besser um ĕn ste͡hn. 
 WS19	Wer hot mĕr me͡in Korb mit Fläsch gestohl(e)?

--- a/15365_Bingen-am-Rhein.csv
+++ b/15365_Bingen-am-Rhein.csv
@@ -14,7 +14,7 @@ WS03	Dhu Kohle in de Owe, daß die Milich ball a͡n zu koche fängt.
 WS04	De gut, alt Mann iß mit dem Gaul durch’s Eis gebroch(e) unn in’s kalt Wasser gefall(e).
 WS05	Er iß vor vier odder sechs Woche gestorw(e).
 WS06	D’s Faier war zu häß, die Kuche se͡in jo unne ganz schwarz gebrennt.
-WS07	Er ißt die Ei͞er immer ohne Salz unn Peffer.
+WS07	Er ißt die Ei͡er immer ohne Salz unn Peffer.
 WS08	Die Füß dhu͡n arig mĕr weh, ich glawe, ich hawe sĕ durch geloff(e).
 WS09	Ich bin bei de Frā gewese unn hawe’s ĕr gesaat, unn sie hot gesaat, sie wollt’s āch ihrer Dochter saa.
 WS10	Ich will’s āch nitt mehr widder dhu͡n.

--- a/16907_Altendorf.csv
+++ b/16907_Altendorf.csv
@@ -22,14 +22,14 @@ WS11	ex hā <(haue; šlô schlage)> dix glaê me(t)n Kôglefl fā də ōrn, du o
 WS12	wû ges(t)n̥ <(gehst dir denn)> hêən, foŷ b?n met? gêən?
 WS13	dōss=faên šlaxta tsaê(t)n̥!
 WS14	maê libəs Kint, blaê ȯx dô hun(t)n̥ s̆têən; də bêəſn̥ gens baêsn̥ diχ ſunst tuət.
-WS15	Du host haêta am merštn̥ gǝlōrt un(t) wȯršt ōrtiχ, dô tȯršta (darfst du = türren tarst) ā frūⱱ (eêndⱱ) haë̄m gêǝn.
+WS15	Du host haêta am merštn̥ gəlōrt un(t) wȯršt ōrtiχ, dô tȯršta (darfst du = türren tarst) ā frūⱱ (eêndⱱ) haë̄m gêən.
 WS16	du best nôx nî grûss gənuk, dos də konst a floš waên austrin(k)ŋ, dô mustə šun(t) nôx a besla woksn un(d) gresɒ wārn.
 WS17	gês, bêss‿ſo gůt un(t) ſēss daênɒ šwestɒ, ſə ſoŷ <(ſoll; suŷt ſollte)> də Klaë̄dɒ fīr aêɒ mutɒ fertiχ neên ůn(t) mẹtɒ piršt aůſputsn̥ <(raë̄n rein.)>
 WS18	hets(t)n̥ ȯx gəkȯnt, dô wērš ȯndɒš und͜ əs wēr (štint) besɒ mêəd͜ en. <(u. es wäre (stünde) besser mit ihm).>
-WS19	Wār hôt mr den men Korp me(t)n flaêš gǝštoŷn?
-WS20	ɒ tôt sûǝ, wî wen sǝ nen tsun drašn beštoë̅t he(t)n, sǝ hons ōbɒ saë̅ɒ gǝmoxt.
+WS19	Wār hôt mr den men Korp me(t)n flaêš gəštoŷn?
+WS20	ɒ tôt sûə, wî wen sə nen tsun drašn beštoë̄t he(t)n, sə hons ōbɒ saë̄ɒ gəmoxt.
 WS21	wām hôd͜ ɐ den dī naêa gəšiχt dɐtsöŷt?
-WS22	mɒ mûs laut pröŷn, sunst vɒštěət‿er‿es nī.
+WS22	mɒ mûs laut pröŷn, sunst vɒštĕət‿er‿es nī.
 WS23	Ba saen mit und hon durst.
 WS24	wi br gestrn trobst <(omts)> haёm koma, do lon ds ondrn šunt aёn bet un(t) šluom fest. <(hon gešlovm)>
 WS25	Da snes ess haet ae da nort bae und lem blem, oba haed ae da fru esja aufgetat.
@@ -38,13 +38,13 @@ WS27	Kint‿ɐ den nī nôx an klan āŋblêək of‿es wòr(t)n; dɐnôxtɐn g�
 WS28	êr tirt <(jezt müst dirft)> nī sẹ(t)n̥ ûənſin traêm.
 WS29	ůnſŋ bark ſaên nī aſûə hûəx; aêəra ſaên vŷə heχŋ.
 WS30	wifə pfŭnt wuršt un(t) wifə brûət wë̄ət‿ɐn hōn?
-WS31	eχ vŋštêə͜ eχ <(betont aêχ)> nī, īər (iŋ) mist a bẹsla lautɒ reên.
+WS31	eχ vŋštêə͡ eχ <(betont aêχ)> nī, īər (iŋ) mist a bẹsla lautɒ reên.
 WS32	Hot rn ni a stekla waesa Saef fo mech of men Tess fun(t)n?
 WS33	ſaê brudɐ wŷə ſiχ tswë̄ šêəna naêa haêſɐ aêɐn gōr(t)n̥ baun.
 WS34	dōәs wōrt kōm nen vọn hartsn̥.
 WS35	dōәs wōr raχt von͡ iχ.
 WS36	wōəs ſẹtsn̥ den dô fīr veêgɒla dô drûəm of dān maêəla?
 WS37	də pauɐn hȯ(t)n̥ fimf ọksn̥ un(t) naên kî un(t) tswë̄f šôv <(šeêvla)> firš dȯrf gəbrôxt un(t) wuŷ(t)n̥ sa vɐkāvm̥.
-WS38	dǝ laêt ſaên haêt ọla dresn̥ oom̥ vaë̄t un(t) hān.
+WS38	də laêt ſaên haêt ọla dresn̥ oom̥ vaë̄t un(t) hān.
 WS39	gêə-ox, dar brauna hunt tut-r nist
 WS40	e bêm mẹ(t)n̥ laê(t)n̥ dô dahin(t)n̥ êəbr də wêss aês Kōn gofōrn.

--- a/16907_Altendorf.csv
+++ b/16907_Altendorf.csv
@@ -24,7 +24,7 @@ WS13	dōss=faên šlaxta tsaê(t)n̥!
 WS14	maê libəs Kint, blaê ȯx dô hun(t)n̥ s̆têən; də bêəſn̥ gens baêsn̥ diχ ſunst tuət.
 WS15	Du host haêta am merštn̥ gǝlōrt un(t) wȯršt ōrtiχ, dô tȯršta (darfst du = türren tarst) ā frūⱱ (eêndⱱ) haë̄m gêǝn.
 WS16	du best nôx nî grûss gənuk, dos də konst a floš waên austrin(k)ŋ, dô mustə šun(t) nôx a besla woksn un(d) gresɒ wārn.
-WS17	gês, bêss‿ſo gůt un(t) ſēss daênɒ šwestɒ, ſə ſoŷ <(ſoll; suŷt ſollte)> də Klaë̄dɒ fīr aêɒ mutɒ fertiᴊ neên ůn(t) mẹtɒ piršt aůſputsn̥ <(raë̄n rein.)>
+WS17	gês, bêss‿ſo gůt un(t) ſēss daênɒ šwestɒ, ſə ſoŷ <(ſoll; suŷt ſollte)> də Klaë̄dɒ fīr aêɒ mutɒ fertiχ neên ůn(t) mẹtɒ piršt aůſputsn̥ <(raë̄n rein.)>
 WS18	hets(t)n̥ ȯx gəkȯnt, dô wērš ȯndɒš und͜ əs wēr (štint) besɒ mêəd͜ en. <(u. es wäre (stünde) besser mit ihm).>
 WS19	Wār hôt mr den men Korp me(t)n flaêš gǝštoŷn?
 WS20	ɒ tôt sûǝ, wî wen sǝ nen tsun drašn beštoë̅t he(t)n, sǝ hons ōbɒ saë̅ɒ gǝmoxt.
@@ -42,7 +42,7 @@ WS31	eχ vŋštêə͜ eχ <(betont aêχ)> nī, īər (iŋ) mist a bẹsla laut�
 WS32	Hot rn ni a stekla waesa Saef fo mech of men Tess fun(t)n?
 WS33	ſaê brudɐ wŷə ſiχ tswë̄ šêəna naêa haêſɐ aêɐn gōr(t)n̥ baun.
 WS34	dōәs wōrt kōm nen vọn hartsn̥.
-WS35	dōәs wōr raχt von͜ iχ.
+WS35	dōәs wōr raχt von͡ iχ.
 WS36	wōəs ſẹtsn̥ den dô fīr veêgɒla dô drûəm of dān maêəla?
 WS37	də pauɐn hȯ(t)n̥ fimf ọksn̥ un(t) naên kî un(t) tswë̄f šôv <(šeêvla)> firš dȯrf gəbrôxt un(t) wuŷ(t)n̥ sa vɐkāvm̥.
 WS38	dǝ laêt ſaên haêt ọla dresn̥ oom̥ vaë̄t un(t) hān.

--- a/16907_Altendorf.csv
+++ b/16907_Altendorf.csv
@@ -16,7 +16,7 @@ WS05	dār êəs fīr vīr ōbⱱ ſeks wọxŋ gəštȯrm.
 WS06	əs wor tsu vŷə vaêa <(hets)>, də Kuxŋ faên jûə un(t)n gonts ōgəbront.
 WS07	ⱱ ẹst də aë̄ⱱ imⱱ <(inda)> ûəna ſȯë̄ts un(t) pfafⱱ.
 WS08	de fis tun mr wî, ech deêcht, ech hö mrsa <(za)> aufg[?]rê[?]m.
-WS09	eχ bêən baê dŋ fraů gəwāst; ůn(t) ſə ſēət, dös‿es ā dŋ toχtŋ ſēən wuŷt.
+WS09	eχ bêən baê dŋ fraů gəwāst; ůn(t) ſə ſēət, dös⁀es ā dŋ toχtŋ ſēən wuŷt.
 WS10	ex wāršun <(werde es schon)> nimŋ mòxŋ.
 WS11	ex hā <(haue; šlô schlage)> dix glaê me(t)n Kôglefl fā də ōrn, du of, dû.
 WS12	wû ges(t)n̥ <(gehst dir denn)> hêən, foŷ b?n met? gêən?
@@ -24,20 +24,20 @@ WS13	dōss=faên šlaxta tsaê(t)n̥!
 WS14	maê libəs Kint, blaê ȯx dô hun(t)n̥ s̆têən; də bêəſn̥ gens baêsn̥ diχ ſunst tuət.
 WS15	Du host haêta am merštn̥ gəlōrt un(t) wȯršt ōrtiχ, dô tȯršta (darfst du = türren tarst) ā frūⱱ (eêndⱱ) haë̄m gêən.
 WS16	du best nôx nî grûss gənuk, dos də konst a floš waên austrin(k)ŋ, dô mustə šun(t) nôx a besla woksn un(d) gresɒ wārn.
-WS17	gês, bêss‿ſo gůt un(t) ſēss daênɒ šwestɒ, ſə ſoŷ <(ſoll; suŷt ſollte)> də Klaë̄dɒ fīr aêɒ mutɒ fertiχ neên ůn(t) mẹtɒ piršt aůſputsn̥ <(raë̄n rein.)>
+WS17	gês, bêss⁀ſo gůt un(t) ſēss daênɒ šwestɒ, ſə ſoŷ <(ſoll; suŷt ſollte)> də Klaë̄dɒ fīr aêɒ mutɒ fertiχ neên ůn(t) mẹtɒ piršt aůſputsn̥ <(raë̄n rein.)>
 WS18	hets(t)n̥ ȯx gəkȯnt, dô wērš ȯndɒš und͜ əs wēr (štint) besɒ mêəd͜ en. <(u. es wäre (stünde) besser mit ihm).>
 WS19	Wār hôt mr den men Korp me(t)n flaêš gəštoŷn?
 WS20	ɒ tôt sûə, wî wen sə nen tsun drašn beštoë̄t he(t)n, sə hons ōbɒ saë̄ɒ gəmoxt.
 WS21	wām hôd͜ ɐ den dī naêa gəšiχt dɐtsöŷt?
-WS22	mɒ mûs laut pröŷn, sunst vɒštĕət‿er‿es nī.
+WS22	mɒ mûs laut pröŷn, sunst vɒštĕət⁀er⁀es nī.
 WS23	Ba saen mit und hon durst.
 WS24	wi br gestrn trobst <(omts)> haёm koma, do lon ds ondrn šunt aёn bet un(t) šluom fest. <(hon gešlovm)>
 WS25	Da snes ess haet ae da nort bae und lem blem, oba haed ae da fru esja aufgetat.
 WS26	Hinta unsan Haus sten drae seena eplbaem met ruetn epln.
-WS27	Kint‿ɐ den nī nôx an klan āŋblêək of‿es wòr(t)n; dɐnôxtɐn gêə‿bɐ meəd‿ix.
+WS27	Kint⁀ɐ den nī nôx an klan āŋblêək of⁀es wòr(t)n; dɐnôxtɐn gêə⁀bɐ meəd⁀ix.
 WS28	êr tirt <(jezt müst dirft)> nī sẹ(t)n̥ ûənſin traêm.
 WS29	ůnſŋ bark ſaên nī aſûə hûəx; aêəra ſaên vŷə heχŋ.
-WS30	wifə pfŭnt wuršt un(t) wifə brûət wë̄ət‿ɐn hōn?
+WS30	wifə pfŭnt wuršt un(t) wifə brûət wë̄ət⁀ɐn hōn?
 WS31	eχ vŋštêə͡ eχ <(betont aêχ)> nī, īər (iŋ) mist a bẹsla lautɒ reên.
 WS32	Hot rn ni a stekla waesa Saef fo mech of men Tess fun(t)n?
 WS33	ſaê brudɐ wŷə ſiχ tswë̄ šêəna naêa haêſɐ aêɐn gōr(t)n̥ baun.

--- a/16907_Altendorf.csv
+++ b/16907_Altendorf.csv
@@ -8,9 +8,9 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	aên wintⱱ dô vlî(g)ŋ dә traê(g)ŋ bleêtⱱ aê dⱱ loft rim.
+WS01	aên wintⱱ dô vlî(g)ŋ də traê(g)ŋ bleêtⱱ aê dⱱ loft rim.
 WS02	s hērt glaê auf tsu šnaên, dɒnôxtɒn wirts wātɒ wêədɒ besɒ wārn.
-WS03	tu koŷn aên ûәvm, dos dә melix boët oveŋkt tsu koxŋ.
+WS03	tu koŷn aên ûəvm, dos də melix boët oveŋkt tsu koxŋ.
 WS04	dār gûda ȯë̄da mōn êəs mẹ(t)n̥ pfār aên aês aêgəbroxŋ und͜aês kȯë̄da wȯsⱱ gəfȯë̄n.
 WS05	dār êəs fīr vīr ōbⱱ ſeks wọxŋ gəštȯrm.
 WS06	əs wor tsu vŷə vaêa <(hets)>, də Kuxŋ faên jûə un(t)n gonts ōgəbront.
@@ -31,7 +31,7 @@ WS20	ɒ tôt sûə, wî wen sə nen tsun drašn beštoë̄t he(t)n, sə hons ōb
 WS21	wām hôd͜ ɐ den dī naêa gəšiχt dɐtsöŷt?
 WS22	mɒ mûs laut pröŷn, sunst vɒštĕət⁀er⁀es nī.
 WS23	Ba saen mit und hon durst.
-WS24	wi br gestrn trobst <(omts)> haёm koma, do lon ds ondrn šunt aёn bet un(t) šluom fest. <(hon gešlovm)>
+WS24	wi br gestrn trobst <(omts)> haëm koma, do lon ds ondrn šunt aën bet un(t) šluom fest. <(hon gešlovm)>
 WS25	Da snes ess haet ae da nort bae und lem blem, oba haed ae da fru esja aufgetat.
 WS26	Hinta unsan Haus sten drae seena eplbaem met ruetn epln.
 WS27	Kint⁀ɐ den nī nôx an klan āŋblêək of⁀es wòr(t)n; dɐnôxtɐn gêə⁀bɐ meəd⁀ix.
@@ -41,8 +41,8 @@ WS30	wifə pfŭnt wuršt un(t) wifə brûət wë̄ət⁀ɐn hōn?
 WS31	eχ vŋštêə͡ eχ <(betont aêχ)> nī, īər (iŋ) mist a bẹsla lautɒ reên.
 WS32	Hot rn ni a stekla waesa Saef fo mech of men Tess fun(t)n?
 WS33	ſaê brudɐ wŷə ſiχ tswë̄ šêəna naêa haêſɐ aêɐn gōr(t)n̥ baun.
-WS34	dōәs wōrt kōm nen vọn hartsn̥.
-WS35	dōәs wōr raχt von͡ iχ.
+WS34	dōəs wōrt kōm nen vọn hartsn̥.
+WS35	dōəs wōr raχt von͡ iχ.
 WS36	wōəs ſẹtsn̥ den dô fīr veêgɒla dô drûəm of dān maêəla?
 WS37	də pauɐn hȯ(t)n̥ fimf ọksn̥ un(t) naên kî un(t) tswë̄f šôv <(šeêvla)> firš dȯrf gəbrôxt un(t) wuŷ(t)n̥ sa vɐkāvm̥.
 WS38	də laêt ſaên haêt ọla dresn̥ oom̥ vaë̄t un(t) hān.

--- a/16907_Altendorf.csv
+++ b/16907_Altendorf.csv
@@ -25,7 +25,7 @@ WS14	maê libəs Kint, blaê ȯx dô hun(t)n̥ s̆têən; də bêəſn̥ gens ba
 WS15	Du host haêta am merštn̥ gǝlōrt un(t) wȯršt ōrtiχ, dô tȯršta (darfst du = türren tarst) ā frūⱱ (eêndⱱ) haë̄m gêǝn.
 WS16	du best nôx nî grûss gənuk, dos də konst a floš waên austrin(k)ŋ, dô mustə šun(t) nôx a besla woksn un(d) gresɒ wārn.
 WS17	gês, bêss‿ſo gůt un(t) ſēss daênɒ šwestɒ, ſə ſoŷ <(ſoll; suŷt ſollte)> də Klaë̄dɒ fīr aêɒ mutɒ fertiᴊ neên ůn(t) mẹtɒ piršt aůſputsn̥ <(raë̄n rein.)>
-WS18	hets(t)n̥ o̊x gəko̊nt, dô wērš o̊ndɒš und͜ əs wēr (štint) besɒ mêəd͜ en. <(u. es wäre (stünde) besser mit ihm).>
+WS18	hets(t)n̥ ȯx gəkȯnt, dô wērš ȯndɒš und͜ əs wēr (štint) besɒ mêəd͜ en. <(u. es wäre (stünde) besser mit ihm).>
 WS19	Wār hôt mr den men Korp me(t)n flaêš gǝštoŷn?
 WS20	ɒ tôt sûǝ, wî wen sǝ nen tsun drašn beštoë̅t he(t)n, sǝ hons ōbɒ saë̅ɒ gǝmoxt.
 WS21	wām hôd͜ ɐ den dī naêa gəšiχt dɐtsöŷt?

--- a/16908_Klein-Mohrau.csv
+++ b/16908_Klein-Mohrau.csv
@@ -38,7 +38,7 @@ WS27	Kinnt er nie noch a Wella off es wartn, drnochtern giëber miëd͜ ich.
 WS28	Ihr tirt nie sette Kinderein <(settes kindisches Zeig)> triem.
 WS29	Unser Barg sein nie suo huoch, eiern sein vüe hecher.
 WS30	Wifl Pfund Wurscht und wifl Bruot wöet͡ er hån.
-WS31	Iëch verstiëh͜ ich nie, ihr mißt a bessla lauter redn. <(sprachn).>
+WS31	Iëch verstiëh͡ ich nie, ihr mißt a bessla lauter redn. <(sprachn).>
 WS32	Hott‿ern nie a Steckla weißa Saef vier miëch off menn Tiësch gefundn?
 WS33	Sei Bruder wüe siëch zwae <(zwae = sächliche Form; männlich: zwee (Ochsn) weiblich: zwü (Küh)> schiëna neia Haiser in eiern Gårtn baun.
 WS34	Dås Wort kåm‿em von Harzn!

--- a/16908_Klein-Mohrau.csv
+++ b/16908_Klein-Mohrau.csv
@@ -19,13 +19,13 @@ WS08	Die Fiss tunn mer wi͡eh; iëch deecht, iëch hå mer se durchgeloffn. <(au
 WS09	Iëch ben bei dar Frau gewaast und hå er’sch gesäht, und sie säht’, sie wuits a ihrer Tochter säh’n.
 WS10	Iëch wöe’s a nimmermehr wiëder tun. <(måchn.)>
 WS11	Iëch schloh dich glei mettn Kogläffel iëber de Ohrn, du Åff!
-WS12	Wu gestn hiën, soi ber met‿der giëhn?
+WS12	Wu gestn hiën, soi ber met⁀der giëhn?
 WS13	s sein schlachte Zeitn. <(auch: schlachta.)>
 WS14	Mei liebes Kind, blei do untn stiën, de biësn Gäns beisn dich tuot.
 WS15	Du hoßt heit ommeistn gelort <(auch: gelernt,)> und best ortich gewast, du darfst (du tårscht) frieer haem giën wie de ondern.
 WS16	Du best noch nie gruoß genug <(auch: genung)> doß de kennst a Flåsch Wein austrinkn, du mußt erscht noch a wing <(auch: a bessla)> woksn und gresser warn.
 WS17	Giëh, biëß sue gutt und säh’s deiner Schwester, se sojt de Klaeder fier eier Mutter fertich neh’n und metter Pirscht raën måchn.
-WS18	Häßt nenn gekånnt, do wär’sch åndersch kumma und stet besser im‿en stiën.
+WS18	Häßt nenn gekånnt, do wär’sch åndersch kumma und stet besser im⁀en stiën.
 WS19	War hot mer men Karb met Fleisch geschtoin?
 WS20	Ar toot suö, wie wenn se nen zun Draschn bastöet hättn, se håns åber saeber gemåcht.
 WS21	Wan hot͡ ern die neie Geschicht derzöht?
@@ -39,10 +39,10 @@ WS28	Ihr tirt nie sette Kinderein <(settes kindisches Zeig)> triem.
 WS29	Unser Barg sein nie suo huoch, eiern sein vüe hecher.
 WS30	Wifl Pfund Wurscht und wifl Bruot wöet͡ er hån.
 WS31	Iëch verstiëh͡ ich nie, ihr mißt a bessla lauter redn. <(sprachn).>
-WS32	Hott‿ern nie a Steckla weißa Saef vier miëch off menn Tiësch gefundn?
+WS32	Hott⁀ern nie a Steckla weißa Saef vier miëch off menn Tiësch gefundn?
 WS33	Sei Bruder wüe siëch zwae <(zwae = sächliche Form; männlich: zwee (Ochsn) weiblich: zwü (Küh)> schiëna neia Haiser in eiern Gårtn baun.
-WS34	Dås Wort kåm‿em von Harzn!
-WS35	Dås wår racht von‿nen. <(In der Anrede: vo Iëhna.)>
+WS34	Dås Wort kåm⁀em von Harzn!
+WS35	Dås wår racht von⁀nen. <(In der Anrede: vo Iëhna.)>
 WS36	Wås setz’n do für Vegela uobn off dan Meierla?
 WS37	De Pauern hottn fünnff Oxn und nein Kieh und zwöef Schefla vier’s <(auch: sch.)> Darf gebråcht, die woitn se verkafn.
 WS38	De Leit sein heit olla dress’n off’n Faed und ha’n.

--- a/16908_Klein-Mohrau.csv
+++ b/16908_Klein-Mohrau.csv
@@ -15,7 +15,7 @@ WS04	Dar gude oede Mån iës mett’n Pfaar durch’s Eis gebrochn und eis koeda
 WS05	Ar iës vir vier åber sex Wochn gestarm. <(Er = ar, besonders: betont “har.”)>
 WS06	s Feier wår zu stark, de Kuchn sein juo untn gånz schwarz wuern.
 WS07	Ar eßt de Aeer immer uona Soiz und Pfaffer.
-WS08	Die Fiss tunn mer wi͜eh; iëch deecht, iëch hå mer se durchgeloffn. <(auch: durchgelafn.)>
+WS08	Die Fiss tunn mer wi͡eh; iëch deecht, iëch hå mer se durchgeloffn. <(auch: durchgelafn.)>
 WS09	Iëch ben bei dar Frau gewaast und hå er’sch gesäht, und sie säht’, sie wuits a ihrer Tochter säh’n.
 WS10	Iëch wöe’s a nimmermehr wiëder tun. <(måchn.)>
 WS11	Iëch schloh dich glei mettn Kogläffel iëber de Ohrn, du Åff!

--- a/16908_Klein-Mohrau.csv
+++ b/16908_Klein-Mohrau.csv
@@ -28,7 +28,7 @@ WS17	Giëh, biëß sue gutt und säh’s deiner Schwester, se sojt de Klaeder fi
 WS18	Häßt nenn gekånnt, do wär’sch åndersch kumma und stet besser im‿en stiën.
 WS19	War hot mer men Karb met Fleisch geschtoin?
 WS20	Ar toot suö, wie wenn se nen zun Draschn bastöet hättn, se håns åber saeber gemåcht.
-WS21	Wan hot͜ ern die neie Geschicht derzöht?
+WS21	Wan hot͡ ern die neie Geschicht derzöht?
 WS22	Mer muß laut pröin, sunst verstiëht har es nie.
 WS23	Bir sein mied und hån Durscht.
 WS24	Wie ber gestern oms zureck kåma, do lågn die åndern schunn ein Bett und wårn fest ein schloufn.
@@ -37,7 +37,7 @@ WS26	Hinder unsern Haus stenn drei schiëna Äppelbaem mett ruetn Appelen.
 WS27	Kinnt er nie noch a Wella off es wartn, drnochtern giëber miëd͜ ich.
 WS28	Ihr tirt nie sette Kinderein <(settes kindisches Zeig)> triem.
 WS29	Unser Barg sein nie suo huoch, eiern sein vüe hecher.
-WS30	Wifl Pfund Wurscht und wifl Bruot wöet͜ er hån.
+WS30	Wifl Pfund Wurscht und wifl Bruot wöet͡ er hån.
 WS31	Iëch verstiëh͜ ich nie, ihr mißt a bessla lauter redn. <(sprachn).>
 WS32	Hott‿ern nie a Steckla weißa Saef vier miëch off menn Tiësch gefundn?
 WS33	Sei Bruder wüe siëch zwae <(zwae = sächliche Form; männlich: zwee (Ochsn) weiblich: zwü (Küh)> schiëna neia Haiser in eiern Gårtn baun.
@@ -46,5 +46,5 @@ WS35	Dås wår racht von‿nen. <(In der Anrede: vo Iëhna.)>
 WS36	Wås setz’n do für Vegela uobn off dan Meierla?
 WS37	De Pauern hottn fünnff Oxn und nein Kieh und zwöef Schefla vier’s <(auch: sch.)> Darf gebråcht, die woitn se verkafn.
 WS38	De Leit sein heit olla dress’n off’n Faed und ha’n.
-WS39	Giëh och, dar brauna Hund tut͜ der nischt.
+WS39	Giëh och, dar brauna Hund tut͡ der nischt.
 WS40	Iëch ben(n) met dan Leit’n do hintn iëber de Wiës eis Koarn gefoarn. <(gånga.)>

--- a/20280_Osnabrück.csv
+++ b/20280_Osnabrück.csv
@@ -31,8 +31,8 @@ WS20	He däe sau as harren se em tom Dasken bestellt (verdaget); se hewwet et au
 WS21	Wem heww he de nigge Gesc-sg-hichte (Vertellsel, Dóónke) vertellet?
 WS22	Men mott luut schreggen, sús (enners) versteet he us nich.
 WS23	Wi sin móóe un hewwet Dost.
-WS24	As wi gistern Aubend trügge queimen (keimen), dau leigen de En̆nern all to Bedde un wóóren faste inne slaupen.
-WS25	De Sn̆ei is düsse Nacht bi us liggen bliiewen, aubers (men) húúte Moeren (von Moeren) is he smolten.
+WS24	As wi gistern Aubend trügge queimen (keimen), dau leigen de Eňnern all to Bedde un wóóren faste inne slaupen.
+WS25	De Sňei is düsse Nacht bi us liggen bliiewen, aubers (men) húúte Moeren (von Moeren) is he smolten.
 WS26	Achter usem huuse stauet dree Appelbáumkes met rooen Äppelkens‘.
 WS27	Küene ji nich nau en Augenblicksken up us tóówen, denn gaue wi met ju.
 WS28	Use Baarge sin nich dúchtig (nútte) hauge, de juen sin vull háuger.

--- a/20280_Osnabrück.csv
+++ b/20280_Osnabrück.csv
@@ -24,7 +24,7 @@ WS13	Wo geeste hen, sülle wi met Di gauen?
 WS14	Miin leewe Kiind, bliiv hier unnen stauen, de báusen (leigen) Gáuse biètet di daud.
 WS15	Du hest van dage dat meeste leeret un bis ardig west, du drafst fróer (eer) to huuse gaun as de Ènnern.
 WS16	Du bist nau nich graut noog, úmm’ne Flaske Wien uut to drinken, du most eerst nau en Ĕnne (en Kopp) wassen und grótter weern.
-WS17	Gonk, sii so good un segge diine S̆üster, se solle de Kleider (dat túúg) vor juue Moder (Moon, Aulske) ferrig neggen un met de Bösten reggen maken.
+WS17	Gonk, sii so good un segge diine Šüster, se solle de Kleider (dat túúg) vor juue Moder (Moon, Aulske) ferrig neggen un met de Bösten reggen maken.
 WS18	Harrest du em kennet! denn wóóre et enners kuemen un et dáe biáter úmme em stauen!
 WS19	Ĕt sind (súnd) leige * Tüen. (* báuse)
 WS20	He däe sau as harren se em tom Dasken bestellt (verdaget); se hewwet et aubers súlwer (súlwerst) dauen.

--- a/20497_Meppen.csv
+++ b/20497_Meppen.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	In’n Winter fleget de drögen Bläere dör de Lucht herüm </besser in de Lucht ohne herüm>
 WS02	Et hört gliks up to sneen, dann wird dät We’er wer bäter.
-WS03	Do Köle <(Kö͜äle)> in den Awen, dät de Mälk bold <(gaue = geschwind)> to Kaken anfangt.
+WS03	Do Köle <(Kö͡äle)> in den Awen, dät de Mälk bold <(gaue = geschwind)> to Kaken anfangt.
 WS04	De gode olde Man ist mit dat Peerd dört Iis braken <(a=o͡a)> un in’t kolde Water fallen <(a immer dumpf)>.
 WS05	He ist for veer of ses Wäke(n) storwen.
 WS06	Dat Füer was to heet <(hait)>, de Koken <(Kauken)> bünt under jä gans swatt brännt.

--- a/24298_Hagen.csv
+++ b/24298_Hagen.csv
@@ -35,7 +35,7 @@ WS24	As wie gistern U͡obünd terügge ka?men, du͡o laggen de Annern schon im B
 WS25	Dä Schnäi es vanen Nacht bi ûs liggen bliewen, uōwer wan Mu͡ō͡urgen es hä geschmolten.
 WS26	Ächter usem Huse stuot drei schü͡ȫ͡üne Appelbü͡ȫ͡ümkes met ru͡ō͡uen Aeppelkes.
 WS27	Könnt itt nitt noch i͡ǟ͡in U͡o͡ugenblicksken op ûs wachten, dann gu͡ō͡uwe met ink.
-WS28	Usse Bi͡ārge sind nitt sähr hu͡ō͡uge, de inken sünd vüěll högger.
+WS28	Usse Bi͡ārge sind nitt sähr hu͡ō͡uge, de inken sünd vüĕll högger.
 WS29	Itt drü͡ewet nitt solke Kinneriggen driewen!
 WS30	Wievüal Pund Wuāst mött itt hewwen?
 WS31	Eck verstuōh ink nitt, itt mütt en biutken hädder sprīaken.

--- a/24298_Hagen.csv
+++ b/24298_Hagen.csv
@@ -33,7 +33,7 @@ WS22	Me mû͡a͡ut hatt schrei’n, suß verstäit hä  us nitt.
 WS23	Wie sind mei un hett Du͡ast.
 WS24	As wie gistern U͡obünd terügge ka?men, du͡o laggen de Annern schon im Berrn un wuoren feste  am schluopen.
 WS25	Dä Schnäi es vanen Nacht bi ûs liggen bliewen, uōwer wan Mu͡ō͡urgen es hä geschmolten.
-WS26	Ächter usem Huse stuot drei schü͡͡͡ȫ͡üne Appelbü͡ȫ͡ümkes met ru͡ō͡uen Aeppelkes.
+WS26	Ächter usem Huse stuot drei schü͡ȫ͡üne Appelbü͡ȫ͡ümkes met ru͡ō͡uen Aeppelkes.
 WS27	Könnt itt nitt noch i͡ǟ͡in U͡o͡ugenblicksken op ûs wachten, dann gu͡ō͡uwe met ink.
 WS28	Usse Bi͡ārge sind nitt sähr hu͡ō͡uge, de inken sünd vüěll högger.
 WS29	Itt drü͡ewet nitt solke Kinneriggen driewen!

--- a/24431_Konnefeld.csv
+++ b/24431_Konnefeld.csv
@@ -28,7 +28,7 @@ WS17	Geh, säch so gutt un säh Dir'r Schwester, se süll die Klehder värr üww
 WS18	Hättest du i͜ änn ge-kahnt! denn wärs angerscht kommen un es thäte besser ümme i͜ ämme stenn.
 WS19	Wer hot me mim'm Korb mit Fleesch gestohlen?
 WS20	He dat so, als hädden se i͜ änn mi͜ et uch zem Dräschen bestahlt, se honn's awer selber gedonn.
-WS21	Wer hot <(hot)> denn de neije Geschichte verzahlt? <(nübbe, nüw̅e)>
+WS21	Wer hot <(hot)> denn de neije Geschichte verzahlt? <(nübbe, nüw̄e)>
 WS22	Me moß lührer böhken, sost <(süst)> verstett he uns nett.
 WS23	Me sinn mühre un honn Dorst.
 WS24	We me gester Obed zurük=ke kamen, da lagen de Angern schon im Bette un waren fest am Schlofen.

--- a/24431_Konnefeld.csv
+++ b/24431_Konnefeld.csv
@@ -12,12 +12,12 @@ WS01	In Wender fliggen dïe drehgen Blatter derch de Loft.
 WS02	Es hört glich <(i͡ezze)> uf ze schne͡ïjjen, denn wird des Wetter ö wirrer schenner <(werd)>.
 WS03	Mach Kollen in̄'en Ohwen, daß de Mellch <(cfr. umst. 10)> bahle mohl anfanget ze kochen.
 WS04	Der gurre ahle Mann i͡eß mit dem Gülle derchs Ihs gebrochen un in das kahle Wasser gefallen
-WS05	He i͜eß vörr vier or'r sechs Wochen gestorben.
+WS05	He i͡eß vörr vier or'r sechs Wochen gestorben.
 WS06	Das Führ wor zu hehs, die Kuchchen sinn ja üngen ganz schwarz gebrahnt <(jo)>
 WS07	He <(fast hä)> ißt de Egger <(Ejjer)> immer ohn Sahlz un Päffer.
 WS08	De Fisse dunn meh awwer so wih, ich glöbe, ich honn me se derch gelöhfen.
 WS09	Ich wi͡ enn be͡ i der Froh g̰ewähn un honns ähr g̰esäht, se säht, se wülls äh=rem Mahnge öh sähng <(ge=ke)>
-WS10	Ich wi͜ ells öh nit mih wir'rer dunn.
+WS10	Ich wi͡ ells öh nit mih wir'rer dunn.
 WS11	Ich schloh dich gleich mit den <(dem)> Kochelöffel ümme die Ohren, du Affe.
 WS12	Wo gehst du hi͡enn, summ me midde gi͡ enn?
 WS13	Es sinn schlächte Zihren
@@ -25,20 +25,20 @@ WS14	Mein liebes Kend, blibb hie ungen sti ͡enn, die besen Gänse bissen dich d
 WS15	Du host hi ͡ödde am besten gelernt un west ahrig gewähn, du derfst ehr=ter hehmgi͡ enn wie die anner.
 WS16	Du west <(kurz)> nanet groß genung, üm̄e ne Flasche Wnig üßzetrenken, du mußt erst nach enn Enge wassen un grösser währn.
 WS17	Geh, säch so gutt un säh Dir'r Schwester, se süll die Klehder värr üwwe Mot=ter fertig nehn un mi͡ ett der Berste renge machen
-WS18	Hättest du i͜ änn ge-kahnt! denn wärs angerscht kommen un es thäte besser ümme i͜ ämme stenn.
+WS18	Hättest du i͡ änn ge-kahnt! denn wärs angerscht kommen un es thäte besser ümme i͡ ämme stenn.
 WS19	Wer hot me mim'm Korb mit Fleesch gestohlen?
-WS20	He dat so, als hädden se i͜ änn mi͜ et uch zem Dräschen bestahlt, se honn's awer selber gedonn.
+WS20	He dat so, als hädden se i͡ änn mi͡ et uch zem Dräschen bestahlt, se honn's awer selber gedonn.
 WS21	Wer hot <(hot)> denn de neije Geschichte verzahlt? <(nübbe, nüw̄e)>
 WS22	Me moß lührer böhken, sost <(süst)> verstett he uns nett.
 WS23	Me sinn mühre un honn Dorst.
 WS24	We me gester Obed zurük=ke kamen, da lagen de Angern schon im Bette un waren fest am Schlofen.
 WS25	Der Schne͡ i es dirre Nahcht be͡ i uns leggen ble͡ iwwen, äber di͡ erren Morgen es he zergi͡ enn.
-WS26	Hinger unsen Hüse sti͜enn drei hübsche Äbbelböhmerchen mit roren Äbbelerchen.
-WS27	Kunnt de ni͜ett nach i͜enn Öjenblick uf uns gewarten, denn gi͜enn me mi͜et uch.
+WS26	Hinger unsen Hüse sti͡enn drei hübsche Äbbelböhmerchen mit roren Äbbelerchen.
+WS27	Kunnt de ni͡ett nach i͡enn Öjenblick uf uns gewarten, denn gi͡enn me mi͡et uch.
 WS28	De derft nit so Kengere ͡ien drieben.
 WS29	Unse Bährge sinn net so hoch, üwwe si͡enn vehle höchcher.
 WS30	Wie vehle Pönd Worscht un wie vehle Brod wollt <(fast u)> de denn honn? 
-WS31	Ech <(e breit)> versteh uch ni͡ ett, de mutt i͜͡enn Bischen lührer schwatzen.
+WS31	Ech <(e breit)> versteh uch ni͡ ett, de mutt i͡enn Bischen lührer schwatzen.
 WS32	Hott de ki͡enn Steckchen wisse Sehfe verr mech uf mim'm Tische föngen?
 WS33	Sein Brudder <(fast rr)> wi͡ell sech zweh <(zwo, zween)> hebsche ne͡ijje Hüsser in üw̄en Gahrten böwwen.
 WS34	Das Wort kam emme von Herzen

--- a/24503_Sachsenberg.csv
+++ b/24503_Sachsenberg.csv
@@ -12,7 +12,7 @@ WS01	In Winter fliegen de trögen Bläder dörch de Luft rüm̄.
 WS02	Et hört glich uffe ze schniggen, denn wörd det Weder wedder besser.
 WS03	Thu Kohlen in den Oben, det de Melch bale an ze kochen fänget.
 WS04	Der gude ale Mann es met den Päre dörcht Eis gebrochen un in det kahle Wasser gefalln.
-WS05	"He e͘s vör vier ebbe {Zeichen, das wie eine kleine 4 aussieht; könnte von einem ""r"" sein} sechs Wochen gestorben."
+WS05	"He ės vör vier ebbe {Zeichen, das wie eine kleine 4 aussieht; könnte von einem ""r"" sein} sechs Wochen gestorben."
 WS06	det Füer war ze heiß, de Kuchen sin jä ungen ganz schwarz gebran̄t.
 WS07	He isset de Eiger ümmer ohne Saalz un Peffer.
 WS08	De Füße thun̄ me so weh, ich gläube, ich hon se dörchgelaufen.
@@ -32,7 +32,7 @@ WS21	Wen hot he de nigge Geschichte verzahlt?
 WS22	Me muß laude schreien, süßt versteht he üns nit.
 WS23	Mi sin müde un hon Dorscht.
 WS24	Als mi gister Obend zurücke kamen, do lagen die Angern Preit zu Bette un waren feste a[n] schlafen.
-WS25	der Schnie es düsse Nacht bi üns leggen geblebben, ebber hödde Morgen e͘s he geschm[u]lzen.
+WS25	der Schnie es düsse Nacht bi üns leggen geblebben, ebber hödde Morgen ės he geschm[u]lzen.
 WS26	Hinger ünsen Hause ston drie schöne Appelbäumchen met roden Äppelchen.
 WS27	Künn ih nit noch en Ogenbli[c]kchen uf üns warten, denn gon me met uch.
 WS28	Ih dörfet nit solche Kennereien treiben.

--- a/24503_Sachsenberg.csv
+++ b/24503_Sachsenberg.csv
@@ -8,19 +8,19 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	In Winter fliegen de trögen Bläder dörch de Luft rüm̅.
+WS01	In Winter fliegen de trögen Bläder dörch de Luft rüm̄.
 WS02	Et hört glich uffe ze schniggen, denn wörd det Weder wedder besser.
 WS03	Thu Kohlen in den Oben, det de Melch bale an ze kochen fänget.
 WS04	Der gude ale Mann es met den Päre dörcht Eis gebrochen un in det kahle Wasser gefalln.
 WS05	"He e͘s vör vier ebbe {Zeichen, das wie eine kleine 4 aussieht; könnte von einem ""r"" sein} sechs Wochen gestorben."
-WS06	det Füer war ze heiß, de Kuchen sin jä ungen ganz schwarz gebran̅t.
+WS06	det Füer war ze heiß, de Kuchen sin jä ungen ganz schwarz gebran̄t.
 WS07	He isset de Eiger ümmer ohne Saalz un Peffer.
-WS08	De Füße thun̅ me so weh, ich gläube, ich hon se dörchgelaufen.
+WS08	De Füße thun̄ me so weh, ich gläube, ich hon se dörchgelaufen.
 WS09	Ich sie bi der Frau gewest, un hon et ehr gesäet, un se säede, se wüll et och ehrer Tochter säen.
 WS10	Ich well et och nit meh wedder dun.
 WS11	Ich schla dich glich met den Kocheleffel üm de Ohrn, du Affe!
 WS12	Bo gehst du hen, sulln mi med[?]die gon?
-WS13	Et sin̅ schlechte Zeiden!
+WS13	Et sin̄ schlechte Zeiden!
 WS14	Mein liebet Keind, bleiv hie ungen ston, de bösen Gänze beissen dich todt.
 WS15	Du host hödde an meisten gelahrt un bist artig gewest, du därfest eher no heim gon wie de angern.
 WS16	Du bist noch nit groß genug, üm eine Flasche Wein auszutrinken, du mußt erscht noch en Enge wassen un grösser wer'n.

--- a/24659_Buhlen.csv
+++ b/24659_Buhlen.csv
@@ -35,12 +35,12 @@ WS24	Wie me’ gästrowet z’recke kamen, do lagen d.’ Angeren greit z’ Bet
 WS25	D’r Schnei <(e-i)> es dedde Nacht bi inz leggen g’blewwen, äwwer dedde Morgen esse g’schmolzen.
 WS26	Hinger inz’n House schden drei schene Appelbeimerch’n met roden Äppelchen.
 WS27	Kunntd’ net noch ’n Augenblickchen of inz warten, dann gehme’ met uch.
-WS28	Deh därfet net so Kennerei’n treiwen <(e – i)>
+WS28	Deh därfet net so Kennerei’n treiwen <(e - i)>
 WS29	Inze Bärge sin net ganz hoch, ugge sin vell hechcher.
 WS30	Wie vell Pond Worschd on wie vell Brod wolldn’ hon?
 WS31	Ech v’rschdeh uch net, deh müddet ’n beßchen härter schwatzen.
 WS32	Hodd’ kann Steckchen wisse Seife fer mech of min Desche g’fongen?
-WS33	Sin Bruder well sech zwei schene nogge Heiser <(e – i)> in uggen Gaarden boggen.
+WS33	Sin Bruder well sech zwei schene nogge Heiser <(e - i)> in uggen Gaarden boggen.
 WS34	D’s Wort kam’n von Härzen
 WS35	Das war recht von än!
 WS36	Was setzen do fer Veilercher owen of d’n Mi=erchen?

--- a/24677_Metze.csv
+++ b/24677_Metze.csv
@@ -34,10 +34,10 @@ WS23	Mäh sinn mierä onn hom Dorschd.
 WS24	Als mäh gästr-Owet zärrekkä kohmen, do logen dä Angerän schonn zä Bättä onn woren feste ohm schlofen.
 WS25	Der Schnei äs derrä Nogd bi ens lechen gäbläwwen, äwwer herrä Morgen ässä geschmolzen.
 WS26	Hinger ensem Husä stenn 3 scheenä Appelbeimerchen medd rorän Äppellerchen.
-WS27	Konnt dä nett noch ä̱n Äugenbleckchen off ens wohrden, dann genn mä mett och.
+WS27	Konnt dä nett noch ä̠n Äugenbleckchen off ens wohrden, dann genn mä mett och.
 WS28	Dä därfet nett solchä Keinäreien triewen.
 WS29	Ense Bährgä sinn nett sehr hoch, oggä sinn vählä hechcher.
-WS30	Wievälä̲ Pund Worscht onn wievälä̲ Brod wollt däh honn?
+WS30	Wievälä̠ Pund Worscht onn wievälä̠ Brod wollt däh honn?
 WS31	Ech versteh och nett, däh mutt än beschen lurer schprächen.
 WS32	Hot däh känn Steckchen wissä Seifä fär mech off minn Deschschä gäfongen?
 WS33	Sinn Brurer wäll sech 2 scheenä̠ noggä̠ Hieser enn ochchem Gohrdän boggen.
@@ -47,4 +47,4 @@ WS36	Wos setzen do fär Veilerchen owän off däm Mierchen?
 WS37	Die Buren hatten fenf Ossen onn ninn Kiwwä onn zwälf Scheeferchen vär dos Dorf gä̠bräucht, die wullen sä̠ verkaufen.
 WS38	Die Lierä sinn herrä allä drussen off dämm Feilä onn meen.
 WS39	Geh nur, där brunnä Hund ditt Dä neks.
-WS40	Ech bänn mett dän Lieren do hingen ewwär dä̱ Wessä̱ ens Korn gä̱fohren. 
+WS40	Ech bänn mett dän Lieren do hingen ewwär dä̠ Wessä̠ ens Korn gä̠fohren. 

--- a/24695_Wattenbach.csv
+++ b/24695_Wattenbach.csv
@@ -21,7 +21,7 @@ WS10	Ech wälls au nett mehr werrer dunn!
 WS11	Ech schlo dech glich mett dem̄ Kochläffel emme de Ohrn, Du Affe!
 WS12	Wo gehst de henne, sonn mä merre <(mett)> Dä genn?
 WS13	Eß senn schlächte Zieten!
-WS14	Min̄ liwes Känd, blibb he ongen stenn, de besen Gǟ̄nse bissen dech dod. 
+WS14	Min̄ liwes Känd, blibb he ongen stenn, de besen Gǟnse bissen dech dod. 
 WS15	Du host hitte om̄ mährschten gelärnt onn bäst ōrdig gewähn, do därfst frejjer noch Heime genn als de Annern.
 WS16	Du bäst noch nett groß g’nung, emme ä Flasche Winn ußz’dräinken, Du moßt erscht noch änn Engge wassen unn grösser wärn.
 WS17	Geh, si sa gutt unn sä Dinner Schwester, sä sollde de Kleider fär ugge Motter färdeg nehn unn mett d’r Bärste reene machen.

--- a/25898_Edelsberg.csv
+++ b/25898_Edelsberg.csv
@@ -9,12 +9,12 @@ Transliterent: ''
 Anmerkungen: ''
 ...
 WS01	D(e) Wender fleïje die trockene Blärrer en dr Luft erim̄.
-WS02	Es hert gleich of sě schneïje, da(n) wird d’s Werrer wirrer besser.
-WS03	Dou Kohlě en d(e) Owe, deß die Melch bāld oh(n)fingt s(e) koche.
+WS02	Es hert gleich of sĕ schneïje, da(n) wird d’s Werrer wirrer besser.
+WS03	Dou Kohlĕ en d(e) Owe, deß die Melch bāld oh(n)fingt s(e) koche.
 WS04	Dr gout alt Mann eß met dm Gaul durchs Eis gebroche un ens kalt Wasser gefalle.
 WS05	E(h) eß fihr veïjer ower sechs Wuche gestorbe.
 WS06	Ds Fauer woar s(e) haaß, die Kouche sei(n) jo unne ganz schworz gebrannt.
-WS07	E(h) ißt die Aijer immer ohně Salz und Peffer.
+WS07	E(h) ißt die Aijer immer ohnĕ Salz und Peffer.
 WS08	Die Fuiß don m(e)r ork wieh, eich glawe, eich hu(n) s(e) durchgelafe.
 WS09	Ich sei(n) bei dr Fra gewest enn huh(n)ser gesaht, en s(e) saht, s(e) wellt’s āg ihrer Dochter sah(n).
 WS10	Ich wills ag nitt mih wirrer dou.

--- a/26532_Düren.csv
+++ b/26532_Düren.csv
@@ -9,30 +9,30 @@ Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
 WS01	Emm Wengte fleege d’drüch Bläde dorch d’Lūēt erömm.
-WS02	Ett hǖēt glich opp ze schnege, dann wīēt ett Wädde wedde bä̅ēsse.
+WS02	Ett hǖēt glich opp ze schnege, dann wīēt ett Wädde wedde bǟēsse.
 WS03	Dohn Kolle ehn de’ Offent, datt d’Mellech bahl ahn z’kauche fänk.
-WS04	Dä gode ahle Mann ehst mett dämm Pä̅a̅t dorch ett Ihs gebrauche ohn ehn et kahlt Wa̅ēsse gefalle.
-WS05	Hä̅a̅ es fǖē vīē ode sechs Wooche gestorve.
-WS06	Et Fǖē wōa̅ z’heehs, d’Kooche sent jo onge ganz schwatz gebrannt.
-WS07	Hä̅a̅ ihs d’Ägge emme ohne Saalz ohn Pä̅ēffe.
+WS04	Dä gode ahle Mann ehst mett dämm Pǟāt dorch ett Ihs gebrauche ohn ehn et kahlt Wāēsse gefalle.
+WS05	Hǟā es fǖē vīē ode sechs Wooche gestorve.
+WS06	Et Fǖē wōā z’heehs, d’Kooche sent jo onge ganz schwatz gebrannt.
+WS07	Hǟā ihs d’Ägge emme ohne Saalz ohn Pǟēffe.
 WS08	D’Föhs dohn me sīē wie, ich glöhve, ich hann se dorchgelohfe.
-WS09	Ich benn bēī d’Frau gewä̅ēs ohn hann et i jesaht, ohn se saht, se wöll ett och ijere Dūa̅te sage.
+WS09	Ich benn bēī d’Frau gewǟēs ohn hann et i jesaht, ohn se saht, se wöll ett och ijere Dūāte sage.
 WS10	Ich well ett och nett mi wedde dohn.
-WS11	Ich schlohn dich jetz mett d’m Kauchlä̅ēffel ömm d’Ūērre, du Ahp!
-WS12	Wo gehs d’hīa̅, solle me mett d’gohn?
-WS13	Ett sent schlä̅a̅te Zeke.
+WS11	Ich schlohn dich jetz mett d’m Kauchlǟēffel ömm d’Ūērre, du Ahp!
+WS12	Wo gehs d’hīā, solle me mett d’gohn?
+WS13	Ett sent schlǟāte Zeke.
 WS14	Mi leev Kenk, bliev he onge stohn, die kott Gäns biehse dich duht.
-WS15	Du hähs höck am mīēz gelīēht ohn behs ahdig gewä̅ēs, du darfs fröhge noh Huhs gohn alz die Angere.
-WS16	Du behs noch nett grūēhs genoog, ömm en Flasch Weng uhszedrenke, du mohs īēsch nauch en Änk wahse ohn gröhse wīa̅de.
-WS17	Gank, behs e su goht ohn sahg denge Schwä̅ēste, se soll d’Klehde fǖē üje Motte fä̅a̅dig nije ohn mett d’Bǖēschtel rehn mahche.
-WS18	Hätts d’enne gekannt! Dann wȫa̅ ett andesch komme ohn ett däht bä̅ēsse ömm ’n stohn.
-WS19	Wä̅a̅ hätt me menge Korref met Fleesch gestolle?
-WS20	Hä̅a̅ däht su, alz hätte se enne zomm Drä̅īsche b’stahlt, se hant ett övve sällefs gedohn.
-WS21	Wämm hätt hä̅a̅ di nȫhj̅ Geschichte verzahlt?
-WS22	Me mohs hatt schreje, sons versteht hä̅a̅ onz nett.
+WS15	Du hähs höck am mīēz gelīēht ohn behs ahdig gewǟēs, du darfs fröhge noh Huhs gohn alz die Angere.
+WS16	Du behs noch nett grūēhs genoog, ömm en Flasch Weng uhszedrenke, du mohs īēsch nauch en Änk wahse ohn gröhse wīāde.
+WS17	Gank, behs e su goht ohn sahg denge Schwǟēste, se soll d’Klehde fǖē üje Motte fǟādig nije ohn mett d’Bǖēschtel rehn mahche.
+WS18	Hätts d’enne gekannt! Dann wȫā ett andesch komme ohn ett däht bǟēsse ömm ’n stohn.
+WS19	Wǟā hätt me menge Korref met Fleesch gestolle?
+WS20	Hǟā däht su, alz hätte se enne zomm Drǟīsche b’stahlt, se hant ett övve sällefs gedohn.
+WS21	Wämm hätt hǟā di nȫhj̅ Geschichte verzahlt?
+WS22	Me mohs hatt schreje, sons versteht hǟā onz nett.
 WS23	Me sent möht ohn hann Honge.
-WS24	Alz me gä̅ēste Ohfend zeröck kohme, do lohge di Andere allt emm Bett ohn wōa̅re fahs am schlohfe.
-WS25	D’Schnēj̅ es des Naht bēj̅ onz lije bleeve, ävve höck morge ehs hä̅a̅ geschmolze.
+WS24	Alz me gǟēste Ohfend zeröck kohme, do lohge di Andere allt emm Bett ohn wōāre fahs am schlohfe.
+WS25	D’Schnēj̅ es des Naht bēj̅ onz lije bleeve, ävve höck morge ehs hǟā geschmolze.
 WS26	Henge onserm Huhs stohn drēī schön Appelböhmchere mett ruht Äppelchere.
 WS27	Könnt ījē nett nauch ehn Ogebleckelche opp ons wahde, dann gohn me mett üch.
 WS28	 Ījē dörft nett solche Kengerēī drihfe.
@@ -42,9 +42,9 @@ WS31	Ich verstohn üch nett, ījē mött e Behsge hatte sprähche.
 WS32	Hatt ījē kehn Stöckelche wisse Sehf füe mich opp mengem Dēīsch fonge?
 WS33	Si Brohde well sich zwei stahze nȫj̅ Hühse en ǖērem Gahde bōūe.
 WS34	Datt Wōēt kohm emm vomm Hätze!
-WS35	Datt wōa rä̅a̅t von enne.
+WS35	Datt wōa rǟāt von enne.
 WS36	Watt setze doh fǖē Vügelchere ovve opp dämm Mǖēche?
-WS37	Di Būēre hotte fönnef Ȫa̅s ohn nöng Köh ohn zwälf Schöhfjere fǖē datt Dörrep braht, die wohlte se vekohfe.
+WS37	Di Būēre hotte fönnef Ȫās ohn nöng Köh ohn zwälf Schöhfjere fǖē datt Dörrep braht, die wohlte se vekohfe.
 WS38	D’Löck sent höck all do fǖēre opp damm Fähld ohn mīj̅e.
 WS39	Gank äckesch, d’bronge Honk deht d’necks.
-WS40	Ich benn mett d’Löck do henge övve d’Bände ehn ett Kōa̅ gefahre.
+WS40	Ich benn mett d’Löck do henge övve d’Bände ehn ett Kōā gefahre.

--- a/26532_Düren.csv
+++ b/26532_Düren.csv
@@ -9,42 +9,42 @@ Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
 WS01	Emm Wengte fleege d’drüch Bläde dorch d’Lūe̅t erömm.
-WS02	Ett hü̅e̅t glich opp ze schnege, dann wi̅e̅t ett Wädde wedde bä̅e̅sse.
+WS02	Ett hü̅e̅t glich opp ze schnege, dann wīe̅t ett Wädde wedde bä̅e̅sse.
 WS03	Dohn Kolle ehn de’ Offent, datt d’Mellech bahl ahn z’kauche fänk.
 WS04	Dä gode ahle Mann ehst mett dämm Pä̅a̅t dorch ett Ihs gebrauche ohn ehn et kahlt Wa̅e̅sse gefalle.
-WS05	Hä̅a̅ es fü̅e̅ vi̅e̅ ode sechs Wooche gestorve.
+WS05	Hä̅a̅ es fü̅e̅ vīe̅ ode sechs Wooche gestorve.
 WS06	Et Fü̅e̅ wōa̅ z’heehs, d’Kooche sent jo onge ganz schwatz gebrannt.
 WS07	Hä̅a̅ ihs d’Ägge emme ohne Saalz ohn Pä̅e̅ffe.
-WS08	D’Föhs dohn me si̅e̅ wie, ich glöhve, ich hann se dorchgelohfe.
-WS09	Ich benn be̅i̅ d’Frau gewä̅e̅s ohn hann et i jesaht, ohn se saht, se wöll ett och ijere Dūa̅te sage.
+WS08	D’Föhs dohn me sīe̅ wie, ich glöhve, ich hann se dorchgelohfe.
+WS09	Ich benn be̅ī d’Frau gewä̅e̅s ohn hann et i jesaht, ohn se saht, se wöll ett och ijere Dūa̅te sage.
 WS10	Ich well ett och nett mi wedde dohn.
 WS11	Ich schlohn dich jetz mett d’m Kauchlä̅e̅ffel ömm d’Ūe̅rre, du Ahp!
-WS12	Wo gehs d’hi̅a̅, solle me mett d’gohn?
+WS12	Wo gehs d’hīa̅, solle me mett d’gohn?
 WS13	Ett sent schlä̅a̅te Zeke.
 WS14	Mi leev Kenk, bliev he onge stohn, die kott Gäns biehse dich duht.
-WS15	Du hähs höck am mi̅e̅z geli̅e̅ht ohn behs ahdig gewä̅e̅s, du darfs fröhge noh Huhs gohn alz die Angere.
-WS16	Du behs noch nett grūe̅hs genoog, ömm en Flasch Weng uhszedrenke, du mohs i̅e̅sch nauch en Änk wahse ohn gröhse wi̅a̅de.
+WS15	Du hähs höck am mīe̅z gelīe̅ht ohn behs ahdig gewä̅e̅s, du darfs fröhge noh Huhs gohn alz die Angere.
+WS16	Du behs noch nett grūe̅hs genoog, ömm en Flasch Weng uhszedrenke, du mohs īe̅sch nauch en Änk wahse ohn gröhse wīa̅de.
 WS17	Gank, behs e su goht ohn sahg denge Schwä̅e̅ste, se soll d’Klehde fü̅e̅ üje Motte fä̅a̅dig nije ohn mett d’Bü̅e̅schtel rehn mahche.
 WS18	Hätts d’enne gekannt! Dann wȫa̅ ett andesch komme ohn ett däht bä̅e̅sse ömm ’n stohn.
 WS19	Wä̅a̅ hätt me menge Korref met Fleesch gestolle?
-WS20	Hä̅a̅ däht su, alz hätte se enne zomm Drä̅i̅sche b’stahlt, se hant ett övve sällefs gedohn.
+WS20	Hä̅a̅ däht su, alz hätte se enne zomm Drä̅īsche b’stahlt, se hant ett övve sällefs gedohn.
 WS21	Wämm hätt hä̅a̅ di nȫhj̅ Geschichte verzahlt?
 WS22	Me mohs hatt schreje, sons versteht hä̅a̅ onz nett.
 WS23	Me sent möht ohn hann Honge.
 WS24	Alz me gä̅e̅ste Ohfend zeröck kohme, do lohge di Andere allt emm Bett ohn wōa̅re fahs am schlohfe.
 WS25	D’Schne̅j̅ es des Naht be̅j̅ onz lije bleeve, ävve höck morge ehs hä̅a̅ geschmolze.
-WS26	Henge onserm Huhs stohn dre̅i̅ schön Appelböhmchere mett ruht Äppelchere.
-WS27	Könnt i̅je̅ nett nauch ehn Ogebleckelche opp ons wahde, dann gohn me mett üch.
-WS28	 I̅je̅ dörft nett solche Kengere̅i̅ drihfe.
-WS29	Onz Berg sent nett si̅je̅ hu, dè ü̅hj̅e sent vell hȫhj̅e.
-WS30	Wivell Ponk Wūe̅sch ohn wivell Brut wellt i̅je̅ hann?
-WS31	Ich verstohn üch nett, i̅je̅ mött e Behsge hatte sprähche.
-WS32	Hatt i̅je̅ kehn Stöckelche wisse Sehf füe mich opp mengem De̅i̅sch fonge?
+WS26	Henge onserm Huhs stohn dre̅ī schön Appelböhmchere mett ruht Äppelchere.
+WS27	Könnt īje̅ nett nauch ehn Ogebleckelche opp ons wahde, dann gohn me mett üch.
+WS28	 Īje̅ dörft nett solche Kengere̅ī drihfe.
+WS29	Onz Berg sent nett sīje̅ hu, dè ü̅hj̅e sent vell hȫhj̅e.
+WS30	Wivell Ponk Wūe̅sch ohn wivell Brut wellt īje̅ hann?
+WS31	Ich verstohn üch nett, īje̅ mött e Behsge hatte sprähche.
+WS32	Hatt īje̅ kehn Stöckelche wisse Sehf füe mich opp mengem De̅īsch fonge?
 WS33	Si Brohde well sich zwei stahze nȫj̅ Hühse en ü̅e̅rem Gahde bōūe.
 WS34	Datt Wōe̅t kohm emm vomm Hätze!
 WS35	Datt wōa rä̅a̅t von enne.
 WS36	Watt setze doh fü̅e̅ Vügelchere ovve opp dämm Mü̅e̅che?
 WS37	Di Būe̅re hotte fönnef Ȫa̅s ohn nöng Köh ohn zwälf Schöhfjere fü̅e̅ datt Dörrep braht, die wohlte se vekohfe.
-WS38	D’Löck sent höck all do fü̅e̅re opp damm Fähld ohn mi̅j̅e.
+WS38	D’Löck sent höck all do fü̅e̅re opp damm Fähld ohn mīj̅e.
 WS39	Gank äckesch, d’bronge Honk deht d’necks.
 WS40	Ich benn mett d’Löck do henge övve d’Bände ehn ett Kōa̅ gefahre.

--- a/26532_Düren.csv
+++ b/26532_Düren.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: REDE
 Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
-WS01	Emm Wengte fleege d’drüch Bläde dorch d’Lūe̅t erömm.
-WS02	Ett hü̅e̅t glich opp ze schnege, dann wīe̅t ett Wädde wedde bä̅e̅sse.
+WS01	Emm Wengte fleege d’drüch Bläde dorch d’Lūēt erömm.
+WS02	Ett hǖēt glich opp ze schnege, dann wīēt ett Wädde wedde bä̅ēsse.
 WS03	Dohn Kolle ehn de’ Offent, datt d’Mellech bahl ahn z’kauche fänk.
-WS04	Dä gode ahle Mann ehst mett dämm Pä̅a̅t dorch ett Ihs gebrauche ohn ehn et kahlt Wa̅e̅sse gefalle.
-WS05	Hä̅a̅ es fü̅e̅ vīe̅ ode sechs Wooche gestorve.
-WS06	Et Fü̅e̅ wōa̅ z’heehs, d’Kooche sent jo onge ganz schwatz gebrannt.
-WS07	Hä̅a̅ ihs d’Ägge emme ohne Saalz ohn Pä̅e̅ffe.
-WS08	D’Föhs dohn me sīe̅ wie, ich glöhve, ich hann se dorchgelohfe.
-WS09	Ich benn be̅ī d’Frau gewä̅e̅s ohn hann et i jesaht, ohn se saht, se wöll ett och ijere Dūa̅te sage.
+WS04	Dä gode ahle Mann ehst mett dämm Pä̅a̅t dorch ett Ihs gebrauche ohn ehn et kahlt Wa̅ēsse gefalle.
+WS05	Hä̅a̅ es fǖē vīē ode sechs Wooche gestorve.
+WS06	Et Fǖē wōa̅ z’heehs, d’Kooche sent jo onge ganz schwatz gebrannt.
+WS07	Hä̅a̅ ihs d’Ägge emme ohne Saalz ohn Pä̅ēffe.
+WS08	D’Föhs dohn me sīē wie, ich glöhve, ich hann se dorchgelohfe.
+WS09	Ich benn bēī d’Frau gewä̅ēs ohn hann et i jesaht, ohn se saht, se wöll ett och ijere Dūa̅te sage.
 WS10	Ich well ett och nett mi wedde dohn.
-WS11	Ich schlohn dich jetz mett d’m Kauchlä̅e̅ffel ömm d’Ūe̅rre, du Ahp!
+WS11	Ich schlohn dich jetz mett d’m Kauchlä̅ēffel ömm d’Ūērre, du Ahp!
 WS12	Wo gehs d’hīa̅, solle me mett d’gohn?
 WS13	Ett sent schlä̅a̅te Zeke.
 WS14	Mi leev Kenk, bliev he onge stohn, die kott Gäns biehse dich duht.
-WS15	Du hähs höck am mīe̅z gelīe̅ht ohn behs ahdig gewä̅e̅s, du darfs fröhge noh Huhs gohn alz die Angere.
-WS16	Du behs noch nett grūe̅hs genoog, ömm en Flasch Weng uhszedrenke, du mohs īe̅sch nauch en Änk wahse ohn gröhse wīa̅de.
-WS17	Gank, behs e su goht ohn sahg denge Schwä̅e̅ste, se soll d’Klehde fü̅e̅ üje Motte fä̅a̅dig nije ohn mett d’Bü̅e̅schtel rehn mahche.
-WS18	Hätts d’enne gekannt! Dann wȫa̅ ett andesch komme ohn ett däht bä̅e̅sse ömm ’n stohn.
+WS15	Du hähs höck am mīēz gelīēht ohn behs ahdig gewä̅ēs, du darfs fröhge noh Huhs gohn alz die Angere.
+WS16	Du behs noch nett grūēhs genoog, ömm en Flasch Weng uhszedrenke, du mohs īēsch nauch en Änk wahse ohn gröhse wīa̅de.
+WS17	Gank, behs e su goht ohn sahg denge Schwä̅ēste, se soll d’Klehde fǖē üje Motte fä̅a̅dig nije ohn mett d’Bǖēschtel rehn mahche.
+WS18	Hätts d’enne gekannt! Dann wȫa̅ ett andesch komme ohn ett däht bä̅ēsse ömm ’n stohn.
 WS19	Wä̅a̅ hätt me menge Korref met Fleesch gestolle?
 WS20	Hä̅a̅ däht su, alz hätte se enne zomm Drä̅īsche b’stahlt, se hant ett övve sällefs gedohn.
 WS21	Wämm hätt hä̅a̅ di nȫhj̅ Geschichte verzahlt?
 WS22	Me mohs hatt schreje, sons versteht hä̅a̅ onz nett.
 WS23	Me sent möht ohn hann Honge.
-WS24	Alz me gä̅e̅ste Ohfend zeröck kohme, do lohge di Andere allt emm Bett ohn wōa̅re fahs am schlohfe.
-WS25	D’Schne̅j̅ es des Naht be̅j̅ onz lije bleeve, ävve höck morge ehs hä̅a̅ geschmolze.
-WS26	Henge onserm Huhs stohn dre̅ī schön Appelböhmchere mett ruht Äppelchere.
-WS27	Könnt īje̅ nett nauch ehn Ogebleckelche opp ons wahde, dann gohn me mett üch.
-WS28	 Īje̅ dörft nett solche Kengere̅ī drihfe.
-WS29	Onz Berg sent nett sīje̅ hu, dè ü̅hj̅e sent vell hȫhj̅e.
-WS30	Wivell Ponk Wūe̅sch ohn wivell Brut wellt īje̅ hann?
-WS31	Ich verstohn üch nett, īje̅ mött e Behsge hatte sprähche.
-WS32	Hatt īje̅ kehn Stöckelche wisse Sehf füe mich opp mengem De̅īsch fonge?
-WS33	Si Brohde well sich zwei stahze nȫj̅ Hühse en ü̅e̅rem Gahde bōūe.
-WS34	Datt Wōe̅t kohm emm vomm Hätze!
+WS24	Alz me gä̅ēste Ohfend zeröck kohme, do lohge di Andere allt emm Bett ohn wōa̅re fahs am schlohfe.
+WS25	D’Schnēj̅ es des Naht bēj̅ onz lije bleeve, ävve höck morge ehs hä̅a̅ geschmolze.
+WS26	Henge onserm Huhs stohn drēī schön Appelböhmchere mett ruht Äppelchere.
+WS27	Könnt ījē nett nauch ehn Ogebleckelche opp ons wahde, dann gohn me mett üch.
+WS28	 Ījē dörft nett solche Kengerēī drihfe.
+WS29	Onz Berg sent nett sījē hu, dè ǖhj̅e sent vell hȫhj̅e.
+WS30	Wivell Ponk Wūēsch ohn wivell Brut wellt ījē hann?
+WS31	Ich verstohn üch nett, ījē mött e Behsge hatte sprähche.
+WS32	Hatt ījē kehn Stöckelche wisse Sehf füe mich opp mengem Dēīsch fonge?
+WS33	Si Brohde well sich zwei stahze nȫj̅ Hühse en ǖērem Gahde bōūe.
+WS34	Datt Wōēt kohm emm vomm Hätze!
 WS35	Datt wōa rä̅a̅t von enne.
-WS36	Watt setze doh fü̅e̅ Vügelchere ovve opp dämm Mü̅e̅che?
-WS37	Di Būe̅re hotte fönnef Ȫa̅s ohn nöng Köh ohn zwälf Schöhfjere fü̅e̅ datt Dörrep braht, die wohlte se vekohfe.
-WS38	D’Löck sent höck all do fü̅e̅re opp damm Fähld ohn mīj̅e.
+WS36	Watt setze doh fǖē Vügelchere ovve opp dämm Mǖēche?
+WS37	Di Būēre hotte fönnef Ȫa̅s ohn nöng Köh ohn zwälf Schöhfjere fǖē datt Dörrep braht, die wohlte se vekohfe.
+WS38	D’Löck sent höck all do fǖēre opp damm Fähld ohn mīj̅e.
 WS39	Gank äckesch, d’bronge Honk deht d’necks.
 WS40	Ich benn mett d’Löck do henge övve d’Bände ehn ett Kōa̅ gefahre.

--- a/26532_Düren.csv
+++ b/26532_Düren.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: REDE
 Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
-WS01	Emm Wengte fleege d’drüch Bläde dorch d’Lu̅e̅t erömm.
+WS01	Emm Wengte fleege d’drüch Bläde dorch d’Lūe̅t erömm.
 WS02	Ett hü̅e̅t glich opp ze schnege, dann wi̅e̅t ett Wädde wedde bä̅e̅sse.
 WS03	Dohn Kolle ehn de’ Offent, datt d’Mellech bahl ahn z’kauche fänk.
 WS04	Dä gode ahle Mann ehst mett dämm Pä̅a̅t dorch ett Ihs gebrauche ohn ehn et kahlt Wa̅e̅sse gefalle.
@@ -16,14 +16,14 @@ WS05	Hä̅a̅ es fü̅e̅ vi̅e̅ ode sechs Wooche gestorve.
 WS06	Et Fü̅e̅ wo̅a̅ z’heehs, d’Kooche sent jo onge ganz schwatz gebrannt.
 WS07	Hä̅a̅ ihs d’Ägge emme ohne Saalz ohn Pä̅e̅ffe.
 WS08	D’Föhs dohn me si̅e̅ wie, ich glöhve, ich hann se dorchgelohfe.
-WS09	Ich benn be̅i̅ d’Frau gewä̅e̅s ohn hann et i jesaht, ohn se saht, se wöll ett och ijere Du̅a̅te sage.
+WS09	Ich benn be̅i̅ d’Frau gewä̅e̅s ohn hann et i jesaht, ohn se saht, se wöll ett och ijere Dūa̅te sage.
 WS10	Ich well ett och nett mi wedde dohn.
-WS11	Ich schlohn dich jetz mett d’m Kauchlä̅e̅ffel ömm d’U̅e̅rre, du Ahp!
+WS11	Ich schlohn dich jetz mett d’m Kauchlä̅e̅ffel ömm d’Ūe̅rre, du Ahp!
 WS12	Wo gehs d’hi̅a̅, solle me mett d’gohn?
 WS13	Ett sent schlä̅a̅te Zeke.
 WS14	Mi leev Kenk, bliev he onge stohn, die kott Gäns biehse dich duht.
 WS15	Du hähs höck am mi̅e̅z geli̅e̅ht ohn behs ahdig gewä̅e̅s, du darfs fröhge noh Huhs gohn alz die Angere.
-WS16	Du behs noch nett gru̅e̅hs genoog, ömm en Flasch Weng uhszedrenke, du mohs i̅e̅sch nauch en Änk wahse ohn gröhse wi̅a̅de.
+WS16	Du behs noch nett grūe̅hs genoog, ömm en Flasch Weng uhszedrenke, du mohs i̅e̅sch nauch en Änk wahse ohn gröhse wi̅a̅de.
 WS17	Gank, behs e su goht ohn sahg denge Schwä̅e̅ste, se soll d’Klehde fü̅e̅ üje Motte fä̅a̅dig nije ohn mett d’Bü̅e̅schtel rehn mahche.
 WS18	Hätts d’enne gekannt! Dann wö̅a̅ ett andesch komme ohn ett däht bä̅e̅sse ömm ’n stohn.
 WS19	Wä̅a̅ hätt me menge Korref met Fleesch gestolle?
@@ -37,14 +37,14 @@ WS26	Henge onserm Huhs stohn dre̅i̅ schön Appelböhmchere mett ruht Äppelche
 WS27	Könnt i̅je̅ nett nauch ehn Ogebleckelche opp ons wahde, dann gohn me mett üch.
 WS28	 I̅je̅ dörft nett solche Kengere̅i̅ drihfe.
 WS29	Onz Berg sent nett si̅je̅ hu, dè ü̅hj̅e sent vell hö̅hj̅e.
-WS30	Wivell Ponk Wu̅e̅sch ohn wivell Brut wellt i̅je̅ hann?
+WS30	Wivell Ponk Wūe̅sch ohn wivell Brut wellt i̅je̅ hann?
 WS31	Ich verstohn üch nett, i̅je̅ mött e Behsge hatte sprähche.
 WS32	Hatt i̅je̅ kehn Stöckelche wisse Sehf füe mich opp mengem De̅i̅sch fonge?
-WS33	Si Brohde well sich zwei stahze nö̅j̅ Hühse en ü̅e̅rem Gahde bo̅u̅e.
+WS33	Si Brohde well sich zwei stahze nö̅j̅ Hühse en ü̅e̅rem Gahde bo̅ūe.
 WS34	Datt Wo̅e̅t kohm emm vomm Hätze!
 WS35	Datt wo̅a rä̅a̅t von enne.
 WS36	Watt setze doh fü̅e̅ Vügelchere ovve opp dämm Mü̅e̅che?
-WS37	Di Bu̅e̅re hotte fönnef Ö̅a̅s ohn nöng Köh ohn zwälf Schöhfjere fü̅e̅ datt Dörrep braht, die wohlte se vekohfe.
+WS37	Di Būe̅re hotte fönnef Ö̅a̅s ohn nöng Köh ohn zwälf Schöhfjere fü̅e̅ datt Dörrep braht, die wohlte se vekohfe.
 WS38	D’Löck sent höck all do fü̅e̅re opp damm Fähld ohn mi̅j̅e.
 WS39	Gank äckesch, d’bronge Honk deht d’necks.
 WS40	Ich benn mett d’Löck do henge övve d’Bände ehn ett Ko̅a̅ gefahre.

--- a/26532_Düren.csv
+++ b/26532_Düren.csv
@@ -13,7 +13,7 @@ WS02	Ett hü̅e̅t glich opp ze schnege, dann wi̅e̅t ett Wädde wedde bä̅e̅
 WS03	Dohn Kolle ehn de’ Offent, datt d’Mellech bahl ahn z’kauche fänk.
 WS04	Dä gode ahle Mann ehst mett dämm Pä̅a̅t dorch ett Ihs gebrauche ohn ehn et kahlt Wa̅e̅sse gefalle.
 WS05	Hä̅a̅ es fü̅e̅ vi̅e̅ ode sechs Wooche gestorve.
-WS06	Et Fü̅e̅ wo̅a̅ z’heehs, d’Kooche sent jo onge ganz schwatz gebrannt.
+WS06	Et Fü̅e̅ wōa̅ z’heehs, d’Kooche sent jo onge ganz schwatz gebrannt.
 WS07	Hä̅a̅ ihs d’Ägge emme ohne Saalz ohn Pä̅e̅ffe.
 WS08	D’Föhs dohn me si̅e̅ wie, ich glöhve, ich hann se dorchgelohfe.
 WS09	Ich benn be̅i̅ d’Frau gewä̅e̅s ohn hann et i jesaht, ohn se saht, se wöll ett och ijere Dūa̅te sage.
@@ -25,26 +25,26 @@ WS14	Mi leev Kenk, bliev he onge stohn, die kott Gäns biehse dich duht.
 WS15	Du hähs höck am mi̅e̅z geli̅e̅ht ohn behs ahdig gewä̅e̅s, du darfs fröhge noh Huhs gohn alz die Angere.
 WS16	Du behs noch nett grūe̅hs genoog, ömm en Flasch Weng uhszedrenke, du mohs i̅e̅sch nauch en Änk wahse ohn gröhse wi̅a̅de.
 WS17	Gank, behs e su goht ohn sahg denge Schwä̅e̅ste, se soll d’Klehde fü̅e̅ üje Motte fä̅a̅dig nije ohn mett d’Bü̅e̅schtel rehn mahche.
-WS18	Hätts d’enne gekannt! Dann wö̅a̅ ett andesch komme ohn ett däht bä̅e̅sse ömm ’n stohn.
+WS18	Hätts d’enne gekannt! Dann wȫa̅ ett andesch komme ohn ett däht bä̅e̅sse ömm ’n stohn.
 WS19	Wä̅a̅ hätt me menge Korref met Fleesch gestolle?
 WS20	Hä̅a̅ däht su, alz hätte se enne zomm Drä̅i̅sche b’stahlt, se hant ett övve sällefs gedohn.
-WS21	Wämm hätt hä̅a̅ di nö̅hj̅ Geschichte verzahlt?
+WS21	Wämm hätt hä̅a̅ di nȫhj̅ Geschichte verzahlt?
 WS22	Me mohs hatt schreje, sons versteht hä̅a̅ onz nett.
 WS23	Me sent möht ohn hann Honge.
-WS24	Alz me gä̅e̅ste Ohfend zeröck kohme, do lohge di Andere allt emm Bett ohn wo̅a̅re fahs am schlohfe.
+WS24	Alz me gä̅e̅ste Ohfend zeröck kohme, do lohge di Andere allt emm Bett ohn wōa̅re fahs am schlohfe.
 WS25	D’Schne̅j̅ es des Naht be̅j̅ onz lije bleeve, ävve höck morge ehs hä̅a̅ geschmolze.
 WS26	Henge onserm Huhs stohn dre̅i̅ schön Appelböhmchere mett ruht Äppelchere.
 WS27	Könnt i̅je̅ nett nauch ehn Ogebleckelche opp ons wahde, dann gohn me mett üch.
 WS28	 I̅je̅ dörft nett solche Kengere̅i̅ drihfe.
-WS29	Onz Berg sent nett si̅je̅ hu, dè ü̅hj̅e sent vell hö̅hj̅e.
+WS29	Onz Berg sent nett si̅je̅ hu, dè ü̅hj̅e sent vell hȫhj̅e.
 WS30	Wivell Ponk Wūe̅sch ohn wivell Brut wellt i̅je̅ hann?
 WS31	Ich verstohn üch nett, i̅je̅ mött e Behsge hatte sprähche.
 WS32	Hatt i̅je̅ kehn Stöckelche wisse Sehf füe mich opp mengem De̅i̅sch fonge?
-WS33	Si Brohde well sich zwei stahze nö̅j̅ Hühse en ü̅e̅rem Gahde bo̅ūe.
-WS34	Datt Wo̅e̅t kohm emm vomm Hätze!
-WS35	Datt wo̅a rä̅a̅t von enne.
+WS33	Si Brohde well sich zwei stahze nȫj̅ Hühse en ü̅e̅rem Gahde bōūe.
+WS34	Datt Wōe̅t kohm emm vomm Hätze!
+WS35	Datt wōa rä̅a̅t von enne.
 WS36	Watt setze doh fü̅e̅ Vügelchere ovve opp dämm Mü̅e̅che?
-WS37	Di Būe̅re hotte fönnef Ö̅a̅s ohn nöng Köh ohn zwälf Schöhfjere fü̅e̅ datt Dörrep braht, die wohlte se vekohfe.
+WS37	Di Būe̅re hotte fönnef Ȫa̅s ohn nöng Köh ohn zwälf Schöhfjere fü̅e̅ datt Dörrep braht, die wohlte se vekohfe.
 WS38	D’Löck sent höck all do fü̅e̅re opp damm Fähld ohn mi̅j̅e.
 WS39	Gank äckesch, d’bronge Honk deht d’necks.
-WS40	Ich benn mett d’Löck do henge övve d’Bände ehn ett Ko̅a̅ gefahre.
+WS40	Ich benn mett d’Löck do henge övve d’Bände ehn ett Kōa̅ gefahre.

--- a/27135_Wenighösbach.csv
+++ b/27135_Wenighösbach.csv
@@ -43,7 +43,7 @@ WS32	Hout da ka Schtickelche weiße Safe fer mich u̬f mam̬ Tisch fu̬n̄e?
 WS33	Sa Brura well sich zwa schäine neie Heiser en eiern Gorte baue.
 WS34	Das Wort kimmt ihm von Herze!
 WS35	Däs̮ woa rächt vo ihne!
-WS36	Wos setzn do fär Vi̬g̮elche dowe uf̮ dem Mäuerchen.
+WS36	Wos setzn do fär Vi̬g̬elche dowe uf̮ dem Mäuerchen.
 WS37	Die Bauern houn finf Ochse un neu Ki̠h un zweleff Scheferchen vers Dorf gerbrocht, die wollte se vekafe.
 WS38	Die Leit sa̬nn heit all dauß u̬fem Feld un mehe.
 WS39	Geh nur, de brau Hund thut da nichs <(nicks gesprochen)>

--- a/27135_Wenighösbach.csv
+++ b/27135_Wenighösbach.csv
@@ -13,7 +13,7 @@ WS02	S’ hiert gleich uff se schneîè, not werd’s Wera wira bessa.
 WS03	Thou Kouhle en Oufe, daß die Milich baal ou zu koche fängt.
 WS04	Der gure alte Mann iß mimm Färd dorchs Eis gebroche un ens kalt Wassar gefalle.
 WS05	Er iß ver via äber sechs Wuche geschtorbe.
-WS06	S’ Feier wor se schtark, die Kuche sann jo u̮ne ganz schwaz gebrennt.
+WS06	S’ Feier wor se schtark, die Kuche sann jo u̬ne ganz schwaz gebrennt.
 WS07	Er ißt die Ag̬a immer ohne Salz un Peffa.
 WS08	Die Fiß thoun ma si̬hr we̬hi, ich glab, ich ho̬u se̬ dorchgelafe.
 WS09	Ich bei <(In dem Worte bin das e und i nicht wie ei, sondern jeden einzeln lesen.)> ba de Fra gewäst un hous a gesät, un se hot gesät, sie wells ach ihrer Tochta soge
@@ -29,12 +29,12 @@ WS18	Hest du ihn gekennt! dann wärs annerscht kumme, un es thet bessa um ihn sc
 WS19	Wäa hot ma man Korb mot Flasch geschtohule?
 WS20	Er tu̬t sou, als hen̬ se̬n zum Dresche beschtellt; sie houns äba selbst gethou.
 WS21	Wemm hora die nei Geschichte erzähilt.
-WS22	Ma mu̮ß laut kreische, sunst veschtähit er uns net.
+WS22	Ma mu̬ß laut kreische, sunst veschtähit er uns net.
 WS23	Wir sann müd <(ü mehr wie i gesprochen)> un houn Dorscht.
 WS24	Wie ma gestern Obed serück kamen, da lagen die Annern schon em Bett un worn fest oum schlofe.
 WS25	De Schnäi iß die Nocht ba uns leige bliebe, äba heit de Morge issa geschmolza.
 WS26	Hin̬a unserm Haus sttähin drei schäine Epelbemarchen mit roure Epelchen.
-WS27	Kunnta nit noch e Ageblickche u̮f uns wate, dann gä̱in ma mit eich.
+WS27	Kunnta nit noch e Ageblickche u̬f uns wate, dann gä̱in ma mit eich.
 WS28	Iha därft nit soune Kinnarei treibe.
 WS29	Unsare Barge sann ni̬t sehr houch, die eiern sann viel häher.
 WS30	Wie vill Pund Worscht un wie vill Brout wollt iha hou?

--- a/27135_Wenighösbach.csv
+++ b/27135_Wenighösbach.csv
@@ -34,7 +34,7 @@ WS23	Wir sann müd <(ü mehr wie i gesprochen)> un houn Dorscht.
 WS24	Wie ma gestern Obed serück kamen, da lagen die Annern schon em Bett un worn fest oum schlofe.
 WS25	De Schnäi iß die Nocht ba uns leige bliebe, äba heit de Morge issa geschmolza.
 WS26	Hin̬a unserm Haus sttähin drei schäine Epelbemarchen mit roure Epelchen.
-WS27	Kunnta nit noch e Ageblickche u̬f uns wate, dann gä̱in ma mit eich.
+WS27	Kunnta nit noch e Ageblickche u̬f uns wate, dann gä̠in ma mit eich.
 WS28	Iha därft nit soune Kinnarei treibe.
 WS29	Unsare Barge sann ni̬t sehr houch, die eiern sann viel häher.
 WS30	Wie vill Pund Worscht un wie vill Brout wollt iha hou?

--- a/27135_Wenighösbach.csv
+++ b/27135_Wenighösbach.csv
@@ -43,7 +43,7 @@ WS32	Hout da ka Schtickelche weiße Safe fer mich u̬f mam̬ Tisch fu̬n̄e?
 WS33	Sa Brura well sich zwa schäine neie Heiser en eiern Gorte baue.
 WS34	Das Wort kimmt ihm von Herze!
 WS35	Däs̮ woa rächt vo ihne!
-WS36	Wos setzn do fär Vi̮g̮elche dowe uf̮ dem Mäuerchen.
+WS36	Wos setzn do fär Vi̬g̮elche dowe uf̮ dem Mäuerchen.
 WS37	Die Bauern houn finf Ochse un neu Ki̠h un zweleff Scheferchen vers Dorf gerbrocht, die wollte se vekafe.
 WS38	Die Leit sa̬nn heit all dauß u̬fem Feld un mehe.
 WS39	Geh nur, de brau Hund thut da nichs <(nicks gesprochen)>

--- a/27150_Wiesthal.csv
+++ b/27150_Wiesthal.csv
@@ -14,7 +14,7 @@ WS03	Thu Kohle nein Ofn, daß die Melch bal köcht.
 WS04	Der gute ahle Mo is’ mit dem Gaul durchs Eis gebrache u. neis kahl Wasser gefalle.
 WS05	Er ist ver vier oder sechs Woche gestorben.
 WS06	Das Feuer war- se stark die Kuche sein jo onne ganz schwarz gebrahnt.
-WS07	Er ōßt die Är im̅er ohne Sals u. Pfeffer.
+WS07	Er ōßt die Är im̄er ohne Sals u. Pfeffer.
 WS08	Die Füß thon mir so weh, ich gläb, ich hon sie durchgelafe
 WS09	Ich be bei der Fra gewese u. ho es ihr gesaht, u. sie saht, sie wollte es auch ihrer Tochter soge.
 WS10	Ich will es a net mehr wieder thue.

--- a/27244_Heddernheim.csv
+++ b/27244_Heddernheim.csv
@@ -13,7 +13,7 @@ WS02	Es heert gleich uff ze schneie, dann werdd deß Wedder widder besser.
 WS03	Dhu Kohle in de Owe, daß die Millich bald an ze koche fängt.
 WS04	Der gute alte Mann is mit’em Gaul <(Perd)> dorchs Eis kgebroche un in deß kalte Wasser gefalle.
 WS05	Er is’ vor vier odder sechs Woche g’storwe.
-WS06	Deß Feujer war ze haaß, die Kuchche sin̅ ja unne ganz schworz verbrennt.
+WS06	Deß Feujer war ze haaß, die Kuchche sin̄ ja unne ganz schworz verbrennt.
 WS07	Er ißt die Aijer immer ohne Salz un Peffer.
 WS08	Die Fis dhun mer sehr weh, ich glaab, ich hawwe se dorch geloffe.
 WS09	Jch bin bei d’r Fra kgewese un hab’ es ihr g’sacht, un sie sachte, sie wollte es ag ihrer Tochter sage.

--- a/27425_Bruchköbel.csv
+++ b/27425_Bruchköbel.csv
@@ -15,7 +15,7 @@ WS04	Der go͜ud ahld Mann ess merrem Gaul dorchs Eis gebroche onn ens kahld Wass
 WS05	Ĕ ess vir ve-ir orrer sechs Wuche gestorwe.
 WS06	D’s Feuer woar zo͜u hahs, di Ko͜uche sei͜-n onne ganz schwoarz gebrennt.
 WS07	Ě esst di Aier immer ohne Sahlz onn Peffer.
-WS08	Di Fo͜-is tho͜n merr sihr wih, ich glahwe ich hu͜h’n sě dorchgelahfe.
+WS08	Di Fo͜-is tho͜n merr sihr wih, ich glahwe ich hu͡h’n sě dorchgelahfe.
 WS09	Eich sei͜n bei drr Frah gewest onn huhn srr gesaht, onn se͜-i hott gesaht, se wällts aach ihrer Dochter sa͜-n.
 WS10	Ich wills aach nedd mih wirrer tho͜n!
 WS11	Ich schloe derr gleich merrem Kochleffel imm di Uhrn, do Aff!
@@ -44,7 +44,7 @@ WS33	Sa Brourer will sich zwaa schihne naue Hoiser en auern Goarte baue.
 WS34	Dohs Woart kohm em vo͜n Herze.
 WS35	Dohs woar rähcht vo ihne.
 WS36	Wo’s setze do vir Vigelchern ohwe uff dem Mäuerche?
-WS37	Di Bauern harre finf Ochse onn neu͜n Ko-ih onn zwelef Schäferchern fir das Dorf gebroacht, dĕ wollte se verkaafe.
+WS37	Di Bauern harre finf Ochse onn neu͡n Ko-ih onn zwelef Schäferchern fir das Dorf gebroacht, dĕ wollte se verkaafe.
 WS38	Di Leud sei͜n haut all draus uff em Feld omm mehe.
-WS39	Gih’ nur der brau͜-n Hond tho͜ut dir nicks.
+WS39	Gih’ nur der brau͡-n Hond tho͜ut dir nicks.
 WS40	Ich sei͜n medd de Leudd do henne iwwer di Wissé ens Korn gefoarn.

--- a/27425_Bruchköbel.csv
+++ b/27425_Bruchköbel.csv
@@ -14,30 +14,30 @@ WS03	Do͡u Kohle enn de Ohwe, daß di Melich bahl o͡n se koche fengt.
 WS04	Der go͡ud ahld Mann ess merrem Gaul dorchs Eis gebroche onn ens kahld Wasser gefalle.
 WS05	Ĕ ess vir ve-ir orrer sechs Wuche gestorwe.
 WS06	D’s Feuer woar zo͡u hahs, di Ko͡uche sei͡-n onne ganz schwoarz gebrennt.
-WS07	Ě esst di Aier immer ohne Sahlz onn Peffer.
-WS08	Di Fo͡-is tho͡n merr sihr wih, ich glahwe ich hu͡h’n sě dorchgelahfe.
-WS09	Eich sei͡n bei drr Frah gewest onn huhn srr gesaht, onn se͜-i hott gesaht, se wällts aach ihrer Dochter sa͜-n.
+WS07	Ĕ esst di Aier immer ohne Sahlz onn Peffer.
+WS08	Di Fo͡-is tho͡n merr sihr wih, ich glahwe ich hu͡h’n sĕ dorchgelahfe.
+WS09	Eich sei͡n bei drr Frah gewest onn huhn srr gesaht, onn se͡-i hott gesaht, se wällts aach ihrer Dochter sa͜-n.
 WS10	Ich wills aach nedd mih wirrer tho͡n!
 WS11	Ich schloe derr gleich merrem Kochleffel imm di Uhrn, do Aff!
-WS12	Wuh gihst de hi, solle merr medd derr gih͜n?
+WS12	Wuh gihst de hi, solle merr medd derr gih͡n?
 WS13	s sa-͜n schlähchte Zeire.
-WS14	Mă le-͜ib Kennd blei he͜-i onne stih͜n, di bihse Gens beiße dich tuhd.
-WS15	Dŏ host heut omm mihste gelernt, onn best oartig gewehst, de därfst fro͡-iher hahm gih͜n, we͜-i di Annern.
-WS16	Dŏ best noch nedd gruß genung, imm e Flasch Weih͜’n aussedrinke, de mußt erst noche bissi woahse onn grisser währn.
+WS14	Mă le-͜ib Kennd blei he͡-i onne stih͡n, di bihse Gens beiße dich tuhd.
+WS15	Dŏ host heut omm mihste gelernt, onn best oartig gewehst, de därfst fro͡-iher hahm gih͡n, we͡-i di Annern.
+WS16	Dŏ best noch nedd gruß genung, imm e Flasch Weih͡’n aussedrinke, de mußt erst noche bissi woahse onn grisser währn.
 WS17	Gih’ să su go͡ut onn sā danner Schwäster, se sell di Klahrer fir auer Modder färdig nehe onn medd dr Bärste ra͜hn mache.
 WS18	Hest do͡u n gekennt, dann wihrsch annerscht komme onn ’s thet besser imm n sti͡hn.
 WS19	Währ hott mr mann Korb madd Flahsch kestohle?
-WS20	Heh tho͡ut suh, als härre sen zom Dresche bestellt, se huhns obber (w.w.) selber gedoh͜n.
+WS20	Heh tho͡ut suh, als härre sen zom Dresche bestellt, se huhns obber (w.w.) selber gedoh͡n.
 WS21	Wem horre de nau Geschichte verzehlt?
-WS22	Merr muß laut kreische, sonst verstihre uhs nedd. (ne͜-it
-WS23	Mer să moid onn huh͜n Dorscht.
-WS24	We͜-i merr gestro=bet sereck kohme, dŏ loage di Annern schunn emm Bett onn woahrn fest omm Schloffe.
+WS22	Merr muß laut kreische, sonst verstihre uhs nedd. (ne͡-it
+WS23	Mer să moid onn huh͡n Dorscht.
+WS24	We͡-i merr gestro=bet sereck kohme, dŏ loage di Annern schunn emm Bett onn woahrn fest omm Schloffe.
 WS25	Der Schnih ess heint Noacht bei ess leihe bliwwe, owwer di Morge ess e geschmolze.
 WS26	Hinner usem Haus stih’n drei schihne Äppelbämerchen medd ruhre Äppelchern.
 WS27	Kennt’r nedd noch e Aageblekche uff ’s wohrte, dann gih mrr merr och.
 WS28	Ihr derfft nett su Kennereie dreiwe.
 WS29	Uhs Bärje sei͡n nedd sihr huch, auer sei͡n vill hiher.
-WS30	Wevill Pond Worscht onn we vill Bruhd wollt’r huh͜-n?
+WS30	Wevill Pond Worscht onn we vill Bruhd wollt’r huh͡-n?
 WS31	Ich verstih och nett, ihr misst ä Bissi laurer schwätze.
 WS32	Hott’r ka͜an Stöckelche weiß Sahfe vir mich uff mamm Desch gefonne?
 WS33	Sa Brourer will sich zwaa schihne naue Hoiser en auern Goarte baue.

--- a/27425_Bruchköbel.csv
+++ b/27425_Bruchköbel.csv
@@ -10,24 +10,24 @@ Anmerkungen: ''
 ...
 WS01	Emm Wender fle͡-ihe di trockne Blerrer dorch di Loft errimm.
 WS02	s hihrt gleich uff se schneie, dann werrds Werrer wirrer besser.
-WS03	Do͜u Kohle enn de Ohwe, daß di Melich bahl o͜n se koche fengt.
-WS04	Der go͜ud ahld Mann ess merrem Gaul dorchs Eis gebroche onn ens kahld Wasser gefalle.
+WS03	Do͡u Kohle enn de Ohwe, daß di Melich bahl o͡n se koche fengt.
+WS04	Der go͡ud ahld Mann ess merrem Gaul dorchs Eis gebroche onn ens kahld Wasser gefalle.
 WS05	Ĕ ess vir ve-ir orrer sechs Wuche gestorwe.
-WS06	D’s Feuer woar zo͜u hahs, di Ko͜uche sei͜-n onne ganz schwoarz gebrennt.
+WS06	D’s Feuer woar zo͡u hahs, di Ko͡uche sei͜-n onne ganz schwoarz gebrennt.
 WS07	Ě esst di Aier immer ohne Sahlz onn Peffer.
-WS08	Di Fo͜-is tho͜n merr sihr wih, ich glahwe ich hu͡h’n sě dorchgelahfe.
+WS08	Di Fo͡-is tho͡n merr sihr wih, ich glahwe ich hu͡h’n sě dorchgelahfe.
 WS09	Eich sei͜n bei drr Frah gewest onn huhn srr gesaht, onn se͜-i hott gesaht, se wällts aach ihrer Dochter sa͜-n.
-WS10	Ich wills aach nedd mih wirrer tho͜n!
+WS10	Ich wills aach nedd mih wirrer tho͡n!
 WS11	Ich schloe derr gleich merrem Kochleffel imm di Uhrn, do Aff!
 WS12	Wuh gihst de hi, solle merr medd derr gih͜n?
 WS13	s sa-͜n schlähchte Zeire.
 WS14	Mă le-͜ib Kennd blei he͜-i onne stih͜n, di bihse Gens beiße dich tuhd.
-WS15	Dŏ host heut omm mihste gelernt, onn best oartig gewehst, de därfst fro͜-iher hahm gih͜n, we͜-i di Annern.
+WS15	Dŏ host heut omm mihste gelernt, onn best oartig gewehst, de därfst fro͡-iher hahm gih͜n, we͜-i di Annern.
 WS16	Dŏ best noch nedd gruß genung, imm e Flasch Weih͜’n aussedrinke, de mußt erst noche bissi woahse onn grisser währn.
-WS17	Gih’ să su go͜ut onn sā danner Schwäster, se sell di Klahrer fir auer Modder färdig nehe onn medd dr Bärste ra͜hn mache.
-WS18	Hest do͜u n gekennt, dann wihrsch annerscht komme onn ’s thet besser imm n sti͜hn.
+WS17	Gih’ să su go͡ut onn sā danner Schwäster, se sell di Klahrer fir auer Modder färdig nehe onn medd dr Bärste ra͜hn mache.
+WS18	Hest do͡u n gekennt, dann wihrsch annerscht komme onn ’s thet besser imm n sti͜hn.
 WS19	Währ hott mr mann Korb madd Flahsch kestohle?
-WS20	Heh tho͜ut suh, als härre sen zom Dresche bestellt, se huhns obber (w.w.) selber gedoh͜n.
+WS20	Heh tho͡ut suh, als härre sen zom Dresche bestellt, se huhns obber (w.w.) selber gedoh͜n.
 WS21	Wem horre de nau Geschichte verzehlt?
 WS22	Merr muß laut kreische, sonst verstihre uhs nedd. (ne͜-it
 WS23	Mer să moid onn huh͜n Dorscht.
@@ -41,10 +41,10 @@ WS30	Wevill Pond Worscht onn we vill Bruhd wollt’r huh͜-n?
 WS31	Ich verstih och nett, ihr misst ä Bissi laurer schwätze.
 WS32	Hott’r ka͜an Stöckelche weiß Sahfe vir mich uff mamm Desch gefonne?
 WS33	Sa Brourer will sich zwaa schihne naue Hoiser en auern Goarte baue.
-WS34	Dohs Woart kohm em vo͜n Herze.
+WS34	Dohs Woart kohm em vo͡n Herze.
 WS35	Dohs woar rähcht vo ihne.
 WS36	Wo’s setze do vir Vigelchern ohwe uff dem Mäuerche?
 WS37	Di Bauern harre finf Ochse onn neu͡n Ko-ih onn zwelef Schäferchern fir das Dorf gebroacht, dĕ wollte se verkaafe.
 WS38	Di Leud sei͜n haut all draus uff em Feld omm mehe.
-WS39	Gih’ nur der brau͡-n Hond tho͜ut dir nicks.
+WS39	Gih’ nur der brau͡-n Hond tho͡ut dir nicks.
 WS40	Ich sei͜n medd de Leudd do henne iwwer di Wissé ens Korn gefoarn.

--- a/27425_Bruchköbel.csv
+++ b/27425_Bruchköbel.csv
@@ -16,7 +16,7 @@ WS05	Ĕ ess vir ve-ir orrer sechs Wuche gestorwe.
 WS06	D’s Feuer woar zo͡u hahs, di Ko͡uche sei͡-n onne ganz schwoarz gebrennt.
 WS07	Ĕ esst di Aier immer ohne Sahlz onn Peffer.
 WS08	Di Fo͡-is tho͡n merr sihr wih, ich glahwe ich hu͡h’n sĕ dorchgelahfe.
-WS09	Eich sei͡n bei drr Frah gewest onn huhn srr gesaht, onn se͡-i hott gesaht, se wällts aach ihrer Dochter sa͜-n.
+WS09	Eich sei͡n bei drr Frah gewest onn huhn srr gesaht, onn se͡-i hott gesaht, se wällts aach ihrer Dochter sa͡-n.
 WS10	Ich wills aach nedd mih wirrer tho͡n!
 WS11	Ich schloe derr gleich merrem Kochleffel imm di Uhrn, do Aff!
 WS12	Wuh gihst de hi, solle merr medd derr gih͡n?
@@ -24,7 +24,7 @@ WS13	s sa-͜n schlähchte Zeire.
 WS14	Mă le-͜ib Kennd blei he͡-i onne stih͡n, di bihse Gens beiße dich tuhd.
 WS15	Dŏ host heut omm mihste gelernt, onn best oartig gewehst, de därfst fro͡-iher hahm gih͡n, we͡-i di Annern.
 WS16	Dŏ best noch nedd gruß genung, imm e Flasch Weih͡’n aussedrinke, de mußt erst noche bissi woahse onn grisser währn.
-WS17	Gih’ să su go͡ut onn sā danner Schwäster, se sell di Klahrer fir auer Modder färdig nehe onn medd dr Bärste ra͜hn mache.
+WS17	Gih’ să su go͡ut onn sā danner Schwäster, se sell di Klahrer fir auer Modder färdig nehe onn medd dr Bärste ra͡hn mache.
 WS18	Hest do͡u n gekennt, dann wihrsch annerscht komme onn ’s thet besser imm n sti͡hn.
 WS19	Währ hott mr mann Korb madd Flahsch kestohle?
 WS20	Heh tho͡ut suh, als härre sen zom Dresche bestellt, se huhns obber (w.w.) selber gedoh͡n.
@@ -39,7 +39,7 @@ WS28	Ihr derfft nett su Kennereie dreiwe.
 WS29	Uhs Bärje sei͡n nedd sihr huch, auer sei͡n vill hiher.
 WS30	Wevill Pond Worscht onn we vill Bruhd wollt’r huh͡-n?
 WS31	Ich verstih och nett, ihr misst ä Bissi laurer schwätze.
-WS32	Hott’r ka͜an Stöckelche weiß Sahfe vir mich uff mamm Desch gefonne?
+WS32	Hott’r ka͡an Stöckelche weiß Sahfe vir mich uff mamm Desch gefonne?
 WS33	Sa Brourer will sich zwaa schihne naue Hoiser en auern Goarte baue.
 WS34	Dohs Woart kohm em vo͡n Herze.
 WS35	Dohs woar rähcht vo ihne.

--- a/27425_Bruchköbel.csv
+++ b/27425_Bruchköbel.csv
@@ -13,10 +13,10 @@ WS02	s hihrt gleich uff se schneie, dann werrds Werrer wirrer besser.
 WS03	Do͡u Kohle enn de Ohwe, daß di Melich bahl o͡n se koche fengt.
 WS04	Der go͡ud ahld Mann ess merrem Gaul dorchs Eis gebroche onn ens kahld Wasser gefalle.
 WS05	Ĕ ess vir ve-ir orrer sechs Wuche gestorwe.
-WS06	D’s Feuer woar zo͡u hahs, di Ko͡uche sei͜-n onne ganz schwoarz gebrennt.
+WS06	D’s Feuer woar zo͡u hahs, di Ko͡uche sei͡-n onne ganz schwoarz gebrennt.
 WS07	Ě esst di Aier immer ohne Sahlz onn Peffer.
 WS08	Di Fo͡-is tho͡n merr sihr wih, ich glahwe ich hu͡h’n sě dorchgelahfe.
-WS09	Eich sei͜n bei drr Frah gewest onn huhn srr gesaht, onn se͜-i hott gesaht, se wällts aach ihrer Dochter sa͜-n.
+WS09	Eich sei͡n bei drr Frah gewest onn huhn srr gesaht, onn se͜-i hott gesaht, se wällts aach ihrer Dochter sa͜-n.
 WS10	Ich wills aach nedd mih wirrer tho͡n!
 WS11	Ich schloe derr gleich merrem Kochleffel imm di Uhrn, do Aff!
 WS12	Wuh gihst de hi, solle merr medd derr gih͜n?
@@ -25,7 +25,7 @@ WS14	Mă le-͜ib Kennd blei he͜-i onne stih͜n, di bihse Gens beiße dich tuhd.
 WS15	Dŏ host heut omm mihste gelernt, onn best oartig gewehst, de därfst fro͡-iher hahm gih͜n, we͜-i di Annern.
 WS16	Dŏ best noch nedd gruß genung, imm e Flasch Weih͜’n aussedrinke, de mußt erst noche bissi woahse onn grisser währn.
 WS17	Gih’ să su go͡ut onn sā danner Schwäster, se sell di Klahrer fir auer Modder färdig nehe onn medd dr Bärste ra͜hn mache.
-WS18	Hest do͡u n gekennt, dann wihrsch annerscht komme onn ’s thet besser imm n sti͜hn.
+WS18	Hest do͡u n gekennt, dann wihrsch annerscht komme onn ’s thet besser imm n sti͡hn.
 WS19	Währ hott mr mann Korb madd Flahsch kestohle?
 WS20	Heh tho͡ut suh, als härre sen zom Dresche bestellt, se huhns obber (w.w.) selber gedoh͜n.
 WS21	Wem horre de nau Geschichte verzehlt?
@@ -36,7 +36,7 @@ WS25	Der Schnih ess heint Noacht bei ess leihe bliwwe, owwer di Morge ess e gesc
 WS26	Hinner usem Haus stih’n drei schihne Äppelbämerchen medd ruhre Äppelchern.
 WS27	Kennt’r nedd noch e Aageblekche uff ’s wohrte, dann gih mrr merr och.
 WS28	Ihr derfft nett su Kennereie dreiwe.
-WS29	Uhs Bärje sei͜n nedd sihr huch, auer sei͜n vill hiher.
+WS29	Uhs Bärje sei͡n nedd sihr huch, auer sei͡n vill hiher.
 WS30	Wevill Pond Worscht onn we vill Bruhd wollt’r huh͜-n?
 WS31	Ich verstih och nett, ihr misst ä Bissi laurer schwätze.
 WS32	Hott’r ka͜an Stöckelche weiß Sahfe vir mich uff mamm Desch gefonne?
@@ -45,6 +45,6 @@ WS34	Dohs Woart kohm em vo͡n Herze.
 WS35	Dohs woar rähcht vo ihne.
 WS36	Wo’s setze do vir Vigelchern ohwe uff dem Mäuerche?
 WS37	Di Bauern harre finf Ochse onn neu͡n Ko-ih onn zwelef Schäferchern fir das Dorf gebroacht, dĕ wollte se verkaafe.
-WS38	Di Leud sei͜n haut all draus uff em Feld omm mehe.
+WS38	Di Leud sei͡n haut all draus uff em Feld omm mehe.
 WS39	Gih’ nur der brau͡-n Hond tho͡ut dir nicks.
-WS40	Ich sei͜n medd de Leudd do henne iwwer di Wissé ens Korn gefoarn.
+WS40	Ich sei͡n medd de Leudd do henne iwwer di Wissé ens Korn gefoarn.

--- a/27444_Hailer.csv
+++ b/27444_Hailer.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	Em Wenter fleïhe dei drockele Blärrer dorch deï Loft h’rim.
 WS02	Es hiert gleich uf z’schneire, dann werd’s Werrer wirrer besser.
-WS03	Da͜ou Kohle enn de Owe, doß dei Melch baal a͜on z’koche fängt.
+WS03	Da͡ou Kohle enn de Owe, doß dei Melch baal a͡on z’koche fängt.
 WS04	Der ga͡ure ale Mann eß mer̄em Gaul dorch’s Eis g’broche on ens ko͡ale Wasser g’falle.
 WS05	Eh es für veier orer sechs Woche g’storwe.
 WS06	Doß Fauer wor z’has, dei Ka͡ouche sei onne ganz schworz g’brännt.

--- a/27444_Hailer.csv
+++ b/27444_Hailer.csv
@@ -14,7 +14,7 @@ WS03	Da͜ou Kohle enn de Owe, doß dei Melch baal a͜on z’koche fängt.
 WS04	Der ga͡ure ale Mann eß mer̄em Gaul dorch’s Eis g’broche on ens ko͡ale Wasser g’falle.
 WS05	Eh es für veier orer sechs Woche g’storwe.
 WS06	Doß Fauer wor z’has, dei Ka͡ouche sei onne ganz schworz g’brännt.
-WS07	E’ eßt deï̇ Ajer immer ohne Saalz on Peffer.
+WS07	E’ eßt deï Ajer immer ohne Saalz on Peffer.
 WS08	Deï Feus do͡u mer sihr wieh, eich g’lawe eich hou se dorch g’lafe.
 WS09	Eich sei bei d’r Fra g’west onn ho͡u s-er g’sat onn seï saat, seï wellt’s ach ihrer Dochter sah(n)
 WS10	Eich well’s ach neït mih wirrer duh.

--- a/27461_Oberndorf.csv
+++ b/27461_Oberndorf.csv
@@ -40,7 +40,7 @@ WS29	Ons Bärg sai net so hoch, euer sein viel höcher.
 WS30	Wie viel Pond Wuescht on wie viel wolldr ho?
 WS31	Ich verschteh euich ned, ihr mußt’s e bessje lauter san.
 WS32	Hott ihr ka Stöckelche weiß Saffe für maich off meim Düsch fonne.
-WS33	Sei Bruder will sich zwa schönne näue Häuser in äeen Go͜atte baue.
+WS33	Sei Bruder will sich zwa schönne näue Häuser in äeen Go͡atte baue.
 WS34	Dos Woat komem vo Häzze.
 WS35	Dos wo͡ar rächt vo Äuch.
 WS36	Wos setze dann do owe für Vögelche off dem Mäuerche?

--- a/27469_Roßbach.csv
+++ b/27469_Roßbach.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Ḛm Winter fliegḛ die trockene Blehtr ḛn der Luft römm.
 WS02	s höărt gleich <(bal)> auf zä schneiḛ, nochĕt wüĕrt’s Wähter wīer besser.
 WS03	Thŭ Koullă ēn <(nei’en)> Ofḛ, daß die Mḛllich bal a̰ ze kochḛ fängt.
-WS04	Der alt gut Mann is mit’m Gaul durch’s Eis gěbroche <(= e fast wie a)> on̰ is ens kall Wassḛr gfallḛ.
+WS04	Der alt gut Mann is mit’m Gaul durch’s Eis gĕbroche <(= e fast wie a)> on̰ is ens kall Wassḛr gfallḛ.
 WS05	Er is für vier äwer sechs Wocha̰ g’storba̰.
 WS06	ĕs Feṵier waer <(a tief)> zĕ stārk, di Kuchḛ sein ja̰ onna gāns schwaarz gebrönnt.
 WS07	Her èst die Ä̰jer ömmer ohna Sālz onn Pfäffer.
@@ -19,7 +19,7 @@ WS08	Die Füß ton’mer weh, ich kläb’, ich hon sa durch gelaffa.
 WS09	Ich sein beid’r Fra gewēst onn hon ser a g’sōgt, onn sie hot gsōgt, sie wöllts ihrer Tochter sog.
 WS10	Ich well’s a net me wier thu.
 WS11	Ich schla̰t’r gleich mitĕm Kochlèffl öm di Uhrn, du Aff! <(A=tief)>.
-WS12	Wu gehst’n hie, sölle měr mittěr geh?
+WS12	Wu gehst’n hie, sölle mĕr mittĕr geh?
 WS13	"Es sein schlechtḛ Zeite. <(dumpfes ""e"")>."
 WS14	Mei lieb Kend, blei da onne stiën, die bö̰se Gens beihsḛ dich tot.
 WS15	Du hāest ha̰it am mèste g’larnt on bist brav <(a tief)> gwèst, du dürfst ender häm̄ geh als bi die Annern.

--- a/27692_Friedrichsthal.csv
+++ b/27692_Friedrichsthal.csv
@@ -20,7 +20,7 @@ WS09	Ich sein bei der Frah gewerst un huns ihr gesaht un sei hot gesaht se wellt
 WS10	Eich wills ach nit mär wirer thoú.
 WS11	Ich hage Dich gleich mirt dem Kouchlöffel um di Urn, dou Aff.
 WS12	Wu gihst dau hi, solle mir mirt dir gih.
-WS13	E’s sei schlā̈chte Zeite.
+WS13	E’s sei schlǟchte Zeite.
 WS14	Mei laiwes Kîrnd bleib häi urne stieh, däi büße Gens beiße Dich tudt.
 WS15	Dou hust heut am mieste gelernt u. birst braov gewerst, dou dürfst fräuher noch Haus gih als die Anen.
 WS16	Dou birst noch nit gruß genug um en Flasch Weih aus z’ trenke, dou mußt irscht noch ein End wouchse un grißer wärn.

--- a/27719_Leidhecken.csv
+++ b/27719_Leidhecken.csv
@@ -42,7 +42,7 @@ WS31	Eich verstieh(n) ouch näit, ihr mußt a(n) bissi lauter spre͡ache.
 WS32	Hoabt’r kah(n) Steckelche waiß Saafe fir maich uff meim Desch gefounne?
 WS33	Sai(n) Brourer will saich zwa schiene naue Häuser en auern Goarte baue.
 WS34	D’s Woart kom em voh(n) Herze!
-WS35	Do͡as w͡oar räicht voh(n) ihn(e)!
+WS35	Do͡as wo͡ar räicht voh(n) ihn(e)!
 WS36	Woas setze do(u) fir Vielecher o͡awe uff d’m Mäuerche?
 WS37	Di Baūern harre finf Osse e͡an neu(n) Koih ean zwelf Schefercher fir d’s Doarf gébroacht, däi wollte se verkaafe.
 WS38	Di Leut sei(n) haut all drauß uff d’m Feld ean mehwe. -

--- a/27871_Borsdorf.csv
+++ b/27871_Borsdorf.csv
@@ -25,9 +25,9 @@ WS14	Mei-i läiwes Kend, bleib häi onne stih, die bise Gais beise daich dut.
 WS15	Daou host haut om mehrste gelernt, ene best oartig gewäißt, daou derfst froüher heim gih, als die Annern.
 WS16	Daou beäst noach nitt gruß genunck im ea Flasch’ Wei-i aus s’ trinke daou mußt irscht noach ea Enn woasse ean grisser weäre.
 WS17	Gih, sei s’ goaut ean sah dei’nr Schweäster, sie söll die Klarrer für au Motter firtig newe ean mett d’r Bö’schte sauber mache.
-WS18	Häßt daou ʼn gekahnt! dann wirsch aanerscht gekomme, ean ’s deth besser im ’n stih.
+WS18	Häßt daou ’n gekahnt! dann wirsch aanerscht gekomme, ean ’s deth besser im ’n stih.
 WS19	Wer hott m’r mein Kuarb mett Flaasch gestouhe?
-WS20	ʼR därt so, als härre s’n zoaum dräsche bestellt; säi huß oawer sälbst gedoh.
+WS20	’R därt so, als härre s’n zoaum dräsche bestellt; säi huß oawer sälbst gedoh.
 WS21	Weäm horre däi nau Geschichte v’rzehlt.
 WS22	M’rr muß laut kraische, sosst v’rstiere us nitt.
 WS23	Mir seii müd ean hu Durscht.
@@ -45,6 +45,6 @@ WS34	Doas Woat kom ’m voh Herze.
 WS35	Doas woar räicht voh auch.
 WS36	Woas setze do firr Vielerchen owe off d’m Mäuerche.
 WS37	Däi Bau’n harre fünf Oasse ean neui Koüh ean zwölf Schäferchen ferrs Doarf gebrocht, däi wollte s’ v’rkaafe.
-WS38	Die Leu seii haut allʼ daus off’m Feäld ean mewe.
+WS38	Die Leu seii haut all’ daus off’m Feäld ean mewe.
 WS39	Gih nur der brau Hund doaut ’r naut.
 WS40	Aich seii mett de Leut do henne iwer die Wisse eans Koarn g’fahre.

--- a/28063_Fulda.csv
+++ b/28063_Fulda.csv
@@ -14,7 +14,7 @@ WS03	Do Kohle in Ofe, doß de Melich bal ze koche ofängt.
 WS04	Der got all Mann os mit dem Gul dorchs Is gebroche on ins ka ll Wasser gefalle
 WS05	Ä os fir vier oder sechs Woche gestorbe.
 WS06	Des Feier wor ze heiß, de Koche sen onne ganz schwoäz gebrohnt.
-WS07	Ä eßt de Eier im̅er ohne Salz on Peffer.
+WS07	Ä eßt de Eier im̄er ohne Salz on Peffer.
 WS08	De Feß don mer weh, ich glai ich hon se durchgeloffe.
 WS09	Ich sen bei der Frau geweßt, on hon’s er gesoät, on se wills au ihrer Doichter soä
 WS10	Jch wills au net widder do.

--- a/28080_Rupsroth.csv
+++ b/28080_Rupsroth.csv
@@ -12,9 +12,9 @@ WS01	Im Wé inter flejen die trockene Bleder duhrch die röm.
 WS02	Es höett glech uf ze schnäe, dann wöett dos Waeder wier baesser.
 WS03	Du Koln in Ofe, doß die Mellich boll oh ze koche feingt.
 WS04	De gut oll Moh es mit dem Guill duhrchs Is gebroche an ins kall Wasser gefalle.
-WS05	E – is vür vier eber saechs Woche gestorbe.
+WS05	E - is vür vier eber saechs Woche gestorbe.
 WS06	Dos Für war ze heisß, die Kuche senn jo eunge gahnz schwoaz gebrahnt.
-WS07	E – eßt die Eier immer ohne Sahlz oh Päffer.
+WS07	E - eßt die Eier immer ohne Sahlz oh Päffer.
 WS08	Die Füß dum ’-’r sehr weh, ich glei, ich hon se duhrch gelaufn. 
 WS09	Ich.senn be-i d’r Frau gewäse ohn hon es ühr gesoat, ahn sei soat, se woll es au ührer Toichter soa.
 WS10	Ich will’s au net meh wier du.

--- a/28122_Kölschhausen.csv
+++ b/28122_Kölschhausen.csv
@@ -21,7 +21,7 @@ WS10	Eich wills ach net werrer thou.
 WS11	Eich schlo der gleich de Koachlöffel hinner die Ohn du Aff.
 WS12	Wu gihst du hi, solle mer mit der gih.
 WS13	Es sei schlechte Zeiren
-WS14	Mei lĕiwes Kend, bleib hĕi oune stih, dĕi bise Gais beiße dich tǎd.
+WS14	Mei lĕiwes Kend, bleib hĕi oune stih, dĕi bise Gais beiße dich tăd.
 WS15	Du host hau am maste gelernt en seist oatig gewäst.
 WS16	Du seist noach net gruß genung im ah Flasch Wai se trinke, de mußt noach Im waase grisser were
 WS17	Gih sei su gout en sahs deiner Schwäster se sill dĕi Klarer fer au Motter fertig nehe en mit dr Berist ra mache
@@ -36,7 +36,7 @@ WS25	Dr Schĕi eß dĕi Noacht bei us leige gebliewe dĕi Moage es he aober gesc
 WS26	Hinner usem Haus stih drei schine Äppelbämcher mit ruhre Äppelcher.
 WS27	Kunnt er netten Agebleck woarte da gih mer mit ach.
 WS28	Ehr däft nett su Kennereie treiwe
-WS29	Us Bääg sĕi nett sǎ huk, au sĕi viel hieger.
+WS29	Us Bääg sĕi nett să huk, au sĕi viel hieger.
 WS30	Wie viel Pont Wuscht en wie viel Brut wollt ehr hu.
 WS31	Eich verstieh uch nett ehr mußt lauter spräche.
 WS32	Hot ehr ka Stückelche weiße Sefe fer meich of meim Tisch gefonne.

--- a/28122_Kölschhausen.csv
+++ b/28122_Kölschhausen.csv
@@ -8,35 +8,35 @@ Transliterationsprojekt: SyHD
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Em Wenter fleuge děi troakene Blirrer en der Loft herim.
-WS02	Es hert gleich of se schněie dann werds Werrer werrer besser.
-WS03	Thou Kehl en de Owe äß děi Milch baal ou se kaache fingt.
+WS01	Em Wenter fleuge dĕi troakene Blirrer en der Loft herim.
+WS02	Es hert gleich of se schnĕie dann werds Werrer werrer besser.
+WS03	Thou Kehl en de Owe äß dĕi Milch baal ou se kaache fingt.
 WS04	Der gaure ale Mann eß mit dem Gaul durchs Eis gebraache u. en ens kale Wasser gefall.
-WS05	Er eß für věierawer sichs Woche gestoawe.
+WS05	Er eß für vĕierawer sichs Woche gestoawe.
 WS06	Doas Fauwer waor se haas, die Kuche sei onne ganz schwaorz gebrinnt.
 WS07	Er ißt die Eiger immer ihne Saalz en Päffer.
-WS08	Děi Fois thou mer se wieh eich glawe eich hu mer se durch glafe.
+WS08	Dĕi Fois thou mer se wieh eich glawe eich hu mer se durch glafe.
 WS09	Eich sei bei der Fraa geweest en hus gesaat en sei saat, sei wollt ach ehrer Toachter saa.
 WS10	Eich wills ach net werrer thou.
 WS11	Eich schlo der gleich de Koachlöffel hinner die Ohn du Aff.
 WS12	Wu gihst du hi, solle mer mit der gih.
 WS13	Es sei schlechte Zeiren
-WS14	Mei lěiwes Kend, bleib hěi oune stih, děi bise Gais beiße dich tǎd.
+WS14	Mei lĕiwes Kend, bleib hĕi oune stih, dĕi bise Gais beiße dich tǎd.
 WS15	Du host hau am maste gelernt en seist oatig gewäst.
 WS16	Du seist noach net gruß genung im ah Flasch Wai se trinke, de mußt noach Im waase grisser were
-WS17	Gih sei su gout en sahs deiner Schwäster se sill děi Klarer fer au Motter fertig nehe en mit dr Berist ra mache
+WS17	Gih sei su gout en sahs deiner Schwäster se sill dĕi Klarer fer au Motter fertig nehe en mit dr Berist ra mache
 WS18	Häst du ihn gekinnt, dann wers anners k’komme, en es det besser im ihn stehn.
 WS19	Wer hott mer mein Koarb mit Flasch gestähl.
 WS20	Er tät s[ou] als herre se ihn zoum dresche bestellt, se hus oaber sälber gethou.
-WS21	Wenn hot er děi naue Geschicht erzehlt
+WS21	Wenn hot er dĕi naue Geschicht erzehlt
 WS22	Mann muß hart kreische, sost verstirre am us net.
 WS23	Wir sei moi en hu Duscht.
-WS24	Als mer gäst Obed serück kome, do loage děi Anere schunt en Bett en schlěife.
-WS25	Dr Schěi eß děi Noacht bei us leige gebliewe děi Moage es he aober geschmolze.
+WS24	Als mer gäst Obed serück kome, do loage dĕi Anere schunt en Bett en schlĕife.
+WS25	Dr Schĕi eß dĕi Noacht bei us leige gebliewe dĕi Moage es he aober geschmolze.
 WS26	Hinner usem Haus stih drei schine Äppelbämcher mit ruhre Äppelcher.
 WS27	Kunnt er netten Agebleck woarte da gih mer mit ach.
 WS28	Ehr däft nett su Kennereie treiwe
-WS29	Us Bääg sěi nett sǎ huk, au sěi viel hieger.
+WS29	Us Bääg sĕi nett sǎ huk, au sĕi viel hieger.
 WS30	Wie viel Pont Wuscht en wie viel Brut wollt ehr hu.
 WS31	Eich verstieh uch nett ehr mußt lauter spräche.
 WS32	Hot ehr ka Stückelche weiße Sefe fer meich of meim Tisch gefonne.

--- a/28346_Großenmoor.csv
+++ b/28346_Großenmoor.csv
@@ -31,7 +31,7 @@ WS20	Hä <(br)> do͡aht so, als hättesen <(br.)> zom Dresche bestahlt; säi hon
 WS21	Bäm <(br)> ho͡atte dee nöu Geschicht’ verzahlt?
 WS22	Mer moß lud schräi, sost verstete ons net.
 WS23	Mäi sen med on hon Do(r)scht.
-WS24	Als mäi nächts <(br.)> O͜abed sereck ko͡ame, do lo͡ake dee Anne(r)n schond im Bätt <(b.)> on wo(r)n fest im schlo͡affe.
+WS24	Als mäi nächts <(br.)> O͡abed sereck ko͡ame, do lo͡ake dee Anne(r)n schond im Bätt <(b.)> on wo(r)n fest im schlo͡affe.
 WS25	Der Schnäi eß des Nächt <(br)> bäi ons läi bläicht äwer desse Morre esse verschmelzt.
 WS26	Henger onsem Hus sten dräi schenne Äbbelsbeim <(br.)> mit rode Äbbelerche <(br.)>.
 WS27	Konnt äi net noch e Auwebleckche of ons wart, do͡a gen mäi mit äich.
@@ -44,7 +44,7 @@ WS33	Sin Broder well sich zwä <(br)> schenne nöuwe Hisser in äiem Go͡arte b�
 WS34	Do͡as Wo͡art ko͡am em vom Härze <(br.)>
 WS35	Do͡as war net rächt <(br.)> von ihne.
 WS36	Bo͡as setze do fir Vegelerche owe of dämm Mié(r)che?
-WS37	Dee Bu(r)n hatte fenf O͜ässe on ni(n) Keh on zwälf Schäferche firsch Dorf gebrächt <(br.)>, dee wollte se verkäif.
+WS37	Dee Bu(r)n hatte fenf O͡ässe on ni(n) Keh on zwälf Schäferche firsch Dorf gebrächt <(br.)>, dee wollte se verkäif.
 WS38	De Lid sen hit all drusse offem Fäld <(br.)> on mähe.
 WS39	Geh nur, der Bru(n) Hond dod der nischt.
 WS40	Ich sen mit de Lid do͡a henge iwer dee Wies’ ins Ko(r)n gefa(r)n.

--- a/28356_Großentaft.csv
+++ b/28356_Großentaft.csv
@@ -25,7 +25,7 @@ WS14	Mihn lebes Keind, blieh he onge stehn, de böse Gääns bisse Dich doot.
 WS15	Dau hoast hitt om möeste gelent on best ardig gewest, dau dörfst fröher nach Huis gen als de Anre.
 WS16	Dou best noch nätt gros genunk, öm eh Flasche Win uiszedreinke, Dau most erscht nog Eng woißé on grösser wer
 WS17	Geh, sei so got on saih dinner Schwäster, sei soll de Kleider für euer’ Modder fetdig nähe’ on mit d’r Bescht’ rein magge.
-WS18	Häst de <(od. Dau)> ihn gekahnt! Dann wärsch’s annerscht gekom{Strich über ‚m’}en, on es däht beser emm ihn stehn.
+WS18	Häst de <(od. Dau)> ihn gekahnt! Dann wärsch’s annerscht gekom̄en, on es däht beser emm ihn stehn.
 WS19	Ber hoat mer min Kuhrb mit Fleisch gestohle?
 WS20	Er dätt so, als hatte’ sei ihn zom dräsche’ bestahlt; sei hons äber selber gedohn.
 WS21	Behm hoat er de neue Geschichte verzählt?

--- a/28358_Rasdorf.csv
+++ b/28358_Rasdorf.csv
@@ -8,8 +8,8 @@ Transliterationsprojekt: SyHD
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Im Weÿnter fli͜änn de trockenä Blēter dūrch de Luft äremm.
-WS02	Es heiert glich ūf zä schneyn, do wi͜äd des Wēter widder besser.
+WS01	Im Weÿnter fli͡änn de trockenä Blēter dūrch de Luft äremm.
+WS02	Es heiert glich ūf zä schneyn, do wi͡äd des Wēter widder besser.
 WS03	Tho Kollä in’n Ofä, doß de Mällich ball o zä koche fangt.
 WS04	Der gōt all Mann eß mit dem Gu͡ill dūrchs Īs gäbrochä on in des kall Wasser gefallä.
 WS05	Ä eß virr vier ober sechs Wochä gästorbä

--- a/28358_Rasdorf.csv
+++ b/28358_Rasdorf.csv
@@ -46,5 +46,5 @@ WS35	Das wuar rēcht von än’n!
 WS36	Bos setzä do für Vöällerchä owä off dem Mīärchä.
 WS37	De Būär honn fenf U͡ässä onn nī Keh onn zwälf Schäfferchä <(Lämmerchä)> für des Dūrf gebru͡acht, de wonn sä verkäuf.
 WS38	De Liēt senn hitt all drussä im Fell onn mäh’n.
-WS39	Geh nu͡är, der brui Hoe͜und thot dä nischt.
+WS39	Geh nu͡är, der brui Hoe͡und thot dä nischt.
 WS40	Ich senn mit den Liēt do hengä über de Wies’ ins Ku͡änn gefoann.

--- a/28358_Rasdorf.csv
+++ b/28358_Rasdorf.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Im Weÿnter fli͜änn de trockenä Blēter dūrch de Luft äremm.
 WS02	Es heiert glich ūf zä schneyn, do wi͜äd des Wēter widder besser.
 WS03	Tho Kollä in’n Ofä, doß de Mällich ball o zä koche fangt.
-WS04	Der gōt all Mann eß mit dem Gu͜ill dūrchs Īs gäbrochä on in des kall Wasser gefallä.
+WS04	Der gōt all Mann eß mit dem Gu͡ill dūrchs Īs gäbrochä on in des kall Wasser gefallä.
 WS05	Ä eß virr vier ober sechs Wochä gästorbä
 WS06	Des Fīärr wo͜ar zä heiß, de Kochä senn jo ongä gānz schwo͜ǟz gebrānt.
 WS07	Ä eßt die Eier immer ohne Sālz o Peffer.
@@ -26,25 +26,25 @@ WS15	Du host hitt om mennstä gälännt o wist (brov) uättäglich gewäst, Du d
 WS16	Du wist noch nätt groß gänunk, emm ä Flo͡asch Wieh uiszätreÿnke, Du moßt escht noch ä Eng wuaß o grösser wär.
 WS17	Geh, seÿ so gōt onn suä Dinner Schwēster, se säll de Kleider für euer Motter fiättig näh onn mit der Büäscht rei mach.
 WS18	Häst d’än gäkānt! noch wiäsch annäscht gekommä, onn äs thät besser emm änn stenn.
-WS19	Bär hot märr minn Ku͜ärb mit Fleisch gestohlä?
+WS19	Bär hot märr minn Ku͡ärb mit Fleisch gestohlä?
 WS20	Ä thätt so, als hättä sänn zom dro͜aschä bästālt; se honn’s aber selber getho.
 WS21	Bemm hottä de neu Geschicht verzahlt?
 WS22	Mä moß luit schreÿ, sonst värstett ä ons nätt.
 WS23	Mä senn mēd on honn Duäscht.
 WS24	Als mä nächtä zäreck kombä, do lokä de Anner schō im Bett onn wo͜ann fest om schloffä.
-WS25	Der Schnǟ eß des Nu͜acht beÿ ons lennä bleÿcht aber dessä Murrn eß ä geschmolzä.
+WS25	Der Schnǟ eß des Nu͡acht beÿ ons lennä bleÿcht aber dessä Murrn eß ä geschmolzä.
 WS26	Hengär onsem Hius stenn dreÿ schönnä Appelbeimerchä mit rothä Äppellerchä. 
 WS27	Konnt dä nätt noch än Augäblickchä off ons gäwuatt, dann genn mä mit euch.
 WS28	Eÿ düäft nätt so Kengereÿä trie.
 WS29	Onsär Berjä senn nätt sehr hoch, euer senn vill höcher.
-WS30	Bevill Pond Wu͜äscht onn bevill Brod wollt dä ho͜ä?
+WS30	Bevill Pond Wu͡äscht onn bevill Brod wollt dä ho͜ä?
 WS31	Ich verstenn euch nätt, eÿ meßt ä bösse lüttescht sprech (schwatz).
-WS32	Hottä kei Steckche wiß Seÿfe fü͜är mīch off mimm Tesch fongä?
-WS33	Sinn Brōder will sich zwä schönnä Hisser in euem Gu͜attä bau
+WS32	Hottä kei Steckche wiß Seÿfe fü͡är mīch off mimm Tesch fongä?
+WS33	Sinn Brōder will sich zwä schönnä Hisser in euem Gu͡attä bau
 WS34	Des Wuät komb äm vo Hezzä!
 WS35	Das wuar rēcht von än’n!
 WS36	Bos setzä do für Vöällerchä owä off dem Mīärchä.
-WS37	De Būär honn fenf U͜ässä onn nī Keh onn zwälf Schäfferchä <(Lämmerchä)> für des Dūrf gebru͜acht, de wonn sä verkäuf.
+WS37	De Būär honn fenf U͡ässä onn nī Keh onn zwälf Schäfferchä <(Lämmerchä)> für des Dūrf gebru͡acht, de wonn sä verkäuf.
 WS38	De Liēt senn hitt all drussä im Fell onn mäh’n.
-WS39	Geh nu͜är, der brui Hoe͜und thot dä nischt.
-WS40	Ich senn mit den Liēt do hengä über de Wies’ ins Ku͜änn gefoann.
+WS39	Geh nu͡är, der brui Hoe͜und thot dä nischt.
+WS40	Ich senn mit den Liēt do hengä über de Wies’ ins Ku͡änn gefoann.

--- a/28358_Rasdorf.csv
+++ b/28358_Rasdorf.csv
@@ -13,7 +13,7 @@ WS02	Es heiert glich ūf zä schneyn, do wi͜äd des Wēter widder besser.
 WS03	Tho Kollä in’n Ofä, doß de Mällich ball o zä koche fangt.
 WS04	Der gōt all Mann eß mit dem Gu͡ill dūrchs Īs gäbrochä on in des kall Wasser gefallä.
 WS05	Ä eß virr vier ober sechs Wochä gästorbä
-WS06	Des Fīärr wo͜ar zä heiß, de Kochä senn jo ongä gānz schwo͜ǟz gebrānt.
+WS06	Des Fīärr wo͡ar zä heiß, de Kochä senn jo ongä gānz schwo͡ǟz gebrānt.
 WS07	Ä eßt die Eier immer ohne Sālz o Peffer.
 WS08	De Feß thon mä sehr weh, ich glei ich honn sä dūrchgelaufä.
 WS09	Ich senn bei der Frau gewest o honns arr gesoat on se sōk, se wällts ihrer Tuächter soa.
@@ -27,17 +27,17 @@ WS16	Du wist noch nätt groß gänunk, emm ä Flo͡asch Wieh uiszätreÿnke, Du 
 WS17	Geh, seÿ so gōt onn suä Dinner Schwēster, se säll de Kleider für euer Motter fiättig näh onn mit der Büäscht rei mach.
 WS18	Häst d’än gäkānt! noch wiäsch annäscht gekommä, onn äs thät besser emm änn stenn.
 WS19	Bär hot märr minn Ku͡ärb mit Fleisch gestohlä?
-WS20	Ä thätt so, als hättä sänn zom dro͜aschä bästālt; se honn’s aber selber getho.
+WS20	Ä thätt so, als hättä sänn zom dro͡aschä bästālt; se honn’s aber selber getho.
 WS21	Bemm hottä de neu Geschicht verzahlt?
 WS22	Mä moß luit schreÿ, sonst värstett ä ons nätt.
 WS23	Mä senn mēd on honn Duäscht.
-WS24	Als mä nächtä zäreck kombä, do lokä de Anner schō im Bett onn wo͜ann fest om schloffä.
+WS24	Als mä nächtä zäreck kombä, do lokä de Anner schō im Bett onn wo͡ann fest om schloffä.
 WS25	Der Schnǟ eß des Nu͡acht beÿ ons lennä bleÿcht aber dessä Murrn eß ä geschmolzä.
 WS26	Hengär onsem Hius stenn dreÿ schönnä Appelbeimerchä mit rothä Äppellerchä. 
 WS27	Konnt dä nätt noch än Augäblickchä off ons gäwuatt, dann genn mä mit euch.
 WS28	Eÿ düäft nätt so Kengereÿä trie.
 WS29	Onsär Berjä senn nätt sehr hoch, euer senn vill höcher.
-WS30	Bevill Pond Wu͡äscht onn bevill Brod wollt dä ho͜ä?
+WS30	Bevill Pond Wu͡äscht onn bevill Brod wollt dä ho͡ä?
 WS31	Ich verstenn euch nätt, eÿ meßt ä bösse lüttescht sprech (schwatz).
 WS32	Hottä kei Steckche wiß Seÿfe fü͡är mīch off mimm Tesch fongä?
 WS33	Sinn Brōder will sich zwä schönnä Hisser in euem Gu͡attä bau

--- a/28392_Herzhausen.csv
+++ b/28392_Herzhausen.csv
@@ -12,7 +12,7 @@ WS01	Em Wiënter fliehe d’ trockene Blärer en d’r Loft rim.
 WS02	Es hält glag off Schneï ze mache; da wird d’s Wirrer wirre besser.
 WS03	Dou Kulln en Owe, deß d’ Melche bahle ofängt z’ koche.
 WS04	Der gore ale Mann es mirm Gaul <(Perd)> durch’s Eise gebroche, on en d’s kale Wasser gefalln.
-WS05	E’ es vier veër awer saï̇chs Woche gestorwe.
+WS05	E’ es vier veër awer saïchs Woche gestorwe.
 WS06	Dos Feuer wor zo häß, d’ Kuche sei jo onne ganz schworz gebrant.
 WS07	Er eßt d’ Aj̈̇er immer uhne Saalz onn Päffer.
 WS08	D’ Feße do m’r weï, ag gläwe, ag hu mersche durch g’läfe.

--- a/28438_Lehrbach.csv
+++ b/28438_Lehrbach.csv
@@ -18,7 +18,7 @@ WS01	Eam Weanter fläihe die troackne Blerer ean dr {der korrigiert zu dr} Loft 
 WS02	Es hirrt gläch of se schne-ie, dahn <(Nasenlaut)> wirds Wearrer {Werrer korrigiert zu Wearrer} wirrer besser.
 WS03	Dou Kon ean de Owe, deß die Mėlch bal on se koche fingt.
 WS04	dr goure ale Mann es met dem Gaul durchs Eis gebroche ean eans kale Wasser gefan.
-WS05	Er eas fuͤr ve-ier eawer sächs Woche gestoarwe.
+WS05	Er eas für ve-ier eawer sächs Woche gestoarwe.
 WS06	ds Feuer woar se häß, die Kuche sein onne schwoarz gebrahnt.
 WS07	Er eßt die Äjer immer uhne Salz ean Peaffer.
 WS08	Die Fe-iß <(ei getren̄t)> thun mr ganz wih, äch gläb, äch hu se dorchgelafe.

--- a/28438_Lehrbach.csv
+++ b/28438_Lehrbach.csv
@@ -37,7 +37,7 @@ WS20	Er deat so, als härresen zoum Dresche bestahlt; si hus oabber selbst getho
 WS21	Wem horrer die nau Geschicht verzahlt?
 WS22	M’r muß laut kreische, sost verstirrer us nit.
 WS23	M’r sei me-id ean hu Dorscht.
-WS24	Als mr geastˑr Owed serec̆k kume, do loage die Ahnere schu em Bett ean woarn fest om schlofe.
+WS24	Als mr geastˑr Owed serečk kume, do loage die Ahnere schu em Bett ean woarn fest om schlofe.
 WS25	der Schne-i eas des Noacht bei ins leihe gebleabe, ower desse Morgen es er geschmolze.
 WS26	hinner inserm haus stih drei schine Äppelbämercher met rure Äppelcher.
 WS27	Kinnt’r nit noach e Ageblickche off ins woarte, dahn <(Nslt)> gih mr met uch.

--- a/28534_Biedenkopf.csv
+++ b/28534_Biedenkopf.csv
@@ -24,7 +24,7 @@ WS13	Eß sei(n) schläägte Zeire!
 WS14	Mai liebes Kennd, bleib hie onne stieh, die beese Gennse bäiße düich dod.
 WS15	Du hast haure om mäh’ste gelännt, on best [o]ddelig geweest, du däffst früha häme gieh, als wie d’nannr.
 WS16	Du best noch net gruß genunk, imm e Flasche Wai auszetrenke, du mußt escht noch e Enne wosse.
-WS17	Gieh, sei se gutt onn saak deiner Schwester se sellt de Kläre für aue Madda fättig nehn, on met‿dä‿B[e]rschte rä’n mache.
+WS17	Gieh, sei se gutt onn saak deiner Schwester se sellt de Kläre für aue Madda fättig nehn, on met⁀dä⁀B[e]rschte rä’n mache.
 WS18	Häst’n gekaant! da wä(r)sch annascht komme, onn es d[e]ht besser imm enn stieh.
 WS19	Wä hot ma d’m[?]i Korb merrem Fläisch gestoh’n.
 WS20	A[n] duhd so als härre senn zum Dräsche bestahlt, se ho(n) s awer selbscht gedoh.
@@ -34,7 +34,7 @@ WS23	Ma säo miere onn  ho Doscht.
 WS24	Als mer gästern z[e] Owet häme kaame, do lage de Anär[n] scho im Bädd on won fäst om schloofe.
 WS25	Da Schni eß d[o]rr[n] Nocht bei ins läij[e] geblew[e], awer haure Morje eß[ē] geschmolze.
 WS26	Hinner insem Haus stieh drei schinn Äbbelbäumcha met rohre Abbelcha.
-WS27	Kinnd’a nett noch en Agebläck of inns gewodde, da gin mer mer‿uch.
+WS27	Kinnd’a nett noch en Agebläck of inns gewodde, da gin mer mer⁀uch.
 WS28	An däfft net solge Kennerei treib[e].
 WS29	Inse Bäärje sei net goar hok, aue sei veel hüjer.
 WS30	Wievel Ponnd Woscht onn wievel Brood wolld’a ha.

--- a/28605_Neukirchen.csv
+++ b/28605_Neukirchen.csv
@@ -20,7 +20,7 @@ WS09	Ich bin <(seng)> bei d’r Frä gewähst o͡un hon s ’r gesäht, o͡un se
 WS10	Ich wells öhch net mi werre düh.
 WS11	Ich schlo͡ah dich glich met d’m Ko͡achleffel em die Ohr’n dü Aff’.
 WS12	Bo gest de hin, sounn m’r met d’r gih?
-WS13	Es seng schlähchte Zäï̈re.
+WS13	Es seng schlähchte Zäïre.
 WS14	Meng liewes Kehnd, bläïb häï enge stih, die behse Gäns’ bäïse dich doudt.
 WS15	Dü host häït d’r minst gelernt, oun best artig gewähst, dü därfst ehnd’r heem gih, bi die Ahnern
 WS16	Dü best no͡ach net groß genünk, em e Flasch Weng äussetrenke, dü müßt erscht no͡ach e Eng wo͡asse o͡un gresser währn.

--- a/28623_Gittersdorf.csv
+++ b/28623_Gittersdorf.csv
@@ -13,7 +13,7 @@ WS02	S herrt glich off se schnein, dow werd ds Wähder werre bässer.
 WS03	Do Kolle in Owe, däß de Melch bahl on se koche fangt.
 WS04	Dr gott ahl Mann es met dm Gull <(Pähr)> dorchs Is gebroche on ins kahl Wasser gefalle.
 WS05	Hä es ferr vier äwer sächs Woche gestarwe.
-WS06	Ds Fier wor se heiß, de Koche senn ȷe onge ganz schwarz gebrahnt.
+WS06	Ds Fier wor se heiß, de Koche senn je onge ganz schwarz gebrahnt.
 WS07	Hä eßt de Eier immer ohne Sahls on Päffer.
 WS08	De Feß donn mäh sähr weh, ech gleib, ech honn se dorch geläufe.
 WS09	Ech wenn bei dr Frai gewäst on honn s’er gesäht, on sä säht, sä wolls ai ärer Tochter säh.

--- a/28640_Herfa.csv
+++ b/28640_Herfa.csv
@@ -13,8 +13,8 @@ WS02	Es hiert glich off zu Schnäun, dann wäd das Weeter werre besser.
 WS03	Tho Kolle en den Ofe, daß de Melch bal an zu koche fängt.
 WS04	Der gorre alle Mann eß met dem Gul dorchs Iß gebroche on ens kall Wasser gefalle
 WS05	Er eß vär 4 oder 6 Woche gestorbe.
-WS06	Das Fier war zu heiß, de Koche sinn ȷa onge ganz schwarz gebrannt.
-WS07	Er eßt de Eiȷer imme uhne Saals on Peffer.
+WS06	Das Fier war zu heiß, de Koche sinn ja onge ganz schwarz gebrannt.
+WS07	Er eßt de Eijer imme uhne Saals on Peffer.
 WS08	De Feß donn mei weh, ech glei ech hann se durch glelaufe.
 WS09	Ech benn bei der Frau gewese onn hann es ihr gesaht onn see saht se well es auch vär ihre Tochter sah.
 WS10	Ech well es auch nett werre doh.

--- a/28651_Frauensee.csv
+++ b/28651_Frauensee.csv
@@ -14,7 +14,7 @@ WS03	Thu Kolle en dän Oube, däß de Melch ball ohn ze koche fängt.
 WS04	Der gut’ ahl’ Mann es met däm Pferd dörchs Ihs gebroche onn ens kall Wasser gefalle.
 WS05	Äh es verr veer otter sächs Woche gestöärbe.
 WS06	Das Fier wöär ze heiß, de Koche sein jä onge ganz schwöärz gebrahnt.
-WS07	Äh eßt de Eier im̅er ouhne Saalz onn Pfäffer.
+WS07	Äh eßt de Eier im̄er ouhne Saalz onn Pfäffer.
 WS08	De Fess’ thom mei sehr weh, ech gleih, ech honn se dörchgelaufe.
 WS09	Ech benn bei der Fräu gewäst onn honns ehr gesöät onn sei souk sei wälls äu ehrer Tochter söä.
 WS10	Ech wells äu nett mehe witter thu.

--- a/30058_Karkelbeck.csv
+++ b/30058_Karkelbeck.csv
@@ -15,8 +15,8 @@ WS04	Geras, fenas Wÿras yra fu Arklu ant Lēdo i {„i“ durchgestrichen} luź
 WS05	Jis ÿra pirm keturu ar fzefzu Nedēlu mires.
 WS06	Ugnis buwo per karfzta, tie Pyrāgai ÿra juk apatczio wifai juo dai fu dēge.
 WS07	Jis [w]algo Kiaufzus wįs bę Drufkōs ir Pįpįrū.
-WS08	Kojes man labai fkausti, afz miflijų, jes ēfas nutrienes.
-WS09	Afz ęfu prie Moterifzkēs buwes ir ęfu jei fakes, ir ji fake, jį nor ir fawo Dųkterei fakīti.
+WS08	Kojes man labai fkausti, afz mifliju̬, jes ēfas nutrienes.
+WS09	Afz ęfu prie Moterifzkēs buwes ir ęfu jei fakes, ir ji fake, jį nor ir fawo Du̬kterei fakīti.
 WS10	Afz noru nieka dos tai darÿti.
 WS11	Afz mufziu tawe tuojau fu Samtoziu apie Aufis, tu Beź dźanka.
 WS12	Kur einį tu, turim mef fu tawim drauge eitį?
@@ -36,7 +36,7 @@ WS25	Sniegas ÿra fzitoje Naktije pas mus gulet pafilikes, ale fzī Ryta jis yra
 WS26	Už mufu Buto ftow tries gražios Obelikles fu raudonais Obuolaitczais.
 WS27	Ar negalit jus dar wiena Akiesmirsni ant muhu laukti, tai eikam mesfu jumis drauge.
 WS28	Jums ne walna toke Wainÿstes prowÿti.
-WS29	Jūsų Kalnai yra nelabai aukfzti, mufz ifzkei ÿra dauk aukfztesni.
+WS29	Jūsu̬ Kalnai yra nelabai aukfzti, mufz ifzkei ÿra dauk aukfztesni.
 WS30	Kiek Swaru Defzros ir Duonos norit jus?
 WS31	Afz ne permanau jus, jus turit maźumele aifz kiaus kalbeti.
 WS32	Ar net efat rade menka Stekeli balto Muilo ut mans Stalelio.

--- a/30060_Plucken-Martin.csv
+++ b/30060_Plucken-Martin.csv
@@ -42,7 +42,7 @@ WS31	Aſz jus ne permanau, jus Turit aiſżkiaus kalbeti.
 WS32	Ar ne Stukeli balta Muile ant maro Stale radot?
 WS33	Mano Brolis nor <i> juſu Darźe du dailu Buttu budawoti.
 WS34	Tas Zodis jam nu S[?]irdies ejo.
-WS35	Tai buwo <Ger nu> Ger nu ȷuſu.
+WS35	Tai buwo <Ger nu> Ger nu juſu.
 WS36	Kas tie per Paukſztelei yra kurie ten ant Mura ſedz?
 WS37	Burai penkes Jautus, dewynes Karwes ir dwylika Awju ten uz Kiemo ant Pardawimo wedzia.
 WS38	Zmones ſzendien wiſi i Lauka ant Dagawimo iſzejo.

--- a/30060_Plucken-Martin.csv
+++ b/30060_Plucken-Martin.csv
@@ -35,7 +35,7 @@ WS24	Kaip mes wakar atgal parejom tai kitti i gìle Mi[?]ge gulejo.
 WS25	Sǹēgs pri muſu dar wakar <gutejo> gulejo, alle jau ſzì Rÿt ſutirpo.
 WS26	Uz muſu Butta ſtow trys grazi Obelmedzei ſu raudonu Obelu.
 WS27	Ar jus ne galit kokia Akies Mirkſne laukti, mes drauge einam.
-WS28	Jums ne reik tokiu̓ Kudikiu̓ S[?]tukas iſzprowyt.
+WS28	Jums ne reik tokiú Kudikiú S[?]tukas iſzprowyt.
 WS29	Muſu Kalnai niera tokios aukſztos, juſu ÿra aukſzteſnos.
 WS30	Kiek Swaru̚ Deſzerů ir kiek Důnos jus norit?
 WS31	Aſz jus ne permanau, jus Turit aiſżkiaus kalbeti.

--- a/30061_Paupeln-Peter.csv
+++ b/30061_Paupeln-Peter.csv
@@ -17,7 +17,7 @@ WS06	Ugnis buwo par karszt, juk Kůka apato powiſam ſudeguſi.
 WS07	Jis Kiauſzas wis walga be Druſka bei Pipira.
 WS08	Kojas man didei ſkauda, manding asz jas buſo praſibēgès.
 WS09	Asz prie tos Moteriſzkês buwau ir jei ta ſakiau, ir ji ſake, kad ji ta ir ſawai Dukterei ſakÿs.
-WS10	Asz ta daugiauis nebʼdarÿſu.
+WS10	Asz ta daugiauis neb’darÿſu.
 WS11	Asz taw tujau muſzu ſu ſamti par Auſû, Bezdone!
 WS12	Kur Tu nueiti, ar eisim ſu Tawimē drauge?
 WS13	Yra trudnōs Gadÿnes.

--- a/30062_Wittauten.csv
+++ b/30062_Wittauten.csv
@@ -26,8 +26,8 @@ WS15	Tù ſendien daugiauſei mokįnais ir padorus bùwai, todēl Tù galį anks
 WS16	Tû dar nè ganį dįddis èſsi, wiſsa Plētſźka Wÿno iſźgérti, Tù dar tùrį Gálà auktį ir didésnis paſtotį.
 WS17	Eik, bûk toks gérs, ir ſakẏk Tawo Sèſirei, ji tùr jûſo Motinos Rûbùs pagatawitį ir ſù Bérſztù iſźcźistitį.
 WS18	Kad Tu jį bûtumbei paźinnes, tai bûtù kittaip nuſidáwes, ir ſù jomį gėraus ſtowētù.
-WS19	Kàs mán máno Pintinį ſu Mēſą pȧwog[?]?
-WS20	Jis dêjos, bûk jie jį kùltį wadįnné o jie pǎtis tai padárę͗.
+WS19	Kàs mán máno Pintinį ſu Mēſą påwog[?]?
+WS20	Jis dêjos, bûk jie jį kùltį wadįnné o jie pătis tai padárę͗.
 WS21	Kam jis ta naujia Nusidawįma papaſakojò?
 WS22	Reikia aiſźkei ſźaukti, ſźeip jis mus ne permano.
 WS23	Més p[?]ilſė ēſam, ir tùrim Tróſzkùli.
@@ -45,6 +45,6 @@ WS34	Tas Źodįs jiam nů Szirdies parējo.
 WS35	Tai gerai nů jû bûwo.
 WS36	Kas tie per Paukſźticźei ant Mûréliû ſēd?
 WS37	Bûrai b[?]wo penkis Jautùs ir dèwinés Karwés ir dwilįka Awéliû prie Kiemo atgabénį; tùs jie norējo pardoti.
-WS38	Źmonès ÿra ſźendien wiſsį ant Lauko ir kértą <(pjȧujia)>.
+WS38	Źmonès ÿra ſźendien wiſsį ant Lauko ir kértą <(pjåujia)>.
 WS39	Tikt eik rùdàſis Szů Taw nieka nè daris.
 WS40	Aſź ſu tais Źmonimis tén uſźpakalij per Piewa i Rùgius waźawau.

--- a/30063_Großjagschen.csv
+++ b/30063_Großjagschen.csv
@@ -28,7 +28,7 @@ WS17	Eik, buk taip gers ir ſakÿk ſawo Sesſerei, jeib Drabuźus Motinai paſu
 WS18	Kad tu jie but pazin̅es, tai but kittaip buwes, ir ſu jůmi geraus ſtowetum.
 WS19	Kas man mano Kúrba ſu Mésa pawoge?
 WS20	Jis taip dare, kaip kad jie ant Kulimo pastellawe butu, alle jie patis tai atliko.
-WS21	Kam jis ta nau̇ja Nuſidawima papaſakojo?
+WS21	Kam jis ta naůja Nuſidawima papaſakojo?
 WS22	Reik didei szaukti, szeip mums nepermano.
 WS23	Mes eſmi pawarge ir isztroszke.
 WS24	Kaip mes wakar Wakar atgal ſugrÿszom, tai kitti gulejo i Lowa ir buwo uźmige.

--- a/30063_Großjagschen.csv
+++ b/30063_Großjagschen.csv
@@ -25,7 +25,7 @@ WS14	Mano miels Kudikis paſilik ſziszon apaczioj be ſtowis, Źasis ſzeip pja
 WS15	Tu szendien daugiauſei mokinais ir esſi patogus buwes, Tu ir ankscźaus gali Namů eit, kaip kitti
 WS16	Tu dar ne esſi didis gana, jeib wiena Butelki Wÿno iszgert gali, dar turi Gala augti ir didesſnis paſtoti.
 WS17	Eik, buk taip gers ir ſakÿk ſawo Sesſerei, jeib Drabuźus Motinai paſutum, ir ſu Bers[?]tu is[?]bersztůtum.
-WS18	Kad tu jie but pazin̅es, tai but kittaip buwes, ir ſu jůmi geraus ſtowetum.
+WS18	Kad tu jie but pazin̄es, tai but kittaip buwes, ir ſu jůmi geraus ſtowetum.
 WS19	Kas man mano Kúrba ſu Mésa pawoge?
 WS20	Jis taip dare, kaip kad jie ant Kulimo pastellawe butu, alle jie patis tai atliko.
 WS21	Kam jis ta naůja Nuſidawima papaſakojo?

--- a/30064_Melnragen.csv
+++ b/30064_Melnragen.csv
@@ -13,7 +13,7 @@ WS02	Tujau paliaus ſnigti, tad bus Pagada wel gereſne.
 WS03	Darÿk Angliu i Kraſni, kad Piens weik wirti pradetu.
 WS04	Tas geraſis ſenaſis Wÿrs ſu Arkliu per Ledu iluźes ir i ſzalta Wandini ikrites.
 WS05	Ans ÿra pirm keturiû ar 6 Nedeliû numires.
-WS06	Ugnis buwa per karſzta, Pÿragâ ÿrʼ Apate gans joda ſudeguſi.
+WS06	Ugnis buwa per karſzta, Pÿragâ ÿr’ Apate gans joda ſudeguſi.
 WS07	Ans walga Kiauſzus wis be Druſka ir be Pipirû.
 WS08	Kâjas man didę ſkaud, aſz miſliju aſz buſu parſibeges.
 WS09	Aſz eſu pri ta Matriſzke buwes ir eſu ana ſakes, ir ana ſake, ana narinti ir ſawa Duktere ſakÿti.
@@ -45,6 +45,6 @@ WS34	Tas Źadis anâm eja nu Szirde!
 WS35	Tas buwa riktinga nu juſu.
 WS36	Kas tie par Paukſztele ſed ten aukſztâ ant
 WS37	Bûra tureja penkis Jautus ir dewÿnes Karwes ir dwÿlaka Aweliu prie Kiema atwede, anie nareja anus pardoti.
-WS38	Źmanis wiſi ſzende ÿr ant Laukû iſzeje ir ſzenaujʼ.
+WS38	Źmanis wiſi ſzende ÿr ant Laukû iſzeje ir ſzenauj’.
 WS39	Ek tik, tas rudaſis Szo taw nieka ne dara.
 WS40	Aſz ſu tâs <Źanimıs> Źmanimis cze uźpakalie per Piewa i Rugius waźawau.

--- a/30064_Melnragen.csv
+++ b/30064_Melnragen.csv
@@ -47,4 +47,4 @@ WS36	Kas tie par Paukſztele ſed ten aukſztâ ant
 WS37	Bûra tureja penkis Jautus ir dewÿnes Karwes ir dwÿlaka Aweliu prie Kiema atwede, anie nareja anus pardoti.
 WS38	Źmanis wiſi ſzende ÿr ant Laukû iſzeje ir ſzenauj’.
 WS39	Ek tik, tas rudaſis Szo taw nieka ne dara.
-WS40	Aſz ſu tâs <Źanimıs> Źmanimis cze uźpakalie per Piewa i Rugius waźawau.
+WS40	Aſz ſu tâs <Źanimis> Źmanimis cze uźpakalie per Piewa i Rugius waźawau.

--- a/30066_Schmelz.csv
+++ b/30066_Schmelz.csv
@@ -12,7 +12,7 @@ WS01	Źema lek sause Lapai kiaura i Ora aplinko.
 WS02	Jau palaus weik snegti, tad bus Pagada geresne.
 WS03	Dek Anglis i Kroasne, kad Pens weike werte pradetu.
 WS04	Wens gers sens Wirs yr so Arklo i Ledo iluźes er i szalta Wandene ipoles.
-WS05	Ans yrʼ perm keturu arba szeszu Nedelu pasimeres.
+WS05	Ans yr’ perm keturu arba szeszu Nedelu pasimeres.
 WS06	Ugnis bowo par karszta, tos Kokas yr apato joda apdegosos.
 WS07	Ans walgo Kiauszus wiss be Druska er be Peperu.
 WS08	Kojes mane skaud dedele, asz mislijo, asz busu jes kiauraij prabēgus.
@@ -32,7 +32,7 @@ WS21	Kam yr ans ta nauje Nusedewema papasakojes?
 WS22	Tor diktik szaukte, szeip ans mus ne permana.
 WS23	Mes esam paelse er isztroszke.
 WS24	Kaip mes wakar Wakare pargryźam, tad goleje jau kete i Lowa ir buwa saldei imege.
-WS25	Snegs yr szi Nakte prie muso palekes, ale szi Rytʼ yr sudrekes.
+WS25	Snegs yr szi Nakte prie muso palekes, ale szi Ryt’ yr sudrekes.
 WS26	Uź muso Bota aug tris Abelekis su raudonais Abelokais.
 WS27	Ar ne galet dar kaki Akismirksne ant muso laukte, tad mes esam drauge.
 WS28	Jus ne toret tokes Kudikistes waryte.

--- a/30071_Petrellen.csv
+++ b/30071_Petrellen.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	I. Sziema lēka ſaŭsi Lapai per Ora aplink.
 WS02	Weikei palaus ſnikti, tai asſiras Pagada wiel gereſne.
 WS03	Deek Angliŭ ÿ Kroſna, kad Piens weikei pradetŭ wirti.
-WS04	Tas geraſsis ſens Wirs ÿra ſŭ Arkli per Leda ilŭſzes, o ÿ ſzalta Wanden̅i ipoles.
+WS04	Tas geraſsis ſens Wirs ÿra ſŭ Arkli per Leda ilŭſzes, o ÿ ſzalta Wanden̄i ipoles.
 WS05	Jis ÿra pirm kettŭrŭ, arba ſzeſzŭ Nedelŭ mires.
 WS06	Ugnis bŭwŭ per karſzta Kokai jŭk ÿra apatczo godai ſŭdĕge.
 WS07	Jis walgo Kiauſzus wiſs be Drŭska ir Pipirrŭ.
@@ -21,8 +21,8 @@ WS10	Aſz ta ir daugaus ne norŭ dariti.
 WS11	Aſz mŭſzŭ tawe weikei ſŭ Werdamoje Szaŭgſzta aplink Aŭſsis, tŭ Besſzone.
 WS12	Kŭr tŭ nŭeini, ar mes tŭrim ſu tawim eiti?
 WS13	Jra ſzlekti Czeſai.
-WS14	Man̅o miels Kŭdiki, palik ſziſzon apaczon beſtowent, piktos Szaſsis tawe smertſzop [ironis].
-WS15	Tu ſzendien daugaus eſsi mokin̅es ir pakajings buwes, tu weikaus galli numes eiti kaip Kitti.
+WS14	Man̄o miels Kŭdiki, palik ſziſzon apaczon beſtowent, piktos Szaſsis tawe smertſzop [ironis].
+WS15	Tu ſzendien daugaus eſsi mokin̄es ir pakajings buwes, tu weikaus galli numes eiti kaip Kitti.
 WS16	Tŭ dar ne eſsi diddels gana, wiena Flaſza [Rinskim] iſz gerti, tŭ dar wiena Gala tŭri augti ir dideſnis paſtoti
 WS17	Eik, buk teip gers ir ſakik ſawo Seſere, kad jie Drabuſzus jŭſŭ Motina gatawas paſŭtŭ ir ſu Berſzta czÿstus padaritu.
 WS18	Kad tŭ jie butum paſzines, tai bŭtŭ kittaip parèjŭſi, ir aplink jie geraus ſtowetŭ.

--- a/30073_Windenburg.csv
+++ b/30073_Windenburg.csv
@@ -31,7 +31,7 @@ WS20	Jis dare taip, kad jie butumbim kulte pastelawes, ji ale patis ta dare.
 WS21	Kam jis ta nauje Nusidawima papasakojo?
 WS22	Turim aisźkei szaugti, sźeib ne perman jis mums
 WS23	Mes esam nuwarge ir turim Trosźkuli
-WS24	Kaip mes wakar Wakare atgal parejom, tai gulejo kitti jau̇ i Lowa ir buwo priepat imiegojo.
+WS24	Kaip mes wakar Wakare atgal parejom, tai gulejo kitti jaů i Lowa ir buwo priepat imiegojo.
 WS25	Sniegas szie Nakti pri musſu guleti palikes ale Sźirÿt jis ÿr sutirpes.
 WS26	Usz musu Trobos stow tris puikus Obulikes su raudonas Obulukas.
 WS27	Ar jus ne galet dar wiena Akies Mirksnele ant musſu laugti, tai mes eisim su jumis.

--- a/30073_Windenburg.csv
+++ b/30073_Windenburg.csv
@@ -44,7 +44,7 @@ WS33	Jo Brolis nor sawe dwi dailus Namus i jusu Darsza budawoti.
 WS34	Tas Źodis iszejo jam isz Szirdies
 WS35	Ta[i] buwo gerai nu ju
 WS36	Kas sed cźe per Paukcźtelei augsztai ant Murelo? /:B:/
-WS37	Burai turejo penkes Jaucźus ir dewines Karwes ir dwilika Awikio pirm Kiemo atwede, tus norejo jie pardůtı.
+WS37	Burai turejo penkes Jaucźus ir dewines Karwes ir dwilika Awikio pirm Kiemo atwede, tus norejo jie pardůti.
 WS38	Szmones yr Sźenden wisſi ant Lauko ir pjaun.
 WS39	Eik tik, tas brunases Szo taw neka nedaries
 WS40	Asz esmi su Szmonemis per Pewa i Jewus waszawes.

--- a/30075_Wabbeln.csv
+++ b/30075_Wabbeln.csv
@@ -38,7 +38,7 @@ WS27	Ar negalit Akiesmirksna ant musu laukti, tai su jumis einam.
 WS28	Ne tokius waikisźkus Darbus turit dirbti.
 WS29	Musu Kalnai ne labai auksźti jusieje daug auksźtesni.
 WS30	Kiek Swaru Desźeru ir kiek Důnos jus norit?
-WS31	Asź jumis neisźmanau turit maźuma aısźkiaus kalbeti.
+WS31	Asź jumis neisźmanau turit maźuma aisźkiaus kalbeti.
 WS32	Ar neradot Stukeli balta Muila man ant mano [Stali].
 WS33	Jo Brolis nor dwi graźu Trobu juso Darźio pabudawoti.
 WS34	Tas Źodis parejo jam nu Sźirdies!

--- a/30076_Schieschgirren.csv
+++ b/30076_Schieschgirren.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Źiemojʾ leka sausiejie Lapai Ore aplinku.
+WS01	Źiemoj’ leka sausiejie Lapai Ore aplinku.
 WS02	Tůjau apsistos ſnigti, tai pastos Ors wel geresnis.
 WS03	Ikresk Anglis i Krosni, kad Piens pradetu weikiei wirti.
 WS04	Tas gerasis senasis Źmogus ira su Arklu per Leda luźis ir i szaltaji Wandeni ikrittis.

--- a/30078_Rudienen.csv
+++ b/30078_Rudienen.csv
@@ -12,7 +12,7 @@ WS01	Źiemôjè lęk faufiejie Lakai per Orà.
 WS02	Weikei pàlaus fnigti, potąm bùs wēl graźęs nis Oràs.
 WS03	Atnefzk Angliu i Kakàli, kad Piens weik atwirtu
 WS04	Gèràfis, fènàfis Wÿrs ÿrà i Lędà iluźes ir i fząltaj i Wąndèni ipŭlęs.
-WS05	Jis ÿra pirm kęturiû {ˋüber ę} arba fzefziu Nèdēliû miręs.
+WS05	Jis ÿra pirm kę̀turiû arba fzefziu Nèdēliû miręs.
 WS06	Ugnis bùwô per karfzta, Pÿragai ÿrà àpàozôj {ˊüber j} jůdai fùdęgę.
 WS07	Jis wis walgo Kiaufźus bè Drùskôs ir be Pipirú.
 WS08	Man Kojès làbai fkaust, mąn rôdôs, àfz èhu jès pràfibēgęs.

--- a/30078_Rudienen.csv
+++ b/30078_Rudienen.csv
@@ -13,7 +13,7 @@ WS02	Weikei pàlaus fnigti, potąm bùs wēl graźęs nis Oràs.
 WS03	Atnefzk Angliu i Kakàli, kad Piens weik atwirtu
 WS04	Gèràfis, fènàfis Wÿrs ÿrà i Lędà iluźes ir i fząltaj i Wąndèni ipŭlęs.
 WS05	Jis ÿra pirm kę̀turiû arba fzefziu Nèdēliû miręs.
-WS06	Ugnis bùwô per karfzta, Pÿragai ÿrà àpàozôj {ˊüber j} jůdai fùdęgę.
+WS06	Ugnis bùwô per karfzta, Pÿragai ÿrà àpàozôj̀ jůdai fùdęgę.
 WS07	Jis wis walgo Kiaufźus bè Drùskôs ir be Pipirú.
 WS08	Man Kojès làbai fkaust, mąn rôdôs, àfz èhu jès pràfibēgęs.
 WS09	Asz bùwau pàs ta Môtèrà ir jei tai fakiau, ji fake, kad ji tai ir fawo Dukterei fakis.
@@ -21,12 +21,12 @@ WS10	Afz daugiaus teip nedarÿfù.
 WS11	Afz taw tůjaus fu Samez iu i Kakta mùfzù, tu Beźdźonie!
 WS12	Kur eini, ar mès futawim drauge eisim?
 WS13	Ÿra fzlekti Czēfai.
-WS14	Mano miels Kudik, pafilik ezon àpàozôj {ˊüber j} ftoweti, piktofes Źafis kand tewe fmertnai.
+WS14	Mano miels Kudik, pafilik ezon àpàozôj̀ ftoweti, piktofes Źafis kand tewe fmertnai.
 WS15	Tu fzendien daugiaufei ifzmokai ir esfi patogus buwes. Tu gali anks ezaus namon eiti kaip kiti.
 WS16	Tu dar ne gana didelis esfi, Plèiźką Wÿno ifzgerti, Tu turi dar popirm gala augti ir didesnis paftoti.
 WS17	Eik, buk teip gers, ir fakik tawo Sęferei, kad ji juhu Motinai Drebuz ius pafutu ir fu Bèrfztu nuwalÿtu.
 WS18	Kad tu butai ji paźines! tai butu kitaip eje ir fu jům geraus but atferade.
-WS19	Kas mano Kàfzęlè {ˊüber ę} fu Mesà pawoge?
+WS19	Kas mano Kàfzę́lè fu Mesà pawoge?
 WS20	Jis dare teip, kaip kad jie ji butu kult wadine, alle jie tai patis atliko.
 WS21	Kam jis ta naujaji Nufidawima pàpáfàkojo?
 WS22	Turi aifzkei fzaukti, fzeip eip jis mus ne permano.

--- a/30083_Kolletzischken.csv
+++ b/30083_Kolletzischken.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Sziemoje lakoj ſauſieje Lapai i Ora aplinku.
 WS02	Tůjau apſiſtos Sniegoſe tai wel bus Ors gereſnis.
 WS03	Dek Anglis i Kakale, kad Piens tůjau wirti pradetu.
-WS04	Taŝ geraſis, ſenaſsis Wirs ÿra ſu Arkliu per Lieda iluſzis, ir i ſzalta Wandene ikritis.
+WS04	Tas̆ geraſis, ſenaſsis Wirs ÿra ſu Arkliu per Lieda iluſzis, ir i ſzalta Wandene ikritis.
 WS05	Jis yra pirm keturu ar ſzeſu Nedeliu mires.
 WS06	Ugnis buwo per karſzta, Kokai yra apaczoy ganz jodai ſudegei.
 WS07	Jis walga Kiauſzus wis be Druskas ir be Pipiriu.

--- a/30245_Disselingen.csv
+++ b/30245_Disselingen.csv
@@ -18,7 +18,7 @@ WS07	I minge tojo les û sans sâ et sans pouèvre.
 WS08	Les pies me fayont bin mâ, je cro que je les â folés.
 WS09	J’à éti chez les fôme et j’y â dit, et elle dej(o) qu’elle velô âsi lo dire et set basêle.
 WS10	Je ne vue pu lô fâre non pu.
-WS11	J’te trique les airayes to de suite évon let couyie de pot, t/peu singe !
+WS11	J’te trique les airayes to de suite évon let couyie de pot, t/peu singe!
 WS12	Ouas-que te vâ, es-que j’devon ollè evon teu.
 WS13	Ca des mou/nres temps.
 WS14	Mon cher ofant, demouaire drassi tossi, les méchantes zouayes te mingerint.
@@ -37,11 +37,11 @@ WS26	Derri chez no, y né tro bé pia peumé évon des piates peumes rouges.
 WS27	As-que vo ne pouvèm no étond in pia moment, je vron evon vo.
 WS28	Vô ne d’vême tant fâre l’afant.
 WS29	Nos montaignes ne sommes bin hâtes, les vôtes sont bî pu hâtes.
-WS30	Combin quev velé de lives de sacisses et de pain ?
-WS31	As-que vo nèm trouvé enne piate caye de savon bian por mé dessi mé taye ?
+WS30	Combin quev velé de lives de sacisses et de pain?
+WS31	As-que vo nèm trouvé enne piate caye de savon bian por mé dessi mé taye?
 WS32	So frère vu se bâtii doux bèlles majons don vote jodien.
 WS33	Let parole lié v’nu di cœur.
-WS34	Qu’asse que ça pou dé pia jognes su lo pia miche ?
+WS34	Qu’asse que ça pou dé pia jognes su lo pia miche?
 WS35	Cetto jenti de vote part.
 WS36	Li paysans avint émounet cinq bûes, nive vèches et doze égnès d’vant lo vilège, y vrint les vende.
 WS37	Tous les gens sont dans les champs aj’deu et sayont.

--- a/30252_Lagarde.csv
+++ b/30252_Lagarde.csv
@@ -31,7 +31,7 @@ WS20	Lé fa comme si on l’évo d’mandé po bette, mâ y l’on fâ d’zou [
 WS21	qui ass què v’lé réconté lè novelle istouère?
 WS22	i fâ baï fort, sans s’lé inn no compramme.
 WS23	Jé sont follé et j’on sa.
-WS24	quand j’on errveni lo soére les âtes atïn on leu [ch] un  treyïn dè dremi.
+WS24	quand j’on errveni lo soére les âtes atïn on leu [ch] un treyïn dè dremi.
 WS25	Lè nage est demouéré chi no lo [paneu], mâ lé fondu ahèdieu lo metïn.
 WS26	Déri chî no y est ca trôh ppeumeu avons des béles peumes dessus.
 WS27	Jeunn [dourro] fare des jeux d’ofant anlé.

--- a/30268_Richeval.csv
+++ b/30268_Richeval.csv
@@ -19,7 +19,7 @@ WS08	Les pieis me fayont mâ je crâ les avor folé.
 WS09	J’otor si lè fôme j’li ai dit et elle me dehors qu’elle vlor ieu assi lo dïeure sai feïeu.
 WS10	Je ne vieu pi ercommencieu.
 WS11	Tot e l’oure je te [youne] lai [coiië] de payon ai l’ai tète singe.
-WS12	Où est-ce que te vais ? Fat-i ollai ovon ti.
+WS12	Où est-ce que te vais? Fat-i ollai ovon ti.
 WS13	C’ost des menres onnées.
 WS14	Demoure en beck mo cher ofant les méchantes znvoieu te touerèrent.
 WS15	A hodié te lo plis étidjeu et te été sège je to permats d’ollai è lé machon pitôt que les âtes.

--- a/30275_Deutsch-Oth.csv
+++ b/30275_Deutsch-Oth.csv
@@ -19,31 +19,31 @@ WS08	Les pieds me fayont tout mō, je creu qu’j’ā trop marchi.
 WS09	J’a étu su la famme, es/t jé l’y ā dit, et elle é dit qu’elle lé d’reu à sa gauche étou.
 WS10	J’né l’féra pu non pu.
 WS11	J’té foutra la kii à pot su les orèyes, singe.
-WS12	Ous qué t’va ? est-ce qué j’ devons n’allaye aveu té.
+WS12	Ous qué t’va? est-ce qué j’ devons n’allaye aveu té.
 WS13	C’est des mauvais temps.
 WS14	Me chér ăfant demōr toucé, embache, les movaises ōyes té mingerint.
 WS15	C’est té qué lé mieux apprin ănū, et té ătu gentit, té pourré t’en nollaye avant les autes.
 WS16	Té n’ème co assaye grand pou boire enne bouteille dé vin, il faut qué t’krescheusse co in po es qué t’fū pu grand.
 WS17	Va der a ta sœur qu’elle acheveusse les betins de not mér es qu’elle les nettieusse aveu eune brou<(/au)>che.
 WS18	Si t’vlèveu connchu, ç’areu atu autrement, et il areu mieux prosperaye.
-WS19	Qui est-ce qui mé prin mé păni de chā ?
+WS19	Qui est-ce qui mé prin mé păni de chā?
 WS20	Y feyeu mention d’avoir atu commandaye dé băte, mā i l’ont fā zaou mém’.
-WS21	A qui est-ce qu’il é raconté la nouvelle histoire ?
+WS21	A qui est-ce qu’il é raconté la nouvelle histoire?
 WS22	Y faut [bayi] fō, ou ben inn’ compenreum’.
 WS23	Jé son hodaye et j’on seuye.
 WS24	Quand j’on r’veni hier a la nu, les aut’ atins déja couchi et dormint come dé [tŏ].
 WS25	La nè[ĕ]ge é d’moraye toute la nuti, mè anu o matin elle é fandu.
 WS26	Dri chenou n’y é treu bé ptit pemi aveu dé rouges pommes.
-WS27	Est-ce qu’é vé n’ pourrīnmes n’attende co in moument ? alors jé vron aveu vou.
+WS27	Est-ce qu’é vé n’ pourrīnmes n’attende co in moument? alors jé vron aveu vou.
 WS28	Vé n’deveumes far dé porreyes enfantillages.
 WS29	Nos cōtes né sont oua haūtes, les votes sont bēn pu hautes.
-WS30	Combien de lives dé saucisses et combien d’pé v’leuve avoir ?
+WS30	Combien de lives dé saucisses et combien d’pé v’leuve avoir?
 WS31	Jé n’ veu comprenme, i faut cousaye in pau pu haūt.
 WS32	Est-ce que v’naveūmes trouvaye in petit lopin d’savon blanc por mé su ma taūye.
 WS33	Sé frère veu bātir daou belles nieuves majons dans vot jardin.
 WS34	Lo mot li v’neu don cœur.
 WS35	C’ateut bin de lō part.
-WS36	Qu’est-ce qué c’est qué ces petits jŏnes qui sont su la p’tite meuraye ?
+WS36	Qu’est-ce qué c’est qué ces petits jŏnes qui sont su la p’tite meuraye?
 WS37	Lé rabouraou avint amoénaye neuf bieux et neuf vaches et douze aniés d’vant le village, i v’lin les vende.
 WS38	Tout le monde é aux champs anu et i fauchont.
 WS39	Va t’en toujou, lé chin brun né t’féré rin.

--- a/31705_Edesheim.csv
+++ b/31705_Edesheim.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: SyHD
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	M’Wender fliegen die trockene Blerrer in dě Luft rum.
-WS02	S’hert gleich uf sě schneiche, dann werd’s Werrer wirrer besser.
-WS03	Du Koule en dě Ouwe, daß d’Millich ball sě koche anfangt.
+WS01	M’Wender fliegen die trockene Blerrer in dĕ Luft rum.
+WS02	S’hert gleich uf sĕ schneiche, dann werd’s Werrer wirrer besser.
+WS03	Du Koule en dĕ Ouwe, daß d’Millich ball sĕ koche anfangt.
 WS04	D’goure alte Mann esch mirem Perd ens Eis gebrahe un ens kalde Wasser g’falle
 WS05	Er esch vor vier ŏrer sechs Woche g’schdorwe.
-WS06	S Feiěr war sŏu schdark, d Kuge sinn jo unne ganz schwarz g’brennt.
+WS06	S Feiĕr war sŏu schdark, d Kuge sinn jo unne ganz schwarz g’brennt.
 WS07	Er ißt d’Eier immer uhne Salz und Peffer.
-WS08	D’Fiß dien měr arg weh, ich gläb, ich häb sě durch g’loffe.
+WS08	D’Fiß dien mĕr arg weh, ich gläb, ich häb sĕ durch g’loffe.
 WS09	Ich ben bei d’Frä g’weßt, un häwers g’sagt un sie hot g’sagt, sie wills ach èhrer Dachtér sagé
 WS10	Ich wills awér nimmi wirrér daun.
 WS11	Ich schlach dér gleich mimm Kochlöffel iwér d’Ohré, du Aff.
-WS12	Wu gèschd n’anne, selle mèhr mit děr gäi
+WS12	Wu gèschd n’anne, selle mèhr mit dĕr gäi
 WS13	Sinn schlechde Zeire.
 WS14	Mei liebs Kénd bleib do unne stäi, d’bäise Gäns beißen dich doud.
 WS15	Du hoscht heit am menschde g’lernt, un beschd ardig gwéßt, du derfschd èder häm gäi, als d’annern.
-WS16	Du beschd noch nitt grŏuß génunk fere Flasch Wein aus sě drinke, du muscht èrscht nah ä bissel wachse un gräißer wérn.
+WS16	Du beschd noch nitt grŏuß génunk fere Flasch Wein aus sĕ drinke, du muscht èrscht nah ä bissel wachse un gräißer wérn.
 WS17	Geh, sei sŏu gud un sag deiner Schweschder, sie sell d’Klärer fér eire Mudder férdig nèhe, un mit d’Bérschd sauwer mache
 WS18	Héschd dun g’kennt, dann wèrs annerscht kumme, un es dèt besser mirrem stäi.
 WS19	Wer hot mèhr mein Karb mit Fläsch gstohle.
 WS20	Er dut sŏu als héren senn zum Dresche beschteld, sie heims awer seliwer g’daun
-WS21	Wèm horer d’Gschicht vězäild.
-WS22	Měr muß laut kreische sunschd verstèhrer uns nitt.
+WS21	Wèm horer d’Gschicht vĕzäild.
+WS22	Mĕr muß laut kreische sunschd verstèhrer uns nitt.
 WS23	Mèhr sinn mied un hänn Dohrscht
 WS24	Als mehr geschdert Owend sèrick kumme sinn, do sinn d’annern schun em Bett gläche un waren fescht em Schlofe.
-WS25	Dě Schnee esch heidt Nagt bei uns lige gěblewe, awer dMorge esch r gschmolze.
+WS25	Dĕ Schnee esch heidt Nagt bei uns lige gĕblewe, awer dMorge esch r gschmolze.
 WS26	Henner unserm Haus stäin drei Ebbelbämelcher mit roure Ebbelcher.
 WS27	Kinn èhr nitt en Ägeblickel uf uns warde, dann gäin mèhr ach mireich.
 WS28	Èhr därfen nitt sŏu Kennerei treiwe.
 WS29	Unsere Berge sinn nitt arg hŏuch eier sinn vèl höicher.
 WS30	Wie vèl Pfund Wohrscht un wie vèl Broud wenn èhr haun.
 WS31	Ich v’steh eich nett, èhr missen e Bissel laurer blaurern.
-WS32	Henn èhr kän Schtickel weißi Säf ěf meim Disch ferr mich g’funne.
+WS32	Henn èhr kän Schtickel weißi Säf ĕf meim Disch ferr mich g’funne.
 WS33	Sein Brurer will sich zwä schäine neie Häuser in eierm Gahrde baue.
 WS34	Das Wort kummt’m vum Herze.
 WS35	Deß war recht vun ihne.
-WS36	Was sitzen dart vér Vögelcher dě owe uf m Mäuerle.
-WS37	Die Bauern hänn finf Ochse un nein Kih un zwelf Schöflich vors Dorf g’braht, die wollden sě věkäfe.
+WS36	Was sitzen dart vér Vögelcher dĕ owe uf m Mäuerle.
+WS37	Die Bauern hänn finf Ochse un nein Kih un zwelf Schöflich vors Dorf g’braht, die wollden sĕ vĕkäfe.
 WS38	Die Leid sinn heit all drauß uf’m Feld un mèhen.
-WS39	Gèh numme d’braune Hund dud děr nix
+WS39	Gèh numme d’braune Hund dud dĕr nix
 WS40	Ich bän mit d’Leid dohenne iwer d’Wiß ins Karn g’fahrn.

--- a/31705_Edesheim.csv
+++ b/31705_Edesheim.csv
@@ -12,8 +12,8 @@ WS01	M’Wender fliegen die trockene Blerrer in dě Luft rum.
 WS02	S’hert gleich uf sě schneiche, dann werd’s Werrer wirrer besser.
 WS03	Du Koule en dě Ouwe, daß d’Millich ball sě koche anfangt.
 WS04	D’goure alte Mann esch mirem Perd ens Eis gebrahe un ens kalde Wasser g’falle
-WS05	Er esch vor vier ǒrer sechs Woche g’schdorwe.
-WS06	S Feiěr war sǒu schdark, d Kuge sinn jo unne ganz schwarz g’brennt.
+WS05	Er esch vor vier ŏrer sechs Woche g’schdorwe.
+WS06	S Feiěr war sŏu schdark, d Kuge sinn jo unne ganz schwarz g’brennt.
 WS07	Er ißt d’Eier immer uhne Salz und Peffer.
 WS08	D’Fiß dien měr arg weh, ich gläb, ich häb sě durch g’loffe.
 WS09	Ich ben bei d’Frä g’weßt, un häwers g’sagt un sie hot g’sagt, sie wills ach èhrer Dachtér sagé
@@ -23,11 +23,11 @@ WS12	Wu gèschd n’anne, selle mèhr mit děr gäi
 WS13	Sinn schlechde Zeire.
 WS14	Mei liebs Kénd bleib do unne stäi, d’bäise Gäns beißen dich doud.
 WS15	Du hoscht heit am menschde g’lernt, un beschd ardig gwéßt, du derfschd èder häm gäi, als d’annern.
-WS16	Du beschd noch nitt grǒuß génunk fere Flasch Wein aus sě drinke, du muscht èrscht nah ä bissel wachse un gräißer wérn.
-WS17	Geh, sei sǒu gud un sag deiner Schweschder, sie sell d’Klärer fér eire Mudder férdig nèhe, un mit d’Bérschd sauwer mache
+WS16	Du beschd noch nitt grŏuß génunk fere Flasch Wein aus sě drinke, du muscht èrscht nah ä bissel wachse un gräißer wérn.
+WS17	Geh, sei sŏu gud un sag deiner Schweschder, sie sell d’Klärer fér eire Mudder férdig nèhe, un mit d’Bérschd sauwer mache
 WS18	Héschd dun g’kennt, dann wèrs annerscht kumme, un es dèt besser mirrem stäi.
 WS19	Wer hot mèhr mein Karb mit Fläsch gstohle.
-WS20	Er dut sǒu als héren senn zum Dresche beschteld, sie heims awer seliwer g’daun
+WS20	Er dut sŏu als héren senn zum Dresche beschteld, sie heims awer seliwer g’daun
 WS21	Wèm horer d’Gschicht vězäild.
 WS22	Měr muß laut kreische sunschd verstèhrer uns nitt.
 WS23	Mèhr sinn mied un hänn Dohrscht
@@ -35,8 +35,8 @@ WS24	Als mehr geschdert Owend sèrick kumme sinn, do sinn d’annern schun em Be
 WS25	Dě Schnee esch heidt Nagt bei uns lige gěblewe, awer dMorge esch r gschmolze.
 WS26	Henner unserm Haus stäin drei Ebbelbämelcher mit roure Ebbelcher.
 WS27	Kinn èhr nitt en Ägeblickel uf uns warde, dann gäin mèhr ach mireich.
-WS28	Èhr därfen nitt sǒu Kennerei treiwe.
-WS29	Unsere Berge sinn nitt arg hǒuch eier sinn vèl höicher.
+WS28	Èhr därfen nitt sŏu Kennerei treiwe.
+WS29	Unsere Berge sinn nitt arg hŏuch eier sinn vèl höicher.
 WS30	Wie vèl Pfund Wohrscht un wie vèl Broud wenn èhr haun.
 WS31	Ich v’steh eich nett, èhr missen e Bissel laurer blaurern.
 WS32	Henn èhr kän Schtickel weißi Säf ěf meim Disch ferr mich g’funne.

--- a/31709_Maikammer.csv
+++ b/31709_Maikammer.csv
@@ -16,7 +16,7 @@ WS05	Er esch vor vier orrer sechs Woche gestorwe.
 WS06	S’ Feier war sou schtark, die Kuche sin jo unne ganz schwarz gebrennt.
 WS07	Er ißt die Eier immer une Salz un Peffer.
 WS08	D’Füß dun mer sou weh, ich glab ich häb se durchgeloffe.
-WS09	Ich běn bei der Fraa gewest un häb s er gsaht un sie hot gsat, si will’s ehrer Dochter aach sage.
+WS09	Ich bĕn bei der Fraa gewest un häb s er gsaht un sie hot gsat, si will’s ehrer Dochter aach sage.
 WS10	Ich will’s aach nimi wirer du’n.
 WS11	Ich schlack dich glei mit’m Kochlöffel um die Ohre, du Aff’.
 WS12	Wu gescht hin̰, solle m’r mit d’r gehn̰?

--- a/31719_Geinsheim.csv
+++ b/31719_Geinsheim.csv
@@ -17,17 +17,17 @@ WS06	Das Feuer war so stark, die Kuhche sinn jo unne ganz schwarz gebrennt.
 WS07	Er ißt die Eier immer uhne Salz unn Peffer.
 WS08	Die Füß dun mer sehr <(arg)> weh’, ich glab, ich habb se dorchgeloffe.
 WS09	Ich binn bei der Fra gewest unn habb’s ehr gsagd, unn sie sagd, sie wöllts ach ihrer Dochder sage.
-WS10	Ich wills ach net widder daun̆.
+WS10	Ich wills ach net widder dauň.
 WS11	Ich schlagg dich gleich mit’m Kochlöffl um d’Ohre, du Aff!
-WS12	Wu gehscht du hin̆, söll’n mer mit dehr geh’?
+WS12	Wu gehscht du hiň, söll’n mer mit dehr geh’?
 WS13	S’ sinn schlechte Zeite!
 WS14	Mei’ lieb Kind, bleib hie unnen steh, die böse Gäns beißen dich doud.
 WS15	Du hoschst heut’ am menschte gelernt u. bischt ardig gewest, du derfst früher nach Haus gehe (Hem geh) als die Annere.
 WS16	Du bischt noch net grouß genung, um̄ e Flasch’ Wein ausetrinke, du muscht erscht noch ebbes wachse und größer were.
 WS17	Geh sei so gut und sag deiner Schweschter, sie söll d’ Kleder für euer Mudder ferdig nähe unn mit d’r Berscht rein (sauber) machen.
 WS18	Häscht du ihn gekannt, dann wär’s anerscht kumme, unn es dät besser umm ihn stehe. 
-WS19	Wer hott mer mein̆ Korb mit Fläsch gestohle?
-WS20	Er hat so gedaun̆, als hänn se ihn zum Dreschen b’stellt; sie häm’s aber selbst gedaun̆.
+WS19	Wer hott mer meiň Korb mit Fläsch gestohle?
+WS20	Er hat so gedauň, als hänn se ihn zum Dreschen b’stellt; sie häm’s aber selbst gedauň.
 WS21	Wem hodd’er die neu G’schicht verzählt?
 WS22	Mann muß laut kreische, sunnscht versteht er uns net.
 WS23	Mer sinn müd unn hänn Dorscht.
@@ -40,11 +40,11 @@ WS29	Unser Berk sinn net arg hoch, euri sinn viel höcher.
 WS30	Wieviel Pund Worscht und wie viel Broud wenn ehr habbe.
 WS31	Ich versteh euch nett, ehr mussn e bissel lauter plaudere.
 WS32	Henn ehr ke Stückel weißi Säf ferr mich uff mein’m Disch gfunne?
-WS33	Sein̆ Brudr will sich zwä schöin̆e naie Häuser in eurem Garde baue.
+WS33	Seiň Brudr will sich zwä schöiňe naie Häuser in eurem Garde baue.
 WS34	Das Wordd isch ihm vunn Herze kumme!
 WS35	Dös war recht vunn ihne!
 WS36	Was sitzen do ferr Vöhelcher obbe uff’m Mäuerle?
-WS37	Die Bauere henn fünf Ochse unn neun̆ Küh unn zwölf Schäfelcher <(Hämmelcher)> vor’s Dorf gebrohcht, die wenn se verkaafe.
+WS37	Die Bauere henn fünf Ochse unn neuň Küh unn zwölf Schäfelcher <(Hämmelcher)> vor’s Dorf gebrohcht, die wenn se verkaafe.
 WS38	Die Leud sinn heut all drauß uff’m Feld unn mehen.
 WS39	Geh’ numme, de brau’ Hund dut dehr nix!
 WS40	Ich binn mit de Leut do hinne über d’ Wiß ins Korn g’fahre.

--- a/31722_Weingarten.csv
+++ b/31722_Weingarten.csv
@@ -8,28 +8,28 @@ Transliterationsprojekt: REDE
 Transliterent: Herrgen
 Anmerkungen: ''
 ...
-WS01	Im Winter fliegen die truckene Bléttěr in der Luft rum.
-WS02	Es hört gleich uf sě schneiche, dann werd’s Wéttěr widder besser.
-WS03	Duh Kouhlě in de Oufe, daß d’Milich ball sě kochě anfangt.
-WS04	D’r gut, alt Mann isch mit’m <(Pèrd)> Gaul durch’s Eis gěbrochě un in’s kalt Wasser g’fallě.
-WS05	Er isch vor vier odd’r séchs Wochě g’schtorbě.
-WS06	Déss Feuer war zu schtark, die Kugě sin jo unně ganz schwarz gěbrénnt.
-WS07	Er ißt die Eer immer uhně Salz un Péffěr.
-WS08	Die Füß’ duhn mer sèhr wèh, ich glaab, ich héb se durch gělöffě.
-WS09	Ich bin bei dèr Fra gewéßt un heb’s ěrr g’saht un sie hot gsaht, sie will ès ach ehrě Dochtěr sagě.
+WS01	Im Winter fliegen die truckene Bléttĕr in der Luft rum.
+WS02	Es hört gleich uf sĕ schneiche, dann werd’s Wéttĕr widder besser.
+WS03	Duh Kouhlĕ in de Oufe, daß d’Milich ball sĕ kochĕ anfangt.
+WS04	D’r gut, alt Mann isch mit’m <(Pèrd)> Gaul durch’s Eis gĕbrochĕ un in’s kalt Wasser g’fallĕ.
+WS05	Er isch vor vier odd’r séchs Wochĕ g’schtorbĕ.
+WS06	Déss Feuer war zu schtark, die Kugĕ sin jo unnĕ ganz schwarz gĕbrénnt.
+WS07	Er ißt die Eer immer uhnĕ Salz un Péffĕr.
+WS08	Die Füß’ duhn mer sèhr wèh, ich glaab, ich héb se durch gĕlöffĕ.
+WS09	Ich bin bei dèr Fra gewéßt un heb’s ĕrr g’saht un sie hot gsaht, sie will ès ach ehrĕ Dochtĕr sagĕ.
 WS10	Ich will’s ach nimmi dau.
-WS11	Ich schlach dich gleich mit’m Kochlöffěl um d’Ohre, du Aff.
+WS11	Ich schlach dich gleich mit’m Kochlöffĕl um d’Ohre, du Aff.
 WS12	Wu gehscht du hḭ, sellen m’r mit d’r gḛi.
-WS13	S’sin schléchtě Zeitě.
-WS14	Mei lieb Kind bleib hier unně stei, die böse Gäns beißěn dich dout.
-WS15	Du hoscht heud am mènschtḛ̌ gelérnt un bischt artig gěwéßt, du dèrfscht éhder <(nach Haus)> heem geḭ als die anněrě.
-WS16	Du bischt noch nét grouß génunk, um ḛ Flasch Weḭ aussědrinkě, du muscht s’érscht noch ébběs wachsě un größěr weerě.
-WS17	Géh sei so gut un sag dann’r Schwéschtěr, sie sěll die Kleeděr for euěr Mudděr fertig nähe un mit d’r Berscht rein mache.
-WS18	Hätscht du’n gěkénnt, dann wèr’s annerscht kumme un’s dèht béssěr um’n stḛi.
+WS13	S’sin schléchtĕ Zeitĕ.
+WS14	Mei lieb Kind bleib hier unnĕ stei, die böse Gäns beißĕn dich dout.
+WS15	Du hoscht heud am mènschtḛ̌ gelérnt un bischt artig gĕwéßt, du dèrfscht éhder <(nach Haus)> heem geḭ als die annĕrĕ.
+WS16	Du bischt noch nét grouß génunk, um ḛ Flasch Weḭ aussĕdrinkĕ, du muscht s’érscht noch ébbĕs wachsĕ un größĕr weerĕ.
+WS17	Géh sei so gut un sag dann’r Schwéschtĕr, sie sĕll die Kleedĕr for euĕr Muddĕr fertig nähe un mit d’r Berscht rein mache.
+WS18	Hätscht du’n gĕkénnt, dann wèr’s annerscht kumme un’s dèht béssĕr um’n stḛi.
 WS19	Wèr hot m’r mein Korb mit Fleesch gschtohle?
-WS20	Er hot so gedaṵ als héttěn s’n zum Dreschě bschtéllt, sie hěn’s awwěr sélběr gedaṵ.
-WS21	Wémm hot’r die nei G’schicht věrzeehlt?
-WS22	M’r muß laut kreischě, sunscht věrschtéht’r uns nét.
+WS20	Er hot so gedaṵ als héttĕn s’n zum Dreschĕ bschtéllt, sie hĕn’s awwĕr sélbĕr gedaṵ.
+WS21	Wémm hot’r die nei G’schicht vĕrzeehlt?
+WS22	M’r muß laut kreischĕ, sunscht vĕrschtéht’r uns nét.
 WS23	M’r sin müd un hen Dorscht.
 WS24	Als m’r geschtern Owed serickkumme <(kamen)> sin, do sin die annere schun im Bett geleche un sin fescht am Schlofe geweßt.
 WS25	D’r Schnee isch die Nacht bei uns liche gebliwe, awwer heud Morge isch’r g’schmolze.

--- a/31883_Neustadt.csv
+++ b/31883_Neustadt.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: REDE
 Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
-WS01	Im Winder fliegen die trockene’ Ble͜dder in dr Luft rum.
+WS01	Im Winder fliegen die trockene’ Ble͡dder in dr Luft rum.
 WS02	 ’s hört gleich uff zu schneige͡n, dann wird’s Wä͜dder wi͡dder besser.
 WS03	Dhu Kohle’ inde’ Offe’, daß d’Millich ba͜ll an zu͡ koche fangt.
 WS04	Der gude’ al[t]e’ Mann isch mit’m Pärd durch’s Eis gebroche unn ins kalde’ Wasser g’falle’.
@@ -25,20 +25,20 @@ WS14	Mein liebes Kind, bleib’ hier unne’ schdehn, die böse’ Gäns beiß�
 WS15	Du haschd heude am meeschde’ gelernt unn bischd ardig geweßt, du därfschd früher nach Haus <(heem)> gehen als d’Annere’.
 WS16	Du bischd noch nit groß genunk, um en Flasch Wein auszutrinke’, du muschd erschd noch ebbes wackse un größer wä͜rre’.
 WS17	Geh’, sei se’ gud unn sag deiner Schweschder, sie soll d’Kläder for eur Mudder ferdig nähe’ un mit d’r Bärscht rein mache’.
-WS18	He͜ttscht du’n gekennt! dann wers annerscht kumme’, un ‚s dehd besser um’n schdeh.
+WS18	He͡ttscht du’n gekennt! dann wers annerscht kumme’, un ‚s dehd besser um’n schdeh.
 WS19	Wer hott m’r mein Korb mit Fläsch gschdohle?
 WS20	Eer hott so geduhn, als hettn sn zum dresche’ bschdelld, sie habben <(hawen)> s awer selber gedhan.
-WS21	We͜mm hott’r die neu G’schichd verzählt?
+WS21	We͡mm hott’r die neu G’schichd verzählt?
 WS22	Märr muß laut schreien <(greische)>, sunschd veersteht’r uns nitt.
 WS23	Mir sinn müd un hawen Durschd.
-WS24	Als merr geschdert Obend <(Owend)> zurück <(redur)> kamen, do henn die Annerne’ schunn im Bett gele͜ge’ un henn feschd gschlofe’.
+WS24	Als merr geschdert Obend <(Owend)> zurück <(redur)> kamen, do henn die Annerne’ schunn im Bett gele͡ge’ un henn feschd gschlofe’.
 WS25	D’r Schnee isch heut Nacht li͡he’ gebliwe’, aber <(awer)> heut Morge’ isch’r gschmoltze’.
 WS26	Hinner unserm Haus sdehn drei schöne Abbelbämcher mit rode’ Ebbelcher.
 WS27	Kénn’r nitt noch en Ageblickche’ of uns warde, dann gehen mä͜rr mit euch.
 WS28	Ihr därft nicht solche’ Kinnereien tréiwe’.
 WS29	Unsre’ Berg sinn nitt sehr hoch, eure sinn vel höher.
 WS30	Wiev?iel Pund Worschd un wieviel Brod woll’n’r hawe’?
-WS31	Ich verschdeh euch nitt, ihr müssen en bissel lauder schbre͜che’.
+WS31	Ich verschdeh euch nitt, ihr müssen en bissel lauder schbre͡che’.
 WS32	Hab’n’r ken Schdickel Säf for mich off meim Disch gfunne’?
 WS33	Sei(n) Bruder will sich zwe neue Häuser ’n eurem Garde’ baue’.
 WS34	Das Wart isch’m vun Herze’ kumme’.

--- a/31883_Neustadt.csv
+++ b/31883_Neustadt.csv
@@ -9,12 +9,12 @@ Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
 WS01	Im Winder fliegen die trockene’ Ble͡dder in dr Luft rum.
-WS02	 ’s hört gleich uff zu schneige͡n, dann wird’s Wä͜dder wi͡dder besser.
-WS03	Dhu Kohle’ inde’ Offe’, daß d’Millich ba͜ll an zu͡ koche fangt.
+WS02	 ’s hört gleich uff zu schneige͡n, dann wird’s Wä͡dder wi͡dder besser.
+WS03	Dhu Kohle’ inde’ Offe’, daß d’Millich ba͡ll an zu͡ koche fangt.
 WS04	Der gude’ al[t]e’ Mann isch mit’m Pärd durch’s Eis gebroche unn ins kalde’ Wasser g’falle’.
 WS05	Er isch vor vier o͡dder sechs Woche’ g’storwe.
 WS06	’s Feuer war ze’ stark, d’Kuge’ sinn jo unne’ ganz schwarz gebrennt.
-WS07	Er ißt d’Eier immer uhne’ Salz und Pä͜ffer.
+WS07	Er ißt d’Eier immer uhne’ Salz und Pä͡ffer.
 WS08	D’Füß dhun m͡r weh, ich glab’ ich hab se’ durchgeloffe’.
 WS09	Ich bin ei d’r Frau geweßt unn hab’sr gsagd, unn sie sagde’, sie wollde’ es ach ihrer Dochder sage’.
 WS10	Ich will’s ach nimmi wi͡dder dhun!
@@ -23,7 +23,7 @@ WS12	Wu gehschd du hin, solle’ mér mit d’r géhé?
 WS13	Es sind schlächde Zeidé!
 WS14	Mein liebes Kind, bleib’ hier unne’ schdehn, die böse’ Gäns beiß’n dich dot.
 WS15	Du haschd heude am meeschde’ gelernt unn bischd ardig geweßt, du därfschd früher nach Haus <(heem)> gehen als d’Annere’.
-WS16	Du bischd noch nit groß genunk, um en Flasch Wein auszutrinke’, du muschd erschd noch ebbes wackse un größer wä͜rre’.
+WS16	Du bischd noch nit groß genunk, um en Flasch Wein auszutrinke’, du muschd erschd noch ebbes wackse un größer wä͡rre’.
 WS17	Geh’, sei se’ gud unn sag deiner Schweschder, sie soll d’Kläder for eur Mudder ferdig nähe’ un mit d’r Bärscht rein mache’.
 WS18	He͡ttscht du’n gekennt! dann wers annerscht kumme’, un ‚s dehd besser um’n schdeh.
 WS19	Wer hott m’r mein Korb mit Fläsch gschdohle?
@@ -34,7 +34,7 @@ WS23	Mir sinn müd un hawen Durschd.
 WS24	Als merr geschdert Obend <(Owend)> zurück <(redur)> kamen, do henn die Annerne’ schunn im Bett gele͡ge’ un henn feschd gschlofe’.
 WS25	D’r Schnee isch heut Nacht li͡he’ gebliwe’, aber <(awer)> heut Morge’ isch’r gschmoltze’.
 WS26	Hinner unserm Haus sdehn drei schöne Abbelbämcher mit rode’ Ebbelcher.
-WS27	Kénn’r nitt noch en Ageblickche’ of uns warde, dann gehen mä͜rr mit euch.
+WS27	Kénn’r nitt noch en Ageblickche’ of uns warde, dann gehen mä͡rr mit euch.
 WS28	Ihr därft nicht solche’ Kinnereien tréiwe’.
 WS29	Unsre’ Berg sinn nitt sehr hoch, eure sinn vel höher.
 WS30	Wiev?iel Pund Worschd un wieviel Brod woll’n’r hawe’?
@@ -43,7 +43,7 @@ WS32	Hab’n’r ken Schdickel Säf for mich off meim Disch gfunne’?
 WS33	Sei(n) Bruder will sich zwe neue Häuser ’n eurem Garde’ baue’.
 WS34	Das Wart isch’m vun Herze’ kumme’.
 WS35	Das isch rech von ihne’ geweßt.
-WS36	Was sitz’n do for Vä͜chel  o͡wn u͡ff’m Mäuerche’?
+WS36	Was sitz’n do for Vä͡chel  o͡wn u͡ff’m Mäuerche’?
 WS37	Die Bauere͡n henn fünf Okse’ unn neun Küh unn zwölf Schefelcher vor’s Dorf gebrogt, die wenn se’ verkafe’.
 WS38	Die Leud sinn heut all drauß off’m Féld unn mehen.
 WS39	Geh numme’, der braun Hund dhud’r nicks.

--- a/31883_Neustadt.csv
+++ b/31883_Neustadt.csv
@@ -12,7 +12,7 @@ WS01	Im Winder fliegen die trockene’ Ble͜dder in dr Luft rum.
 WS02	 ’s hört gleich uff zu schneige͡n, dann wird’s Wä͜dder wi͜dder besser.
 WS03	Dhu Kohle’ inde’ Offe’, daß d’Millich ba͜ll an zu͡ koche fangt.
 WS04	Der gude’ al[t]e’ Mann isch mit’m Pärd durch’s Eis gebroche unn ins kalde’ Wasser g’falle’.
-WS05	Er isch vor vier o͜dder sechs Woche’ g’storwe.
+WS05	Er isch vor vier o͡dder sechs Woche’ g’storwe.
 WS06	’s Feuer war ze’ stark, d’Kuge’ sinn jo unne’ ganz schwarz gebrennt.
 WS07	Er ißt d’Eier immer uhne’ Salz und Pä͜ffer.
 WS08	D’Füß dhun m͡r weh, ich glab’ ich hab se’ durchgeloffe’.
@@ -43,7 +43,7 @@ WS32	Hab’n’r ken Schdickel Säf for mich off meim Disch gfunne’?
 WS33	Sei(n) Bruder will sich zwe neue Häuser ’n eurem Garde’ baue’.
 WS34	Das Wart isch’m vun Herze’ kumme’.
 WS35	Das isch rech von ihne’ geweßt.
-WS36	Was sitz’n do for Vä͜chel  o͜wn u͡ff’m Mäuerche’?
+WS36	Was sitz’n do for Vä͜chel  o͡wn u͡ff’m Mäuerche’?
 WS37	Die Bauere͡n henn fünf Okse’ unn neun Küh unn zwölf Schefelcher vor’s Dorf gebrogt, die wenn se’ verkafe’.
 WS38	Die Leud sinn heut all drauß off’m Féld unn mehen.
 WS39	Geh numme’, der braun Hund dhud’r nicks.

--- a/31883_Neustadt.csv
+++ b/31883_Neustadt.csv
@@ -9,7 +9,7 @@ Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
 WS01	Im Winder fliegen die trockene’ Ble͜dder in dr Luft rum.
-WS02	 ’s hört gleich uff zu schneige͡n, dann wird’s Wä͜dder wi͜dder besser.
+WS02	 ’s hört gleich uff zu schneige͡n, dann wird’s Wä͜dder wi͡dder besser.
 WS03	Dhu Kohle’ inde’ Offe’, daß d’Millich ba͜ll an zu͡ koche fangt.
 WS04	Der gude’ al[t]e’ Mann isch mit’m Pärd durch’s Eis gebroche unn ins kalde’ Wasser g’falle’.
 WS05	Er isch vor vier o͡dder sechs Woche’ g’storwe.
@@ -17,7 +17,7 @@ WS06	’s Feuer war ze’ stark, d’Kuge’ sinn jo unne’ ganz schwarz gebren
 WS07	Er ißt d’Eier immer uhne’ Salz und Pä͜ffer.
 WS08	D’Füß dhun m͡r weh, ich glab’ ich hab se’ durchgeloffe’.
 WS09	Ich bin ei d’r Frau geweßt unn hab’sr gsagd, unn sie sagde’, sie wollde’ es ach ihrer Dochder sage’.
-WS10	Ich will’s ach nimmi wi͜dder dhun!
+WS10	Ich will’s ach nimmi wi͡dder dhun!
 WS11	Ich schlag dich glai mit’m Kochleffel um d’Ohra, du Aff!
 WS12	Wu gehschd du hin, solle’ mér mit d’r géhé?
 WS13	Es sind schlächde Zeidé!
@@ -32,7 +32,7 @@ WS21	We͜mm hott’r die neu G’schichd verzählt?
 WS22	Märr muß laut schreien <(greische)>, sunschd veersteht’r uns nitt.
 WS23	Mir sinn müd un hawen Durschd.
 WS24	Als merr geschdert Obend <(Owend)> zurück <(redur)> kamen, do henn die Annerne’ schunn im Bett gele͜ge’ un henn feschd gschlofe’.
-WS25	D’r Schnee isch heut Nacht li͜he’ gebliwe’, aber <(awer)> heut Morge’ isch’r gschmoltze’.
+WS25	D’r Schnee isch heut Nacht li͡he’ gebliwe’, aber <(awer)> heut Morge’ isch’r gschmoltze’.
 WS26	Hinner unserm Haus sdehn drei schöne Abbelbämcher mit rode’ Ebbelcher.
 WS27	Kénn’r nitt noch en Ageblickche’ of uns warde, dann gehen mä͜rr mit euch.
 WS28	Ihr därft nicht solche’ Kinnereien tréiwe’.

--- a/31883_Neustadt.csv
+++ b/31883_Neustadt.csv
@@ -43,8 +43,8 @@ WS32	Hab’n’r ken Schdickel Säf for mich off meim Disch gfunne’?
 WS33	Sei(n) Bruder will sich zwe neue Häuser ’n eurem Garde’ baue’.
 WS34	Das Wart isch’m vun Herze’ kumme’.
 WS35	Das isch rech von ihne’ geweßt.
-WS36	Was sitz’n do for Vä͜chel  o͜wn u͜ff’m Mäuerche’?
+WS36	Was sitz’n do for Vä͜chel  o͜wn u͡ff’m Mäuerche’?
 WS37	Die Bauere͡n henn fünf Okse’ unn neun Küh unn zwölf Schefelcher vor’s Dorf gebrogt, die wenn se’ verkafe’.
 WS38	Die Leud sinn heut all drauß off’m Féld unn mehen.
 WS39	Geh numme’, der braun Hund dhud’r nicks.
-WS40	Ich bin mit de’ Leut do hinne’ ü͜wer d’wiß ins Korn gfahre’.
+WS40	Ich bin mit de’ Leut do hinne’ ü͡wer d’wiß ins Korn gfahre’.

--- a/31887_Ruppertsberg.csv
+++ b/31887_Ruppertsberg.csv
@@ -11,12 +11,12 @@ Anmerkungen: ''
 WS01	Im Winder fliegen die druggene Bléder <(Blerer=Zungen=r)> in d’r Luft rum.
 WS02	’s hèrt glei uff se schneige, dann werds Wädder wider besser.
 WS03	Du Koule in de Ouwe, daß die Milich bal se koche añfangt.
-WS04	Der gut alt Mann isch mit dem Gaul dorchs Eis gebrǒche un isch in des kalt Wasser gfalle.
-WS05	Ǎr isch vǒr vier ǒder sechs Woche gschdorwe.
+WS04	Der gut alt Mann isch mit dem Gaul dorchs Eis gebrŏche un isch in des kalt Wasser gfalle.
+WS05	Ǎr isch vŏr vier ŏder sechs Woche gschdorwe.
 WS06	s Feier isch so stark gewäßt, die Kuuche sin jo unne ganz schwarz verbrennt.
 WS07	Ǎr ißt die Eier jedesmool uune Salz un Päffer.
 WS08	Die Fiiß duñ mr aarig wèh, ich glaab, ich hǎb se dorchgeloffe.
-WS09	Ich bin bei dääre Fraa gewäßt un hǎbs ǎr gsagt, un sie hǒt gesagt, sie wéll’s ehrer Dochter ǎch sage.
+WS09	Ich bin bei dääre Fraa gewäßt un hǎbs ǎr gsagt, un sie hŏt gesagt, sie wéll’s ehrer Dochter ǎch sage.
 WS10	Ich will’s ach nimmii duuñ.
 WS11	I schlǎg dr gleich mit dem Kochleffel um die Ohre, du Aff!
 WS12	Wu gehsch’n hiñ, sellemer mit dr gähñ?
@@ -28,7 +28,7 @@ WS17	Geh un sag deiner Schwechter, sie sell die Kläder for eier Mudder fertig n
 WS18	Hescht duä̌n gekennt! dann wär’s annerscht ’kumme un s däät bésser mit(r)m stähñ
 WS19	Wäär hott mèr mein Korb mit Flääsch gschdohle?
 WS20	Ǎr dut so, wie wann ’s’n zum Dresche bschtellt hèttn; sie hänns awer sälwer gedañ.
-WS21	Wä̌m hǒt ǎr dann die nei Gschicht verzèhlt?
+WS21	Wä̌m hŏt ǎr dann die nei Gschicht verzèhlt?
 WS22	Mǎr muß laut kreische, schunscht verschteht ǎr uns nit.
 WS23	Mǎr sin miid un hän Do(r)scht.
 WS24	Wie mr geschter owend’s hääm kumme sin, do hän die annere schun im Bett gelä̌ge un hän fescht gschloofe.
@@ -43,7 +43,7 @@ WS32	Häner kä Schdickl weißi Säf vor mich uf meim Disch gfunne?
 WS33	Seiñ Brud(r)er will sich zwä schäne neie Heiser in eierm Gaarde baue.
 WS34	Deß Wo(r)t ischm vum Herze kumme.
 WS35	Deß war ganz recht vunnen.
-WS36	Wǎs vor Véglcher sitzen dann do ǒwe uf dem Meierle?
+WS36	Wǎs vor Véglcher sitzen dann do ŏwe uf dem Meierle?
 WS37	Die Baure hän finf Ochse un neiñ Kih un zwelf Hämmelcher vors Dorf gebroocht, die hän se welle verkaafe.
 WS38	Die Leit sin heit all drauß im Feld und mehen.
 WS39	Geh norre, der brauñ Hund duuder nix.

--- a/31887_Ruppertsberg.csv
+++ b/31887_Ruppertsberg.csv
@@ -12,9 +12,9 @@ WS01	Im Winder fliegen die druggene Bléder <(Blerer=Zungen=r)> in d’r Luft ru
 WS02	’s hèrt glei uff se schneige, dann werds Wädder wider besser.
 WS03	Du Koule in de Ouwe, daß die Milich bal se koche añfangt.
 WS04	Der gut alt Mann isch mit dem Gaul dorchs Eis gebrŏche un isch in des kalt Wasser gfalle.
-WS05	Ǎr isch vŏr vier ŏder sechs Woche gschdorwe.
+WS05	Ăr isch vŏr vier ŏder sechs Woche gschdorwe.
 WS06	s Feier isch so stark gewäßt, die Kuuche sin jo unne ganz schwarz verbrennt.
-WS07	Ǎr ißt die Eier jedesmool uune Salz un Päffer.
+WS07	Ăr ißt die Eier jedesmool uune Salz un Päffer.
 WS08	Die Fiiß duñ mr aarig wèh, ich glaab, ich hăb se dorchgeloffe.
 WS09	Ich bin bei dääre Fraa gewäßt un hăbs ăr gsagt, un sie hŏt gesagt, sie wéll’s ehrer Dochter ăch sage.
 WS10	Ich will’s ach nimmii duuñ.
@@ -27,7 +27,7 @@ WS16	Du bisch no ni(t) grouß genunk vär ä Flasch Weiñ aussetrinke, du musch 
 WS17	Geh un sag deiner Schwechter, sie sell die Kläder for eier Mudder fertig nehe un mit der Bäřscht sauwer mache.
 WS18	Hescht duä̌n gekennt! dann wär’s annerscht ’kumme un s däät bésser mit(r)m stähñ
 WS19	Wäär hott mèr mein Korb mit Flääsch gschdohle?
-WS20	Ǎr dut so, wie wann ’s’n zum Dresche bschtellt hèttn; sie hänns awer sälwer gedañ.
+WS20	Ăr dut so, wie wann ’s’n zum Dresche bschtellt hèttn; sie hänns awer sälwer gedañ.
 WS21	Wä̌m hŏt ăr dann die nei Gschicht verzèhlt?
 WS22	Măr muß laut kreische, schunscht verschteht ăr uns nit.
 WS23	Măr sin miid un hän Do(r)scht.

--- a/31887_Ruppertsberg.csv
+++ b/31887_Ruppertsberg.csv
@@ -37,7 +37,7 @@ WS26	Hinnich unserem Haus stehn drei schäne Ebbelbämcher mit roud(r)e Ebblcher
 WS27	Kinnener nit noch ä klääñ bißl uf uns waarte, not gehñ mr midich.
 WS28	Ehr därfen käñ so kinnische Sache mache.
 WS29	Unser Berge sin nit aarig houch, eire sin viel hècher.
-WS30	Wieviel Pund Woscht un wieviel Broud wän ěr dann hǎwe?
+WS30	Wieviel Pund Woscht un wieviel Broud wän ĕr dann hǎwe?
 WS31	Ich verschdeh eich nit, ehr mißn ä bißl lauder plaudere.
 WS32	Häner kä Schdickl weißi Säf vor mich uf meim Disch gfunne?
 WS33	Seiñ Brud(r)er will sich zwä schäne neie Heiser in eierm Gaarde baue.

--- a/31887_Ruppertsberg.csv
+++ b/31887_Ruppertsberg.csv
@@ -15,10 +15,10 @@ WS04	Der gut alt Mann isch mit dem Gaul dorchs Eis gebrŏche un isch in des kalt
 WS05	Ǎr isch vŏr vier ŏder sechs Woche gschdorwe.
 WS06	s Feier isch so stark gewäßt, die Kuuche sin jo unne ganz schwarz verbrennt.
 WS07	Ǎr ißt die Eier jedesmool uune Salz un Päffer.
-WS08	Die Fiiß duñ mr aarig wèh, ich glaab, ich hǎb se dorchgeloffe.
-WS09	Ich bin bei dääre Fraa gewäßt un hǎbs ǎr gsagt, un sie hŏt gesagt, sie wéll’s ehrer Dochter ǎch sage.
+WS08	Die Fiiß duñ mr aarig wèh, ich glaab, ich hăb se dorchgeloffe.
+WS09	Ich bin bei dääre Fraa gewäßt un hăbs ăr gsagt, un sie hŏt gesagt, sie wéll’s ehrer Dochter ăch sage.
 WS10	Ich will’s ach nimmii duuñ.
-WS11	I schlǎg dr gleich mit dem Kochleffel um die Ohre, du Aff!
+WS11	I schlăg dr gleich mit dem Kochleffel um die Ohre, du Aff!
 WS12	Wu gehsch’n hiñ, sellemer mit dr gähñ?
 WS13	’s sinn schlächte Zeide!
 WS14	Bleib do unne stähñ, Kind, die bèse Gäns beißen dich doud.
@@ -28,22 +28,22 @@ WS17	Geh un sag deiner Schwechter, sie sell die Kläder for eier Mudder fertig n
 WS18	Hescht duä̌n gekennt! dann wär’s annerscht ’kumme un s däät bésser mit(r)m stähñ
 WS19	Wäär hott mèr mein Korb mit Flääsch gschdohle?
 WS20	Ǎr dut so, wie wann ’s’n zum Dresche bschtellt hèttn; sie hänns awer sälwer gedañ.
-WS21	Wä̌m hŏt ǎr dann die nei Gschicht verzèhlt?
-WS22	Mǎr muß laut kreische, schunscht verschteht ǎr uns nit.
-WS23	Mǎr sin miid un hän Do(r)scht.
+WS21	Wä̌m hŏt ăr dann die nei Gschicht verzèhlt?
+WS22	Măr muß laut kreische, schunscht verschteht ăr uns nit.
+WS23	Măr sin miid un hän Do(r)scht.
 WS24	Wie mr geschter owend’s hääm kumme sin, do hän die annere schun im Bett gelä̌ge un hän fescht gschloofe.
-WS25	Dr Schnee isch heit Nacht bei uns lǐge blǐwe, heit Morge isch’r ǎwer wǐder vergange.
+WS25	Dr Schnee isch heit Nacht bei uns lǐge blǐwe, heit Morge isch’r ăwer wǐder vergange.
 WS26	Hinnich unserem Haus stehn drei schäne Ebbelbämcher mit roud(r)e Ebblcher.
 WS27	Kinnener nit noch ä klääñ bißl uf uns waarte, not gehñ mr midich.
 WS28	Ehr därfen käñ so kinnische Sache mache.
 WS29	Unser Berge sin nit aarig houch, eire sin viel hècher.
-WS30	Wieviel Pund Woscht un wieviel Broud wän ĕr dann hǎwe?
+WS30	Wieviel Pund Woscht un wieviel Broud wän ĕr dann hăwe?
 WS31	Ich verschdeh eich nit, ehr mißn ä bißl lauder plaudere.
 WS32	Häner kä Schdickl weißi Säf vor mich uf meim Disch gfunne?
 WS33	Seiñ Brud(r)er will sich zwä schäne neie Heiser in eierm Gaarde baue.
 WS34	Deß Wo(r)t ischm vum Herze kumme.
 WS35	Deß war ganz recht vunnen.
-WS36	Wǎs vor Véglcher sitzen dann do ŏwe uf dem Meierle?
+WS36	Wăs vor Véglcher sitzen dann do ŏwe uf dem Meierle?
 WS37	Die Baure hän finf Ochse un neiñ Kih un zwelf Hämmelcher vors Dorf gebroocht, die hän se welle verkaafe.
 WS38	Die Leit sin heit all drauß im Feld und mehen.
 WS39	Geh norre, der brauñ Hund duuder nix.

--- a/31889_Meckenheim.csv
+++ b/31889_Meckenheim.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: REDE
 Transliterent: Herrgen
 Anmerkungen: ''
 ...
-WS01	Im Winder fliejen die truckne Ble̖rer in d’Luft rum.
+WS01	Im Winder fliejen die truckne Blè̱rer in d’Luft rum.
 WS02	s hört gleich uff s schneḭche, do werd’s werer besser.
 WS03	Duh Koule in d’e O̰uwe, daß die Milich ball se̗ koche̗’ anfangt.
 WS04	Der gut alt Mann isch mit dem Gaul do̰richs Eis gebroche̗ unn ins kalt Wasser gfalle̗
 WS05	Er isch vo̰r vier orer sechs Woche̗ gstorwe̗.
 WS06	s Feuer war zu stark, die Kuche̗ sinn’ jo unne̗ ganz schwarz gebrennt.
 WS07	Er ißt die A̰ier immer uhne Salz unn Pfeffer.
-WS08	Die Füß tun měr sou we̖h, ich glab ich häb se̗ dorch geloffe̗
+WS08	Die Füß tun mĕr sou wèh, ich glab ich häb se̗ dorch geloffe̗
 WS09	Ich binn bei der Fraa gewest unn häb’s ’r g’saaht, unn sie hott gsaaht, sie wills ihre Tochter aach sage.
 WS10	Ich wills ach nimmi thau <(dhau)>
 WS11	Ich schlack dr glei mim Kochlöffel uff die Oohre, du Aff.
 WS12	Wuu geehscht’ n hier sellen mir mit dr gehi?
 WS13	Es sinn schlechte Zeire.
 WS14	Meḭ liewes Kind, bleib do unne stäh, die böse Gäns beisen dich doot.
-WS15	Du hoscht heut am määnschte g’lernt unn bischt andlich ge̗wě̗st, du derfscht eder hem gehe als die Anněrě.
-WS16	Du bischt noch net groß genung, daßte’ Flasch Wei austrinke kannscht, du muscht noch serscht wachse̗ unn größer weerě.
+WS15	Du hoscht heut am määnschte g’lernt unn bischt andlich ge̗wĕ̗st, du derfscht eder hem gehe als die Annĕrĕ.
+WS16	Du bischt noch net groß genung, daßte’ Flasch Wei austrinke kannscht, du muscht noch serscht wachse̗ unn größer weerĕ.
 WS17	Geeh, sei so gut unn saag deiner Schweschter, sie soll die Kleerer for eure̗ Mutter fertig mache unn mit derr Berscht rei mache.
 WS18	Hescht du ihn gekennt, dann wärs annerscht kumme unn es däht besser um ihn stähi.
-WS19	Wer hott mě̗rr meḭ Korb voll Flääsch gstohle?
+WS19	Wer hott mĕ̗rr meḭ Korb voll Flääsch gstohle?
 WS20	Er hott sou g’dau as wannsn zum Dresche bschstellt he̗rre̗n awer sie henns selber g’dau.
 WS21	Wem horrer dann die nei Gschicht verzeehlt?
-WS22	Meer muß laut greische schunscht vě̖steeht er unns nett.
+WS22	Meer muß laut greische schunscht vĕ̖steeht er unns nett.
 WS23	Meer sinn müd unn hann Dorscht.
-WS24	Wieměr geschterd Owerd häm kumme sinn, do waren die Anněrě schunn im Bett gelääje unn henn fescht g’schloofe.
+WS24	Wiemĕr geschterd Owerd häm kumme sinn, do waren die Annĕrĕ schunn im Bett gelääje unn henn fescht g’schloofe.
 WS25	De’ Schnee isch heunt Naacht bai uns liehje gebliewwe awer hait Morje isch’r vergange.
 WS26	Hinner unserem Haus steh’n drei schöine Appelböhmillcher mit rourer Ep’lcher.
 WS27	Kenn ehr nett noch’n Aageblick uff uns warte d’nod geh mer mirrich.
-WS28	Ehr derfen nett solgě̗ Kinnerei dreiwe.
+WS28	Ehr derfen nett solgĕ̗ Kinnerei dreiwe.
 WS29	Unser Berje sinn nett so houch, euere sinn viel höcher.
 WS30	Wieviel Pund Worscht unn wie viel Broud wenn ehr hawe.
-WS31	Ich versteeh euch nett, ehr miss’n e bißl lauter plaudě̗rě̗.
+WS31	Ich versteeh euch nett, ehr miss’n e bißl lauter plaudĕ̗rĕ̗.
 WS32	Henn ’r ke Stück’l weißi Seef for mich uff meim Tisch g’funne?
-WS33	Seḭ Brurer will sich zwä schöině neuě Haiser in euerem Gaarte baue.
-WS34	Deß Wort  isch’m vumm Herzě kummě
+WS33	Seḭ Brurer will sich zwä schöinĕ neuĕ Haiser in euerem Gaarte baue.
+WS34	Deß Wort  isch’m vumm Herzĕ kummĕ
 WS35	Deß war recht vunn iihne.
-WS36	Was hocken do vor Vögl owě uff’m Mäuerlě.
-WS37	Di Bauerě henn finf Ochsě unn neḭ Küh unn zwelf Schöflcher vorrs Dorf gebroogt unn henn sě wellě věaafě.
+WS36	Was hocken do vor Vögl owĕ uff’m Mäuerlĕ.
+WS37	Di Bauerĕ henn finf Ochsĕ unn neḭ Küh unn zwelf Schöflcher vorrs Dorf gebroogt unn henn sĕ wellĕ vĕaafĕ.
 WS38	Die Leit sinn heit all drauß uffm Feld unn meejen.
 WS39	Geh norre, der Braṵ Hund duhder nix.
-WS40	Ich bin mit denně Leit do hinně iwer die Wiß ins Korn g’fahre.
+WS40	Ich bin mit dennĕ Leit do hinnĕ iwer die Wiß ins Korn g’fahre.

--- a/31954_Hargarten.csv
+++ b/31954_Hargarten.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	Öm Wönder flöijn de dröcken Blehder ön der Loft erröm
 WS02	Ed leßd hordig n(oa)h se schneidn, da göfd ded Wähder n(öä)hs besser.
-WS03	Leh Kolln ön d’n Uěwen, ded de Möllig hordig afängt se kochn.
+WS03	Leh Kolln ön d’n Uĕwen, ded de Möllig hordig afängt se kochn.
 WS04	De goud’n ald’n Mann öß möd seim Pär dorichd Eis gebroch’,on öß önd kald Wasser gefall.
 WS05	Ön öß fir v(öi)r oder sechs Woch’n gestorf.
 WS06	Et Feier w(oa)r se h(öä)hs, de Kouchen öß önn ganz schwarz verbrannt.
@@ -18,7 +18,7 @@ WS07	Ön ößd sein Äier ömmer (ou)hn’n Salz on (oa)hn’n Gewiehrz.
 WS08	De Föihs döi’ mir greilich weh, ich gl(öä)f, ich hamm r se off gelahf.
 WS09	Ich w(oa)r bei dr Fra on hann’rt gesahd, on se hät gesahd se geht hirem Medchen et och sah’n.
 WS10	Ich wöll’d och sei Läw’n nömm’eh döin.
-WS11	Ich schlehn d’r de Breileffel öm d’ Uěren, dau Aff.
+WS11	Ich schlehn d’r de Breileffel öm d’ Uĕren, dau Aff.
 WS12	Wo geschde hinn, soll’m’r möt dr gehn?
 WS13	Öt sönn schlecht Zeid’n.
 WS14	Mei löif Könd bleif hei önn’n stehn, soß beiß’n döi bös Gäns deich d(ou)d.
@@ -29,12 +29,12 @@ WS18	Hätscht dau ä kannt, dann wär’et aneschd’r möt’m komm, onn et geh
 WS19	Wenn hät m’r mei’ Korf mötd’m Fläösch gestuhl.
 WS20	En hät ged(oo)hn, es we wann s’n zoum Dreschen bestald hätt’n; se hannt ewer selwer ged(oa)hn
 WS21	Wemm hät’n dat nau Stöckelchen verziehelt
-WS22	M’r moß hart kr(äö)sch’n, soß versteht ěrěs nöt.
+WS22	M’r moß hart kr(äö)sch’n, soß versteht ĕrĕs nöt.
 WS23	M’r sönn möid on hann Duscht.
 WS24	We m’r gescht’r (Oa)wnd h(äö)m komm sönn, dou h(oa)tt’n däi Ann’rn schonn alle gar’n öm Bett geleh’ on hann fescht g’schl(oa)hf
 WS25	De Schnöö öß diß Naht bei us leih’n blief, on haut Morrj öß’n verschmölzt.
 WS26	Hönn’r us’m Haus stehn drei schön’r Äppelbämcher, döi hann rod Äppelcher an.
-WS27	Könnt d’r noch’n (Äö)eblöck owwěs wahrd’n da gehm’r möt ich.
+WS27	Könnt d’r noch’n (Äö)eblöck owwĕs wahrd’n da gehm’r möt ich.
 WS28	D’r derft k(äö)n so Könnerdöngertreiw’n
 WS29	Us Bärig sönnöt eso hehch, eier sön vill hehch’r.
 WS30	Wivill Pont Worrscht on wivill Pont Brod wölld’r hann.

--- a/32008_Rehweiler.csv
+++ b/32008_Rehweiler.csv
@@ -10,28 +10,28 @@ Anmerkungen: ''
 ...
 WS01	Im Winder fliie die drockene Blä̌rrer in der Luft erum.
 WS02	’s hört gleich uff se schneire, dann werd’s Wärrer besser.
-WS03	Du Kohle in de Owě, daß dieMilch ball anfangt se koche.
+WS03	Du Kohle in de Owĕ, daß dieMilch ball anfangt se koche.
 WS04	Der gud alt Mann is mett dem Pärd darchs Eis gebroch unn ins kalt Wasser gefall.
 WS05	Er is vor vier oder sechs Wuche geschtarb.
 WS06	Daß Feier war so schdärk, die Kuche sinn jo unne ganz schwarz gebrännd.
 WS07	Er äßt die Eier immer ohne Salz unn Päffer.
 WS08	Die Füß dun meer so weh, ich gläb, eich hänn se darchgelääf.
-WS09	Eich bin bei  der Fra geween unn hanns ěr gesaat un se hat gesaat, sě wollts a ehrer Dochder saan.
+WS09	Eich bin bei  der Fra geween unn hanns ĕr gesaat un se hat gesaat, sĕ wollts a ehrer Dochder saan.
 WS10	Eich wills a nimme dun.
-WS11	Eich schlahn děr gleich met dem Kochlöffel um die Ohre, du Aff’.
-WS12	Wo geeschd dě hèn, sollě mer met děr gehn?
+WS11	Eich schlahn dĕr gleich met dem Kochlöffel um die Ohre, du Aff’.
+WS12	Wo geeschd dĕ hèn, sollĕ mer met dĕr gehn?
 WS13	Es sin schlèchte Zeite.
 WS14	Mei lieb Kind, bleib do unne schdehn,die bése Gäns’ beißen dich dot.
-WS15	Du hascht heit am meenschte gelehrt un bischt ardig geween, dě därfschd ee’nder hämgehn als die annere.
-WS16	Du bischt noch net groß genunk far ě Flasch Wein̰ aus se trinke, de muschd erscht noch wachse un groß wärre.
-WS17	Geh’ sei so gut un sah deiner Schwester, sě soll die Klärer far auer Motter fertig nähe un met děr Bärscht sauber mache.
+WS15	Du hascht heit am meenschte gelehrt un bischt ardig geween, dĕ därfschd ee’nder hämgehn als die annere.
+WS16	Du bischt noch net groß genunk far ĕ Flasch Wein̰ aus se trinke, de muschd erscht noch wachse un groß wärre.
+WS17	Geh’ sei so gut un sah deiner Schwester, sĕ soll die Klärer far auer Motter fertig nähe un met dĕr Bärscht sauber mache.
 WS18	Häscht du en ne gekinnt, dann wärsch annerscht kumm un es dät bèsser um ehne schdehn.
 WS19	Wer hat mer mei Korb met dem Fleesch geschdohl?
 WS20	Er dut so, als härrese ne zum Drèsche beschtellt, sie han es awer selbscht gedun.
 WS21	Wem hat er die nei Geschecht verzählt?
 WS22	Mer muß hart kreische, sunscht verschteht er uns net.
 WS23	Mer sin mied un han Dǎrscht.
-WS24	Wie mer gischter Owend serick kumm sin, do hǎn die Aněre schun im Bett gelèh un ware fescht am Schlofe.
+WS24	Wie mer gischter Owend serick kumm sin, do hǎn die Anĕre schun im Bett gelèh un ware fescht am Schlofe.
 WS25	Der Schnee is heint Nacht bei uns leie bleb, aber heit Morje is er geschmolz.
 WS26	Hinner unserm Haus schtehn drei scheene Äbbelbemcher mit rore Äbbelcher.
 WS27	Kinnener net noch en Ageblick uff uns waarte, dann gehn mer met auch.
@@ -41,10 +41,10 @@ WS30	Wie vel Pund Warscht un wie vel Brod wollen ehr han?
 WS31	Eich verschtehn auch net, ehr misse en̰ bißche fèschter schproche.
 WS32	Han ehr ken̰ Stickelche weiß Seef far meich uff meim Disch fun.
 WS33	Sein̰ Brurer will sich zwee scheene neie Heiser in auere Gaarte baue.
-WS34	Daß Wǎrt is ěm vum Herze kumm.
-WS35	Daß war recht vun ěne.
-WS36	Waß sitze do fǎr Vöchelcher owě uff dem Mäuerche.
-WS37	Die Bauere han finf Ochse un neun̰ Küh un zwölf Schäfcher vor Dorf braacht, die wollte sě verkäfe.
+WS34	Daß Wǎrt is ĕm vum Herze kumm.
+WS35	Daß war recht vun ĕne.
+WS36	Waß sitze do fǎr Vöchelcher owĕ uff dem Mäuerche.
+WS37	Die Bauere han finf Ochse un neun̰ Küh un zwölf Schäfcher vor Dorf braacht, die wollte sĕ verkäfe.
 WS38	Die Leut sin heut all drauß uff’m Feld un mähe.
-WS39	Geh noore, der braun Hund dut děr nix.
+WS39	Geh noore, der braun Hund dut dĕr nix.
 WS40	Eich sin met de Leut do hinne iwer die Wies ins Korn gefahr.

--- a/32008_Rehweiler.csv
+++ b/32008_Rehweiler.csv
@@ -30,8 +30,8 @@ WS19	Wer hat mer mei Korb met dem Fleesch geschdohl?
 WS20	Er dut so, als härrese ne zum Drèsche beschtellt, sie han es awer selbscht gedun.
 WS21	Wem hat er die nei Geschecht verzählt?
 WS22	Mer muß hart kreische, sunscht verschteht er uns net.
-WS23	Mer sin mied un han Dǎrscht.
-WS24	Wie mer gischter Owend serick kumm sin, do hǎn die Anĕre schun im Bett gelèh un ware fescht am Schlofe.
+WS23	Mer sin mied un han Dărscht.
+WS24	Wie mer gischter Owend serick kumm sin, do hăn die Anĕre schun im Bett gelèh un ware fescht am Schlofe.
 WS25	Der Schnee is heint Nacht bei uns leie bleb, aber heit Morje is er geschmolz.
 WS26	Hinner unserm Haus schtehn drei scheene Äbbelbemcher mit rore Äbbelcher.
 WS27	Kinnener net noch en Ageblick uff uns waarte, dann gehn mer met auch.
@@ -41,9 +41,9 @@ WS30	Wie vel Pund Warscht un wie vel Brod wollen ehr han?
 WS31	Eich verschtehn auch net, ehr misse en̰ bißche fèschter schproche.
 WS32	Han ehr ken̰ Stickelche weiß Seef far meich uff meim Disch fun.
 WS33	Sein̰ Brurer will sich zwee scheene neie Heiser in auere Gaarte baue.
-WS34	Daß Wǎrt is ĕm vum Herze kumm.
+WS34	Daß Wărt is ĕm vum Herze kumm.
 WS35	Daß war recht vun ĕne.
-WS36	Waß sitze do fǎr Vöchelcher owĕ uff dem Mäuerche.
+WS36	Waß sitze do făr Vöchelcher owĕ uff dem Mäuerche.
 WS37	Die Bauere han finf Ochse un neun̰ Küh un zwölf Schäfcher vor Dorf braacht, die wollte sĕ verkäfe.
 WS38	Die Leut sin heut all drauß uff’m Feld un mähe.
 WS39	Geh noore, der braun Hund dut dĕr nix.

--- a/32049_Kaiserslautern.csv
+++ b/32049_Kaiserslautern.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	Im Winder fliehen  die truckene Blärre(r) in d(e) Luft erum.
 WS02	S hört glei uff s(e) schnee’e, dann werd’s Werre(r) wirre(r) besser.
-WS03	Dhu Kohle in d(e) Owe, daß die Millich bǎll a se koche fangt.
+WS03	Dhu Kohle in d(e) Owe, daß die Millich băll a se koche fangt.
 WS04	D(e) gure alde Mann is mirr(e)m Gaul durchs Eis g(e)broch und ins kald Wasser g(e)fall.
 WS05	Er is vorr vier orre sechs Woche g(e)schtorb.
 WS06	’S Feier war so schtark, die Kuche sinn jo unne ganz schwarz g(e)brennt.

--- a/32049_Kaiserslautern.csv
+++ b/32049_Kaiserslautern.csv
@@ -23,7 +23,7 @@ WS12	Wo gehschte hĩ? Solle merr mit der gehe?
 WS13	’S sinn schlechte Zeite.
 WS14	Mei liewes Kind, bleib unne schtehe, sche[?]nn beißen dich die böse Gäns dod.
 WS15	Du hascht heit am menschte  gelernt unn bischt a(r)dig geweßt. Du derfscht friher häm gehe als die annere.
-WS16	Du bischt noch nět groß genunk, um e Flasch Weĩ auss(e)trinke; du muscht erscht noch ebbes wachse (wakse) unn greßer werre.
+WS16	Du bischt noch nĕt groß genunk, um e Flasch Weĩ auss(e)trinke; du muscht erscht noch ebbes wachse (wakse) unn greßer werre.
 WS17	Geh, sei so gut unn saa deiner Schweschter, sie soll die Kläre for eier Mutter ferdig nähe unn mit de Berscht rein mache.
 WS18	Häscht ’n(e) gekennt, dann wär’s annerscht kumm unn s dhet besser um (e)’ne schtehe.
 WS19	Wer hat m’r mei Korb mirr(e)m Fläsch gschtohl?
@@ -34,11 +34,11 @@ WS23	Mr sinn mied unn hann Dorscht.
 WS24	Wie m(e)r geschtern Owend s(e)rück kumm sinn, do hänn die annere schunn im Bett geläh unn waren fescht am Schlofe.
 WS25	De Schnee iß heunt <(haint)> Nacht leihe geblǐb; awer heit <(hait)> Morje iß er g(e)schmolz.
 WS26	Hinner unserm Haus schtehe drei scheene E(Ä)pp(bb)elbämcher mit rore E(Ä)bbelcher.
-WS27	Kennen’r nět e Aueblickche uff uns wa(r)de, dann gehe mr mit eich.
+WS27	Kennen’r nĕt e Aueblickche uff uns wa(r)de, dann gehe mr mit eich.
 WS28	Ehr derfen kè̃ so Kinnereie treiwe.
-WS29	Unsere Berge sinn nět so hook, die eiere sinn viel heker.
+WS29	Unsere Berge sinn nĕt so hook, die eiere sinn viel heker.
 WS30	Wie v(ie)l Pund Worscht unn wie vl Brod woll’n ’r hann?
-WS31	Ich veschteh eich nět, ehr miss’n e bißje lauder plaurere.
+WS31	Ich veschteh eich nĕt, ehr miss’n e bißje lauder plaurere.
 WS32	Hänn’r kè̃ Schtückelche weißi Säf for mich uff meim Disch gfunn?
 WS33	Sẽĩ Brure(r) will sich zwè schène neie Haiser in ei?erm Gaa(r)de baue.
 WS34	’S Wort is ’m vum Hèrz kumm.

--- a/32050_Mehlingen.csv
+++ b/32050_Mehlingen.csv
@@ -43,7 +43,7 @@ WS32	Henner ke Stückelche weißi Sef for mich uff mein Disch funn.
 WS33	Seḭ Brure will sich zwee schenne naie Haiser in eirem Gaarde baue.
 WS34	Das Wort issm vo̰m Herze kumm.
 WS35	Das war recht vunene.
-WS36	Wa͜s sitze do̰ for Vöögelcher owe uff dem Mäuerche.
+WS36	Wa͡s sitze do̰ for Vöögelcher owe uff dem Mäuerche.
 WS37	Die Baure henn fünf O̰chse unn na̰i Küh unn zwelf Schäfcher vorr’s Dorf brung, die wollten se verkafe.
 WS38	Die Leut sinn heut all draus uff’m Feld unn mähen.
 WS39	Geh norre dè͡r braune Hund dut dè͡r nichts.

--- a/32050_Mehlingen.csv
+++ b/32050_Mehlingen.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	Im Winter flieh’n die druckne Blärre in der Luft h’rumm.
 WS02	Es hört gleich uff s’schnee, dann werds Werre beser.
-WS03	Dun Kohle in dr Owe, daß die Milich a̰ fangt se͜ koche.
+WS03	Dun Kohle in dr Owe, daß die Milich a̰ fangt se͡ koche.
 WS04	Dr guure alte Mann iss mirm Gaul ins Eis gebroch unn ins kalte Wasser gefall.
 WS05	Er isch vorr vier orre sechs Woche gestorb.
 WS06	s’ Faier war se’ stark, die Kuche sinn jo all unne ganz schwarz vebrennt.
@@ -18,7 +18,7 @@ WS07	Er ess’t die Aier immer uh̰ne Salz un̰n Peffer.
 WS08	Die Füß du’hmer weh, ich glab ich hann se dorch geloffe.
 WS09	Ich bin bei dr Fraa gewest unn hann’sr gesah’t unn sie sah’t sie wollt’s ah erer Tochter sah.
 WS10	Ich will’s ah net wirre dṵn.
-WS11	Ich schlah de͜r gleich mirm K̰ochlöffel an die Ohre, du Aff.
+WS11	Ich schlah de͡r gleich mirm K̰ochlöffel an die Ohre, du Aff.
 WS12	W̰o gescht de h̰ie, soll ich mit der geh.
 WS13	s’binn schlechte Zeite.
 WS14	Mei lieb Kind, bleib do̰ hunne steh, die böse Gäns beißen dich dot.
@@ -38,7 +38,7 @@ WS27	Könn ner nett noch e Ablick uff us warte not geh’ mer mirr euch.
 WS28	Er derfen nett so Kinnerei treibe.
 WS29	Unsere Berje sinn nett so ho̰k, die eiere sinn viel höher
 WS30	Wievel Pund Worscht unn wievel Bro̰d woll ner hann?
-WS31	Ich versteh euch nett, è͜r müssen e bische härter plauere.
+WS31	Ich versteh euch nett, è͡r müssen e bische härter plauere.
 WS32	Henner ke Stückelche weißi Sef for mich uff mein Disch funn.
 WS33	Seḭ Brure will sich zwee schenne naie Haiser in eirem Gaarde baue.
 WS34	Das Wort issm vo̰m Herze kumm.
@@ -46,5 +46,5 @@ WS35	Das war recht vunene.
 WS36	Wa͜s sitze do̰ for Vöögelcher owe uff dem Mäuerche.
 WS37	Die Baure henn fünf O̰chse unn na̰i Küh unn zwelf Schäfcher vorr’s Dorf brung, die wollten se verkafe.
 WS38	Die Leut sinn heut all draus uff’m Feld unn mähen.
-WS39	Geh norre dè͜r braune Hund dut dè͜r nichts.
+WS39	Geh norre dè͡r braune Hund dut dè͡r nichts.
 WS40	Ich bin mit de Leut do̰ hinne iwer die Wisse ins Korn gefahre.

--- a/32050_Mehlingen.csv
+++ b/32050_Mehlingen.csv
@@ -10,41 +10,41 @@ Anmerkungen: ''
 ...
 WS01	Im Winter flieh’n die druckne Blärre in der Luft h’rumm.
 WS02	Es hört gleich uff s’schnee, dann werds Werre beser.
-WS03	Dun Kohle in dr Owe, daß die Milich a̰̰ fangt se͜ koche.
+WS03	Dun Kohle in dr Owe, daß die Milich a̰ fangt se͜ koche.
 WS04	Dr guure alte Mann iss mirm Gaul ins Eis gebroch unn ins kalte Wasser gefall.
 WS05	Er isch vorr vier orre sechs Woche gestorb.
-WS06	s’ Faier war se’ stark, die ,Kuche sinn jo all unne ganz schwarz vebrennt.
-WS07	Er ess’t die Aier immer uh̰̰ne Salz un̰̰n Peffer.
+WS06	s’ Faier war se’ stark, die Kuche sinn jo all unne ganz schwarz vebrennt.
+WS07	Er ess’t die Aier immer uh̰ne Salz un̰n Peffer.
 WS08	Die Füß du’hmer weh, ich glab ich hann se dorch geloffe.
 WS09	Ich bin bei dr Fraa gewest unn hann’sr gesah’t unn sie sah’t sie wollt’s ah erer Tochter sah.
-WS10	Ich will’s ah net wirre dṵ̰n.
-WS11	Ich schlah de͜r gleich mirm K̰̰ochlöffel an die Ohre, du Aff.
-WS12	W̰̰o gescht de h̰̰ie, soll ich mit der geh.
+WS10	Ich will’s ah net wirre dṵn.
+WS11	Ich schlah de͜r gleich mirm K̰ochlöffel an die Ohre, du Aff.
+WS12	W̰o gescht de h̰ie, soll ich mit der geh.
 WS13	s’binn schlechte Zeite.
-WS14	Mei lieb Kind, bleib do̰̰ hunne steh, die böse Gäns beißen dich dot.
+WS14	Mei lieb Kind, bleib do̰ hunne steh, die böse Gäns beißen dich dot.
 WS15	Du hoscht heit am menschte gelernt, unn bischt ordlich gewest, du derfscht eder hem as wie die annere.
-WS16	Du bischt net groß genunk um e Flasch Weḭ̰ aus se drünke, du muscht erscht noch ebes wachse unn größer werre.
-WS17	Geh, sei so gut unn sah’s deine Schweschter, sie soll die Klè(K)re for eiere Mo̰̰tter fertig nähe unn mit de Berscht sauber mache.
+WS16	Du bischt net groß genunk um e Flasch Weḭ aus se drünke, du muscht erscht noch ebes wachse unn größer werre.
+WS17	Geh, sei so gut unn sah’s deine Schweschter, sie soll die Klè(K)re for eiere Mo̰tter fertig nähe unn mit de Berscht sauber mache.
 WS18	Häschte ne gekennt? do wers annerscht worr, unn s’ dät besser mirm steh.
 WS19	Wer hot mer mei Korb mit Flesch gestohl.
-WS20	Er dut so, as herrn se ihn zum dresche beschtellt; sie hann’s aw̰̰er selbert gedu.
+WS20	Er dut so, as herrn se ihn zum dresche beschtellt; sie hann’s aw̰er selbert gedu.
 WS21	Wemm horre die nei Geschicht verzählt.
 WS22	Mr muß hart kreische sunscht verstehre uns nett.
 WS23	Mer sinn müd unn henn Dorscht.
-WS24	Als mer gestern Nobend se rück gekumm waren, do̰̰ henn die Annere schun im Bett geleh unn waren fescht am schlo̰̰fe.
-WS25	Dr Schnee iss denne Nacht leihe bleb, awer heut Morje isch’r geschmo̰̰lz.
-WS26	Hinner unsrm Haus stehn drei schenne Apebämcher mit ro̰̰re Äpelcher.
+WS24	Als mer gestern Nobend se rück gekumm waren, do̰ henn die Annere schun im Bett geleh unn waren fescht am schlo̰fe.
+WS25	Dr Schnee iss denne Nacht leihe bleb, awer heut Morje isch’r geschmo̰lz.
+WS26	Hinner unsrm Haus stehn drei schenne Apebämcher mit ro̰re Äpelcher.
 WS27	Könn ner nett noch e Ablick uff us warte not geh’ mer mirr euch.
 WS28	Er derfen nett so Kinnerei treibe.
-WS29	Unsere Berje sinn nett so ho̰̰k, die eiere sinn viel höher
-WS30	Wievel Pund Worscht unn wievel Bro̰̰d woll ner hann?
+WS29	Unsere Berje sinn nett so ho̰k, die eiere sinn viel höher
+WS30	Wievel Pund Worscht unn wievel Bro̰d woll ner hann?
 WS31	Ich versteh euch nett, è͜r müssen e bische härter plauere.
 WS32	Henner ke Stückelche weißi Sef for mich uff mein Disch funn.
-WS33	Seḭ̰ Brure will sich zwee schenne naie Haiser in eirem Gaarde baue.
-WS34	Das Wort issm vo̰̰m Herze kumm.
+WS33	Seḭ Brure will sich zwee schenne naie Haiser in eirem Gaarde baue.
+WS34	Das Wort issm vo̰m Herze kumm.
 WS35	Das war recht vunene.
 WS36	Wa͜s sitze do̰ for Vöögelcher owe uff dem Mäuerche.
-WS37	Die Baure henn fünf O̰chse unn na̰̰i Küh unn zwelf Schäfcher vorr’s Dorf brung, die wollten se verkafe.
+WS37	Die Baure henn fünf O̰chse unn na̰i Küh unn zwelf Schäfcher vorr’s Dorf brung, die wollten se verkafe.
 WS38	Die Leut sinn heut all draus uff’m Feld unn mähen.
 WS39	Geh norre dè͜r braune Hund dut dè͜r nichts.
 WS40	Ich bin mit de Leut do̰ hinne iwer die Wisse ins Korn gefahre.

--- a/32067_Erpolzheim.csv
+++ b/32067_Erpolzheim.csv
@@ -39,7 +39,7 @@ WS28	Ehr derfen net so Kinnerreie treiwe.
 WS29	Unsere Berje sinn net so hoch, eire sinn viel höcher.
 WS30	Wiefehl Pund Worscht unn wiefehl Brod wenner dann hawe?
 WS31	Ich versteh euch net, ehr müssen e bissel lauter plaurere.
-WS32	Henner ke Stück’l weiße Se̱f forr mich uff meim Disch gfunne?
+WS32	Henner ke Stück’l weiße Se̠f forr mich uff meim Disch gfunne?
 WS33	Sei Brurer will sich zwee schene neie Heiser in eierm Gaarde baue.
 WS34	Das Wort kam ihm vun̄ Herze!
 WS35	Daß war recht vunn ihne!

--- a/32076_Dannstadt.csv
+++ b/32076_Dannstadt.csv
@@ -11,29 +11,29 @@ Anmerkungen: <Statt des Imperfects wird hier stets das Perfekt gebraucht.>
 WS01	Im Winder fliegen die druckene Bledder in der Luft rum. <(dd = etwas verschwommen).>
 WS02	"’s hört glei uff se schneiche, derno werd’s Wetter widder beser <(tt u.dd   ""           ""    )>."
 WS03	Douh Kohle in de Owwe, daß die Millich ball a̰fangt se koche.
-WS04	Der gut alt Mann is <(auch isch)> mi’m Gaul durchs Eis gebroche un in dé ̆ kalt Wasser g’falle.
+WS04	Der gut alt Mann is <(auch isch)> mi’m Gaul durchs Eis gebroche un in dé̆ kalt Wasser g’falle.
 WS05	Er is vor vier odder sechs Woche g’storwe. <(dd = wie oben)>.
 WS06	’s Feuer war so schtark, die Kuche sinn jo unne ganz schwarz gebrennt.
 WS07	Er ißt die Ajer immer uhne Salz un Peffer.
-WS08	Die Füß duhn mèr weh, ich glaab, ich ha ̆b se durchgeloffe <(mèr = sehr kurz. e fast unhörbar)>.
-WS09	Ich bin bei der Fraa gewest un ha ̆b’s er g’saat, un sie hot g’saat, sie wollt’s a éhrer Dochter sage.
+WS08	Die Füß duhn mèr weh, ich glaab, ich hăb se durchgeloffe <(mèr = sehr kurz. e fast unhörbar)>.
+WS09	Ich bin bei der Fraa gewest un hăb’s er g’saat, un sie hot g’saat, sie wollt’s a éhrer Dochter sage.
 WS10	Ich will’s a nimmi widder da̰h(n)!
 WS11	Ich schlack dich glei mim Kochlöffel um die Ohre, du Aff!
 WS12	Wu géhscht hḭ(n), solle mer mit d’r gèh(n)?
 WS13	’s sinn schlèchte Zeite! <(t = wie in Wetter)>.
 WS14	Ma̰ lieb’ Kind, bleib do unne schtèh, die böse Gäns beißen dich dod.
 WS15	Du hoscht heut am mèhnschte gelernt un bischt artig gewest, du därfscht früher häm gèh’ as (wie) die Annere.
-WS16	Du bischt noch net groß genunk, um è Fla ̆sch Weḭ’ aussetrinke, du muscht sérscht noch ebbes wachse un größer wèrre.
+WS16	Du bischt noch net groß genunk, um è Flăsch Weḭ’ aussetrinke, du muscht sérscht noch ebbes wachse un größer wèrre.
 WS17	Geh, sei so gut un saak danner Schweschter, sie soll die Klääder for euer Mutter fertig néhe un mit der Bèrscht sauwer mache <(rein = rää̰, nur für fein gebräuchlich)>.
 WS18	Héscht ’n gekènnt! dann wär’s annerscht kumm, un ’s dehd besser um èn schtèh <(èn = sehr kurz)>.
-WS19	Wer hot mèr ma̰ ̆n Korb mit Fläsch g’schtohle?
+WS19	Wer hot mèr mă̰n Korb mit Fläsch g’schtohle?
 WS20	Er hot so geda̰h, as hétten s’n zum drèsche b’schtéllt; sie hänn’s awwer sèlber geda̰h’.
 WS21	Wèm hot ’r <(t = wie in Wetter)> die neu G’schicht verzéhlt?
 WS22	M’r muß laut kreische, sunscht verschtéht er uns nét.
 WS23	M’r sinn müd un hänn Dorscht.
 WS24	Wie m’r géster Owed sèrück kumme sinn, do sinn die Annere schunn im Bett gelège <(g = wie ein leises ch)> un waren féscht am schlofe.
-WS25	Der Schneé is heunt Nacht bei uns li ̆ge gebliwwe, aber heut Morje is er g’schmolze.
-WS26	Hinner unse ̆rm Haus schtehen drei sch schäne Abbelbämelcher mit rote Ebbelcher <(t in rote = wie in Wetter)>.
+WS25	Der Schneé is heunt Nacht bei uns lĭge gebliwwe, aber heut Morje is er g’schmolze.
+WS26	Hinner unsĕrm Haus schtehen drei sch schäne Abbelbämelcher mit rote Ebbelcher <(t in rote = wie in Wetter)>.
 WS27	Kännen èr nèt noch è Ageblickel uff uns waarte, dann géhn m’r mit euch.
 WS28	Ehr dürfen net so Kinnereie treiwe.
 WS29	Unser Bèrje sinn nèt arg <(statt sehr, g = wie k)> hoch, euri sinn viel höcher.
@@ -41,10 +41,10 @@ WS30	Wie viel Pund Worscht un wie viel Brod wänn éhr hawwe?
 WS31	Ich verschtéh euch net, éhr müssen è bissel lauter schprèche (t in lauter = wie in Wetter).
 WS32	Hänn éhr kä̰ Stückel weißi Sääf for mich uff ma̰m Disch g’funne?
 WS33	Sa̰ Bruder <(d = wie oben)> will sich zweè schäne neue Häuser in eurem Gaarde baue.
-WS34	Dè ̆s Wort is ’m vun Hèrze kumme!
+WS34	Dè̆s Wort is ’m vun Hèrze kumme!
 WS35	Dé war rècht vun ihne!
 WS36	Was sitzen do for Vögelcher <(g = wie ein leises ch)> owwe uff dem Mäuerche?
-WS37	Die Bauere hänn fünf Ochse un neṵ Küh un zwélf Schéfelcher vors Dorf gebroocht g’hatt, die hänn se ̆ verkaafe wolle.
+WS37	Die Bauere hänn fünf Ochse un neṵ Küh un zwélf Schéfelcher vors Dorf gebroocht g’hatt, die hänn sĕ verkaafe wolle.
 WS38	Die Leut sinn heut all drauß uff’Äm Feld un méhen.
 WS39	Geh numme <(norr)>, der braṵ Hund duht d’r nix.
 WS40	Ich bin mit dènne Leut do hinne iwwer die Wiß ins Korn g’fahre.<(eu in Leute u. heute ? = mehr dem ei ähnlich)>

--- a/33102_Gleiszellen.csv
+++ b/33102_Gleiszellen.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	Im Winter fliegen die trockene Blärrer in dè Luft rum.
 WS02	Es hört gleich uf se schneige, dan̄ werd das Werrer besser.
-WS03	Dhu Kouhlen in dè Oufe, daß die Milich bald se koche a͂nfangt.
+WS03	Dhu Kouhlen in dè Oufe, daß die Milich bald se koche ãnfangt.
 WS04	Der gut, alt Mann esch mit’m Gaul durchs Eis gebroche unn ins kalt Wasser gefalle.
 WS05	Er esch vor vier oorer sechs Woche gschorbe.
 WS06	s’ Feuer esch sou stark gewest, die Kuche sinn jo un̄e ganz schwarz gebrennt.

--- a/33111_Herxheimweyher.csv
+++ b/33111_Herxheimweyher.csv
@@ -29,7 +29,7 @@ WS18	Hetscht du’n gekennt! dann wär’s annersch kumme, unn es deht besser um
 WS19	Wer hott mer me͂i Korb mit Flēsch gschtohle?
 WS20	Er hott sou gedau͂, als hettesen zum Dresche bschtellt; sie henns awer selwer gedau͂.
 WS21	Wem hot’r d’ nei Gschicht verzäihlt?
-WS22	Man̆ muß laut kreische, sunscht versteht’r uns nit.
+WS22	Maň muß laut kreische, sunscht versteht’r uns nit.
 WS23	Mĕr sinn mid unn henn Dorscht.
 WS24	Als m’r geschter Owend hēm kumme sinn, sinn die Annere schunn im Bett geleche unn henn fescht gschlofe.
 WS25	De Schnee esch diĕ Nacht bei uns liche geblewe, awer heit Morge esch’r gschmolze.

--- a/33111_Herxheimweyher.csv
+++ b/33111_Herxheimweyher.csv
@@ -17,24 +17,24 @@ WS06	’s Feier war sŏ stark, die Kuge sinn jo unne ganz schwarz verbrennt.
 WS07	Er ißt die Äjr immer uhne Salz unn Peffer.
 WS08	Die Fīeß dihn m’r weh, ich gläb, ich häbse durchgeloffe.
 WS09	Ich benn bei dĕr Frä geweßt unn häbser gsagt, unn sie hott gsagt, sie will’s äch ehre Dochder sage.
-WS10	Ich wills ǟch nimmi dau͂.
+WS10	Ich wills ǟch nimmi daũ.
 WS11	Ich schlach d’r gleich de Kochleff’l um d’ Ohre, du Aff!
-WS12	Wu gescht du nau͂, sellen m’r mit d’r geu͂j?
+WS12	Wu gescht du naũ, sellen m’r mit d’r geũj?
 WS13	Es sinn schlechte Zeite.
-WS14	Mei liebes Kind, bleib drunne steu͂j, die böüse Gäns beiße dich doud.
-WS15	Du hoscht heit am menschte gelernt unn bescht artig g’west, du derfscht ehder hēm geu͂j aß d’ annere.
+WS14	Mei liebes Kind, bleib drunne steũj, die böüse Gäns beiße dich doud.
+WS15	Du hoscht heit am menschte gelernt unn bescht artig g’west, du derfscht ehder hēm geũj aß d’ annere.
 WS16	Du bescht noch nit grouß genunk, um ĕ Flasch Wĕi aussetrinke; du muscht erscht noch ebbes wachse unn gröüßer werre.
 WS17	Geh sei sou gut unn sag deiner Schweschtăr, sie sell die Klejer for eier Mutter fertig nehe unn mit dr Berscht sauwer mache.
-WS18	Hetscht du’n gekennt! dann wär’s annersch kumme, unn es deht besser um’n steu͂j. 
-WS19	Wer hott mer me͂i Korb mit Flēsch gschtohle?
-WS20	Er hott sou gedau͂, als hettesen zum Dresche bschtellt; sie henns awer selwer gedau͂.
+WS18	Hetscht du’n gekennt! dann wär’s annersch kumme, unn es deht besser um’n steũj. 
+WS19	Wer hott mer mẽi Korb mit Flēsch gschtohle?
+WS20	Er hott sou gedaũ, als hettesen zum Dresche bschtellt; sie henns awer selwer gedaũ.
 WS21	Wem hot’r d’ nei Gschicht verzäihlt?
 WS22	Maň muß laut kreische, sunscht versteht’r uns nit.
 WS23	Mĕr sinn mid unn henn Dorscht.
 WS24	Als m’r geschter Owend hēm kumme sinn, sinn die Annere schunn im Bett geleche unn henn fescht gschlofe.
 WS25	De Schnee esch diĕ Nacht bei uns liche geblewe, awer heit Morge esch’r gschmolze.
-WS26	Henner unserm Haus steu͂j drei schöine Appelbämle mit route Eppelcher.
-WS27	Kennener nit ĕ Ägeblick uff uns wahrde, dann geu͂j m’r mit ech. 
+WS26	Henner unserm Haus steũj drei schöine Appelbämle mit route Eppelcher.
+WS27	Kennener nit ĕ Ägeblick uff uns wahrde, dann geũj m’r mit ech. 
 WS28	Ehr derfe kä̃n sou Kinnereie dreiwe.
 WS29	Unser Berg sinn nit sou houch; eieri sinn vel (höühcher) höicher.
 WS30	Wie vel Pund Brout unn wie vel Pund Worscht wenner häwe?
@@ -46,5 +46,5 @@ WS35	Deß isch recht geweßt vunnen!
 WS36	Was sitzen do ver Vöchelche owe uff dem Maierle?
 WS37	Die Bauere henn finf Ochse unn neĩn Kih unn zwelf Schäfcher vor’s Dorf gebrocht, die wollte sĕ verkāfe.
 WS38	Die Leit sinn all drauß uff’m Feld unn mähe.
-WS39	Geh norre, der brau͂ Hund duhd’r nix.
+WS39	Geh norre, der braũ Hund duhd’r nix.
 WS40	Ich benn mit denne Leit dohenne üwer d’ Wies in’s Korn gfahre.

--- a/33258_Ilbesheim.csv
+++ b/33258_Ilbesheim.csv
@@ -39,7 +39,7 @@ WS28	Er dérfen nit so Kinnereie treiwe.
 WS29	Unser Berge sin nit so arig houch, eieer sin vel höicher.
 WS30	Wie vel Pund Woorscht un wie vel Broud wenn er hann?
 WS31	Ich verschteh ich nit, ĕr missen e bissel lauter spreche.
-WS32	Henn ĕr kèn̰ Schtickel weißi Sèf fer mich uff meim̰ Disch g’funne?
+WS32	Henn ĕr kèn̰ Schtickel weißi Sèf fer mich uff meḭm Disch g’funne?
 WS33	Sein̰ Brurer will sich zwè schḛ̀ne neie Haiser in eierm Gaarte baue.
 WS34	Das Wort esch ĕm vun Herze kumme
 WS35	Das esch recht vun-ĕn geweßt!

--- a/33273_Bellheim.csv
+++ b/33273_Bellheim.csv
@@ -21,13 +21,13 @@ WS10	Ich wills ä nimmert werrer dhaun.<(Nase)>
 WS11	Ich schlagter gleich midd’m Kochleffel um d’Ohre, du Affeg’sicht.
 WS12	Wu gehscht ’na, sollemer midd’r ge?-h?
 WS13	’s sinn schlächte Zeide.
-WS14	Mei liebs Kend, bleib unne schteh, die böse Gäns beißen dich doou̮ht.
+WS14	Mei liebs Kend, bleib unne schteh, die böse Gäns beißen dich doou̬ht.
 WS15	Du hoscht heit am mehnschte g’lernt un bescht orndlich g’weßt, du derfscht früher heme gëë-ih als die Annere.
 WS16	Du bescht noch nit grouß g’nunk, um e Flasch Weih ausedrinke, du muscht erscht noch ebbes wachse un gröiser werre.
 WS17	Geh, sei so gud un saag deiner Schweschter, sie soll die Kleder for eier Mudder ferdig nehe, un mit d’r Berscht sauwer mache.
 WS18	Hetscht’n gekennt, dann wehr’s anerscht kumme un ’s dhet besser um ’n schteh.
 WS19	Wer hot m’r mei Korb mit Fläsch g’schtohle?
-WS20	Er hot soou̮ gedauh, als hettensen zum Dresche bschtellt; sie henns awer selbscht gedauh.
+WS20	Er hot soou̬ gedauh, als hettensen zum Dresche bschtellt; sie henns awer selbscht gedauh.
 WS21	Wem hot’r die nei G’schicht verzehlt?
 WS22	M’r muß laut kreische, sunscht versteht er uns nit.
 WS23	Mehr sinn mied un henn Dorscht.
@@ -36,7 +36,7 @@ WS25	Der Schnee äsch d’Nacht bei uns liehe geblewe, aber heit morje äsch er 
 WS26	Henner unserm Haus schtehe drei schene Abbelbämlich mit rore Ebbelcher.
 WS27	Kinner nit noch e Ägeblick uf uns wahrte, dann gehmer mirèg.
 WS28	Ehr derfen nit so vor Kennereie treiwe.
-WS29	Unser Berge sen nit so hoou̮ch, eier sinn viel höger.
+WS29	Unser Berge sen nit so hoou̬ch, eier sinn viel höger.
 WS30	Wie viel Pund Brout un Worscht wellener <(häwig?)> haun?
 WS31	Ich verschteh üch nit, ehr mißt ebbes lauder rerre.
 WS32	Hänner e Stückl weißi Säf for mich of meim Disch g’funne?

--- a/33331_Steinbuch.csv
+++ b/33331_Steinbuch.csv
@@ -12,7 +12,7 @@ WS01	Im Winter fliehe die truckne Blärrer in der Luft rim.
 WS02	Es härt glei uf zu scheige, nort wird das Wetter wirrer besser.
 WS03	Dau Kauhle in den Owe, daß die Millich bold o zu koche fängt.
 WS04	Der gure olte Mann is mit dem Gaul durchs Eis gebroche un in das kalte Wasser gefalle.
-WS05	Er is vǒr vier oder sech Woche gesturwe.
+WS05	Er is vŏr vier oder sech Woche gesturwe.
 WS06	Das Feuer war zu haß, die Kuche sin jo unne ganz schwarz gebrennt.
 WS07	Er ißt die Ajer uhne Solz un Pfeffer.
 WS08	Die Füß daun mer sehr weih, ich glab ich heb se durch gelafe.

--- a/33366_Külsheim.csv
+++ b/33366_Külsheim.csv
@@ -25,7 +25,7 @@ WS14	Ma libs Ki[e]nd, blei do una st[en] a, die böisen Gens beiße d[i] toud.
 WS15	Du hoscht hait am mersten g’lernt un bischt oartig gwä, du dörfscht ender hoam gena, wie die anner[n].
 WS16	Du bist no [ne]t grouß genunk, um e[in]e Flasche Way auszutrinke, du muscht erst no a bisle wo̠hse un größer werde.
 WS17	Geh ane, sei so gut u.[n] sog dere Schwester, si soll die Gladr vor euer Mutter ferti nöhn un mit der Börscht sauber ma̠che.
-WS18	Heschtn gekennt, nocht wä[?]rs annerscht komma, uns‿tät besser üm an stehn.
+WS18	Heschtn gekennt, nocht wä[?]rs annerscht komma, uns⁀tät besser üm an stehn.
 WS19	Wer hat man Korab mit Fla̠sch g’stouhle?
 WS20	Er hot sou getu[n]n, wie wannsi ihn zum Dreschen beschtellt hätten, sie hens aber selber getu[n]n.
 WS21	Wemm hot er di naie G’schichte verzailt?

--- a/33559_Würzburg.csv
+++ b/33559_Würzburg.csv
@@ -8,12 +8,12 @@ Transliterationsprojekt: REDE
 Transliterent: Victoria
 Anmerkungen: '{Bei einigen Wörtern hat der Schreiber eine Art Kombination aus t und
   d (d. h. t mit einem zusätzlichen Bogen wie beim d) verwendet. Diese werden hier
-  mangels eines ähnlicheren Zeichens mit d̞ wiedergegeben.}'
+  mangels eines ähnlicheren Zeichens mit đ [Änderung Abraham Shoukry] wiedergegeben.}'
 ...
-WS01	In Wind̞er fliege die d̞ruckene Blätter in dr Luft ’rumm.
-WS02	’S hört glei auf ză schneie, nachr werz Wed̞d̞er widder schönner.
+WS01	In Winđer fliege die đruckene Blätter in dr Luft ’rumm.
+WS02	’S hört glei auf ză schneie, nachr werz Weđđer widder schönner.
 WS03	Du Kohle neḭ’n Ofe, däß die Milch ball ān ză koche fengt.
-WS04	D’r gud̞e ald̞e Mann is mit’m Gaul ins Eis neḭgăbroche unn nei’s kalde Wasser g’falle.
+WS04	D’r guđe alđe Mann is mit’m Gaul ins Eis neḭgăbroche unn nei’s kalde Wasser g’falle.
 WS05	Er is vor vier oder sechs Wuche g’schtorbe.
 WS06	’S Feuer war ză stark, die Kuche sinn ja unde ganz schwarz gebrönnt.
 WS07	Er ißt die Eier ümmer ohne Salz unn Pfeffer.
@@ -25,7 +25,7 @@ WS12	Wu gehste hḭ, sölln m’r mit dr geh?
 WS13	’S senn schlechte Zeite!
 WS14	Meḭ liab’s Kind, blei hunde steh, die böse Gens beiße die sunst dot.
 WS15	Du hast heut’m mèrsche g’lernt unn bist brav g’wese, du därfst eher hemm wie die Annere.
-WS16	Du bist no zu klē, daß dĕ ĕ Flasche Weḭ d̞rink kannst, du mußt nö ĕ weng wax, daß dĕ grösser wörscht.
+WS16	Du bist no zu klē, daß dĕ ĕ Flasche Weḭ đrink kannst, du mußt nö ĕ weng wax, daß dĕ grösser wörscht.
 WS17	Du, sei so gut unn sag deiner Schwester, sie soll die Kläder für euer Mutter fertich mach unn mit der Börschte sauber mach.
 WS18	Häst’n gekennt, nă wärsch annersch ganga, nacher stinget er besser.
 WS19	Wer hat denn meḭn Korb mit Flǟsch g’stohle?
@@ -39,7 +39,7 @@ WS26	Hinder unsern Haus stinn drei schönne Öpfelbäumli mit rode Öpfeli.
 WS27	Könnt’r nitt nŏ e bißle auf uns wart, nach’r gemm’r ā mit.
 WS28	Ihr dörft kḛ̄ sō ĕ Kinnereie mach.
 WS29	Unser Berg sinn nitt so arch hoch, euere sinn viel höcher.
-WS30	Wie viel Pfund Wörscht unn wie viel Brod̞ wöllt’r hab?
+WS30	Wie viel Pfund Wörscht unn wie viel Brođ wöllt’r hab?
 WS31	I vrsteh euch nitt, ihr müßt ĕ bißle lauder red!
 WS32	Habt’r kḛ̄ Stückle weiße Säffe für mĭ auf mim Tisch g’funne?
 WS33	Demm seḭ Bruder will sĭ zwä schönne neue Häuser in euern Garte b[au].

--- a/33725_Rüsselsheim.csv
+++ b/33725_Rüsselsheim.csv
@@ -19,7 +19,7 @@ WS08	Die Fieß dhun merr sehr weh, ich glab, ich honn se dorch gelaafe.
 WS09	Ich sein bei der Fraa gewest unn honn ’ser gesoht <(zw. o u. a)> und sie soht, sie wollt’s aach ihrer Dochder souhe.
 WS10	Ich well’s aach nett meh wirre dho͂! <(Nasal)>
 WS11	Ich schloue dich glei merrem Kochlöffel im die Uhrn, du Aff!
-WS12	Wo gehst de he͂, selle merr mit derr geh?
+WS12	Wo gehst de hẽ, selle merr mit derr geh?
 WS13	Es sein schlächte Zeite, auch Zeirre.
 WS14	Mẽi lieb Kind, bleib do unne steh, die bese Gens beiße dich dodt.
 WS15	Du host heit am mãste gelārnt unn best brov gewest, du darfst ehner hãm gẽh als die annern.

--- a/33725_Rüsselsheim.csv
+++ b/33725_Rüsselsheim.csv
@@ -10,14 +10,14 @@ Anmerkungen: ''
 ...
 WS01	Im Winder fliehe die trockne Blärre dorch die Luft erim.
 WS02	’S hert glei uff ze schneije, dann werd ’s Werre wirre besser.
-WS03	Dhu Kohle in Owe, daß die Milch baal o͂ ze koche fengt.
+WS03	Dhu Kohle in Owe, daß die Milch baal õ ze koche fengt.
 WS04	De gure alte Mann eß merrem Gaul dorch den Eis gebroche unn in’s kalt Wasser gefalle.
 WS05	Er eß verr vier, orre sechs Woche gestorbe.
 WS06	’S Feier wor ze haaß, die Kuche sein jo unne ganz schwarz gebrennt.
 WS07	Er ißt die Aijer immer ohne Salz unn Peffer.
 WS08	Die Fieß dhun merr sehr weh, ich glab, ich honn se dorch gelaafe.
 WS09	Ich sein bei der Fraa gewest unn honn ’ser gesoht <(zw. o u. a)> und sie soht, sie wollt’s aach ihrer Dochder souhe.
-WS10	Ich well’s aach nett meh wirre dho͂! <(Nasal)>
+WS10	Ich well’s aach nett meh wirre dhõ! <(Nasal)>
 WS11	Ich schloue dich glei merrem Kochlöffel im die Uhrn, du Aff!
 WS12	Wo gehst de hẽ, selle merr mit derr geh?
 WS13	Es sein schlächte Zeite, auch Zeirre.
@@ -27,7 +27,7 @@ WS16	Du best noch nett groß genungk, um a Flasch Wẽi auszetrinke, Du mußt er
 WS17	Geh, sei so gut unn sou deiner Schwester, sie sellt die Klaare ferr eier Modder fertig nehe unn mit der Berscht sauber mache.
 WS18	Häst Du ’n gekennt! dann wär’s annerscht kumme unn ’s det besser um ’n stẽh. 
 WS19	Wer <(war)> hott merr mein Korb mit Flasch gestohle?
-WS20	Er hot so gedho͂, als hätte se ehn zum Dresche bestellt, se honn’s awer selwer gedho͂.
+WS20	Er hot so gedhõ, als hätte se ehn zum Dresche bestellt, se honn’s awer selwer gedhõ.
 WS21	Wem hot er die nei Geschicht vezehlt?
 WS22	Merr muß laut kreische, sunst versteht er ahm nett.
 WS23	Merr sein mied unn honn Dorscht.

--- a/34001_Daudenzell.csv
+++ b/34001_Daudenzell.csv
@@ -11,11 +11,11 @@ Anmerkungen: ''
 WS01	Em Wintr fliegé truckene Blettr in dr Luft rum.
 WS02	S’ hert glei uff zu schneiche, darnocht werds Weddr widdr sché.
 WS03	Dŭ Koule in de Offe, daß d Milich bal zu koche a̰fängt.
-WS04	Dr gutt ǎlt Mann isch mim Gaul durch de Eis gebroche un ins kalt Wassr gfalle.
+WS04	Dr gutt ălt Mann isch mim Gaul durch de Eis gebroche un ins kalt Wassr gfalle.
 WS05	Er isch vŏr vier oddr sechs Woche gschtorwe.
 WS06	S’ Feuer war <(isch)> zu schtarik, d Kuche senn jo unne ganz schwarz gbrennt.
 WS07	Er ißt d Aier immer uhne Salz un Pfeffer.
-WS08	D Füß dun̄emer W weh; i glab, i hǎb si durchgloffe.
+WS08	D Füß dun̄emer W weh; i glab, i hăb si durchgloffe.
 WS09	I bin bei dr Fra gwest un hab’s ér gsat un si secht, si wills a ihrer Dochter sage.
 WS10	I wills a nimmer daun̰!
 WS11	I schlag di glei mim Kochlöffl um die Ohre, du Aff!

--- a/34001_Daudenzell.csv
+++ b/34001_Daudenzell.csv
@@ -12,7 +12,7 @@ WS01	Em Wintr fliegé truckene Blettr in dr Luft rum.
 WS02	S’ hert glei uff zu schneiche, darnocht werds Weddr widdr sché.
 WS03	Dŭ Koule in de Offe, daß d Milich bal zu koche a̰fängt.
 WS04	Dr gutt ǎlt Mann isch mim Gaul durch de Eis gebroche un ins kalt Wassr gfalle.
-WS05	Er isch vǒr vier oddr sechs Woche gschtorwe.
+WS05	Er isch vŏr vier oddr sechs Woche gschtorwe.
 WS06	S’ Feuer war <(isch)> zu schtarik, d Kuche senn jo unne ganz schwarz gbrennt.
 WS07	Er ißt d Aier immer uhne Salz un Pfeffer.
 WS08	D Füß dun̄emer W weh; i glab, i hǎb si durchgloffe.

--- a/34076_Ludwigshafen.csv
+++ b/34076_Ludwigshafen.csv
@@ -12,14 +12,14 @@ WS01	Imm Winder flieche die droggene Blédder inn d’r Luft rumm.
 WS02	S’hērt glei uff ze schneiche, unn’s Wĕdder wèrd widder bésser.
 WS03	Dūh Kōhlĕ inn dĕ Offĕ, daß die Milich bald a̰nfangd ze kochĕ.
 WS04	Der gūd alt Mann is midd’m Perd durchs Eis g’broche unn in’s kalt Wasser g’fallĕ.
-WS05	Er is vŏr vier odder sechs Wochě gestōrwe.
+WS05	Er is vŏr vier odder sechs Wochĕ gestōrwe.
 WS06	S’ Feier wār so schtārk, di Kuchĕ sinn unnĕ ganz verbrennt.
 WS07	Der eßt die Aier immer ō̰hne Peffer unn Salz.
 WS08	Di Fiehs dū m’r so ārich wēh, ich glaab, ich habb se dōrchg’loffe.
 WS09	Ich binn bei dĕr Frā gewēse, unn dō hăw ich ’s er g’săcht, unn do hodd se g’săcht, sĭ dḗhd’s ihrer Dochter sāche.
 WS10	Ich will’s āch nimmer widder dūhe!
 WS11	Ich schlā (hā) d’r glei midd’m Kochlöffel uff’s Ōhr, du Aff’!
-WS12	Wo gē̄́scht dann hīn? Solle mer midder gēhḛ?
+WS12	Wo gḗ́scht dann hīn? Solle mer midder gēhḛ?
 WS13	s’ Sinn schlechte Zeide alleweil!
 WS14	Mḛin lieb Kind, bleib dō unnĕ schtēhe, die bḗse Gens, beiße dich dōd.
 WS15	Du hoscht heit s’mēhrscht (s’mēnscht) g’lernd, unn bischt orndlich gewḗse, du därfscht heit früher hēem gēhe als die Annere.

--- a/34076_Ludwigshafen.csv
+++ b/34076_Ludwigshafen.csv
@@ -12,7 +12,7 @@ WS01	Imm Winder flieche die droggene Blédder inn d’r Luft rumm.
 WS02	S’hērt glei uff ze schneiche, unn’s Wĕdder wèrd widder bésser.
 WS03	Dūh Kōhlĕ inn dĕ Offĕ, daß die Milich bald a̰nfangd ze kochĕ.
 WS04	Der gūd alt Mann is midd’m Perd durchs Eis g’broche unn in’s kalt Wasser g’fallĕ.
-WS05	Er is vǒr vier odder sechs Wochě gestōrwe.
+WS05	Er is vŏr vier odder sechs Wochě gestōrwe.
 WS06	S’ Feier wār so schtārk, di Kuchĕ sinn unnĕ ganz verbrennt.
 WS07	Der eßt die Aier immer ō̰hne Peffer unn Salz.
 WS08	Di Fiehs dū m’r so ārich wēh, ich glaab, ich habb se dōrchg’loffe.

--- a/34076_Ludwigshafen.csv
+++ b/34076_Ludwigshafen.csv
@@ -44,7 +44,7 @@ WS33	Sḛin Brūder will sich zwḗ schḕne neie Heiser in eierm Gārde baue.
 WS34	Deß Word is ’m vunn Herze kumme!
 WS35	Deß wār recht vunn īhne!
 WS36	Was sitzḛ̆ dō fōr Vöchelcher ŏwĕ uff’m Meier’che?
-WS37	Die Bauere hĕnn finf Oxe unn nḛṵn Ki͞eh unn zwölf Schḗfcher vor’s Dōrf g’brocht g’habbt, die henn se verka͞afĕ wolle.
+WS37	Die Bauere hĕnn finf Oxe unn nḛṵn Ki͡eh unn zwölf Schḗfcher vor’s Dōrf g’brocht g’habbt, die henn se verka͞afĕ wolle.
 WS38	Die Leid sinn heit all drauß uff’m Féld unn mèh’n.
 WS39	Geh nor, de braun Hund wèrd d’r nix duhn.
 WS40	Ich binn mit de Leid do hinne ĭwer die Wĭß in’s Korn g’fa̅hre.

--- a/34076_Ludwigshafen.csv
+++ b/34076_Ludwigshafen.csv
@@ -34,7 +34,7 @@ WS23	Mer sinn mied unn henn dorscht.
 WS24	Wie mer geschdern Ohwend heem kumme sinn, do sinn die Annere schunn im Bett geleche unn henn fescht g’schlofe.
 WS25	D’r Schnee is heit Nacht bei uns liche <(leihe)> gebliwe, awer heit Morje isser vergange.
 WS26	Hinner unserm Haus do schteh’n drei schene Ebbelbemcher midd rode Ebbelcher.
-WS27	Kènnt’ ner net noch ḛ̀ Aachebliggche uff uns wa͞rde, dann gḗh m’r midd eich. 
+WS27	Kènnt’ ner net noch ḛ̀ Aachebliggche uff uns wārde, dann gḗh m’r midd eich. 
 WS28	Ehr därft kḛ̀n so Kinnereiĕ măchĕ. <(dreiwe.)>
 WS29	Unser Bèrche sinn net ārich hōgg, ei’re sinn viel hḗcher.
 WS30	Wieviel Pund Worschd unn wieviel Brod woll’ner dann? <(hăwe?)>
@@ -44,7 +44,7 @@ WS33	Sḛin Brūder will sich zwḗ schḕne neie Heiser in eierm Gārde baue.
 WS34	Deß Word is ’m vunn Herze kumme!
 WS35	Deß wār recht vunn īhne!
 WS36	Was sitzḛ̆ dō fōr Vöchelcher ŏwĕ uff’m Meier’che?
-WS37	Die Bauere hĕnn finf Oxe unn nḛṵn Ki͡eh unn zwölf Schḗfcher vor’s Dōrf g’brocht g’habbt, die henn se verka͞afĕ wolle.
+WS37	Die Bauere hĕnn finf Oxe unn nḛṵn Ki͡eh unn zwölf Schḗfcher vor’s Dōrf g’brocht g’habbt, die henn se verkāafĕ wolle.
 WS38	Die Leid sinn heit all drauß uff’m Féld unn mèh’n.
 WS39	Geh nor, de braun Hund wèrd d’r nix duhn.
-WS40	Ich binn mit de Leid do hinne ĭwer die Wĭß in’s Korn g’fa̅hre.
+WS40	Ich binn mit de Leid do hinne ĭwer die Wĭß in’s Korn g’fāhre.

--- a/34096_Ursenbach.csv
+++ b/34096_Ursenbach.csv
@@ -47,4 +47,4 @@ WS36	Wa̮s sitzé do for Vüjélén o̮wè uff dém̄ Meierlè.
 WS37	Die Bauèrn häwè finf Ochsé un nein̰ Kih, un zwélf Schefln vors Dorf gebrocht katt, die wolltese vakaafe.
 WS38	Die Leit sinn heit all draus uffm Fèld unn mehä.
 WS39	Gäi na, da brau Hund dut da nix.
-WS40	Ich bin mit de Leit do̱ hinné iwa̮ die Wiß ins Korn gfahn.
+WS40	Ich bin mit de Leit do̠ hinné iwa̮ die Wiß ins Korn gfahn.

--- a/34096_Ursenbach.csv
+++ b/34096_Ursenbach.csv
@@ -8,13 +8,13 @@ Transliterationsprojekt: SyHD
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Im Winda fliejé di͜ druggene Blerer in da͜ Luft rum.
+WS01	Im Winda fliejé di͡ druggene Blerer in da͜ Luft rum.
 WS02	Es hèrt glei uff ze schneichè, not wèrds Wèdda wirra béssa.
 WS03	Du Koule in dè Offé, daß die Milich ball anfängt zu kochè.
 WS04	Da̮ gud ald Mann isch mim Pèrd dorchs Eis gebroché un in’s kald Wassa gfalle.
 WS05	Er isch vor viear ewa sechs Woche gschtorwè.
 WS06	S Feija wa ze starik, di Kuche sinn un̄è ganz schwaz gebrénnt.
-WS07	Er ißt di̮ Aija imma uhné Salz un Pèffa.
+WS07	Er ißt di̬ Aija imma uhné Salz un Pèffa.
 WS08	Di Fieß dǔhn ma wäi, ich glab, ich hèbb se dorchgèloffè.
 WS09	Ich bin ba da Fra̠ géwèst un hèbb sa gsa̠t, un sie hott gsa̠t, si̠ wo̠tts a̠ èhra Dochda sagè.
 WS10	Ich wills a némmé wirra dau.

--- a/34096_Ursenbach.csv
+++ b/34096_Ursenbach.csv
@@ -43,7 +43,7 @@ WS32	Hädda ka Stickl weißi Saf fa mich uff mam Disch gfunne?
 WS33	Sa Brura will sich zwa schéné neié Heisa in eiam Gadé baué.
 WS34	Déß Wort kimmdem vum Herzé.
 WS35	Déß wa rècht vunném.
-WS36	Wa̮s sitzé do for Vüjélén o̮wè uff dém̄ Meierlè.
+WS36	Wa̮s sitzé do for Vüjélén o̬wè uff dém̄ Meierlè.
 WS37	Die Bauèrn häwè finf Ochsé un nein̰ Kih, un zwélf Schefln vors Dorf gebrocht katt, die wolltese vakaafe.
 WS38	Die Leit sinn heit all draus uffm Fèld unn mehä.
 WS39	Gäi na, da brau Hund dut da nix.

--- a/34096_Ursenbach.csv
+++ b/34096_Ursenbach.csv
@@ -8,10 +8,10 @@ Transliterationsprojekt: SyHD
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Im Winda fliejé di͡ druggene Blerer in da͜ Luft rum.
+WS01	Im Winda fliejé di͡ druggene Blerer in da͡ Luft rum.
 WS02	Es hèrt glei uff ze schneichè, not wèrds Wèdda wirra béssa.
 WS03	Du Koule in dè Offé, daß die Milich ball anfängt zu kochè.
-WS04	Da̮ gud ald Mann isch mim Pèrd dorchs Eis gebroché un in’s kald Wassa gfalle.
+WS04	Da̬ gud ald Mann isch mim Pèrd dorchs Eis gebroché un in’s kald Wassa gfalle.
 WS05	Er isch vor viear ewa sechs Woche gschtorwè.
 WS06	S Feija wa ze starik, di Kuche sinn un̄è ganz schwaz gebrénnt.
 WS07	Er ißt di̬ Aija imma uhné Salz un Pèffa.
@@ -24,7 +24,7 @@ WS13	Sinn schlèchdè Zeire!
 WS14	Ma̰ lieb Kind, bleib do unné schtéhn̰, die bäisé Géns beißé dich doud.
 WS15	Du hoscht heit am menschde gelernt, un̄ bischt adich gewèst, du dèrscht fria ham gehn̰, aß die An̄arn.
 WS16	Du bischt noch nét grouß genunk, um é Flasch Wein̰ auszudrinke, du muscht se̬rscht noch èbbes wachse un gräisr wärn.
-WS17	Gäi sa̮ so gut, un̄ sag deina Schweschda, sie soll die Klara fa eija Mudda ferdich nèhä, un mit da Berscht sauwa maché.
+WS17	Gäi sa̬ so gut, un̄ sag deina Schweschda, sie soll die Klara fa eija Mudda ferdich nèhä, un mit da Berscht sauwa maché.
 WS18	Héscht du én gekénnt, not wärs an̄aschd kum̄é, un s déhd béssa um én stéhn̰.
 WS19	Wèr hott ma man̄ Korb mit Flasch gschtohlé.
 WS20	Er hott sou gedau, als heresen zum Dresche bschdellt; sie häwes èwa sèlwa gédau.
@@ -34,7 +34,7 @@ WS23	Ma sinn mid un häwé dorscht.
 WS24	Wie ma geschda Owed zurick kumme sinn, sinn die Annarn schun im Bett geleje unn häwe feschd gschlofe.
 WS25	Da Schnäi isch heint Nacht bei uns leije gebliewe, ewa heit Morje ischa gschmolza.
 WS26	Hin̄a unsam Haus schdehn drei schene Ebelbemln mit roure Ebelen.
-WS27	Kénn da nét noch en Agéblick uff uns wa̱rdé, not géhn ma̱ mirich.
+WS27	Kénn da nét noch en Agéblick uff uns wa̠rdé, not géhn ma̠ mirich.
 WS28	Èr dèrft nét sou Kinnareien dreiwè.
 WS29	Unsa Bèrig sinn nét sou houch, eiari sinn vel häicha.
 WS30	Wiffl Pund Worscht un wiffl Pund Brout woda haṵ?
@@ -43,8 +43,8 @@ WS32	Hädda ka Stickl weißi Saf fa mich uff mam Disch gfunne?
 WS33	Sa Brura will sich zwa schéné neié Heisa in eiam Gadé baué.
 WS34	Déß Wort kimmdem vum Herzé.
 WS35	Déß wa rècht vunném.
-WS36	Wa̮s sitzé do for Vüjélén o̬wè uff dém̄ Meierlè.
+WS36	Wa̬s sitzé do for Vüjélén o̬wè uff dém̄ Meierlè.
 WS37	Die Bauèrn häwè finf Ochsé un nein̰ Kih, un zwélf Schefln vors Dorf gebrocht katt, die wolltese vakaafe.
 WS38	Die Leit sinn heit all draus uffm Fèld unn mehä.
 WS39	Gäi na, da brau Hund dut da nix.
-WS40	Ich bin mit de Leit do̠ hinné iwa̮ die Wiß ins Korn gfahn.
+WS40	Ich bin mit de Leit do̠ hinné iwa̬ die Wiß ins Korn gfahn.

--- a/34447_Berghausen.csv
+++ b/34447_Berghausen.csv
@@ -47,4 +47,4 @@ WS36	Wăß sitza̠ dō fŏr Vé̠ga̠lè d’roba̠ ŭf a̠m Meia̠rlé.
 WS37	D’ Baua̠ra̠ hénn finf Ochsa̠ unn nei Kih unn zwelf Schäflè vors Dorf brŏcht unn hennsĕ́ vorkaafa̠ wélla.
 WS38	D’Leit sěnn heit allě draußa uf’m Féll unn mäha.
 WS39	Géh nomma, d’r brau Hunn dud dar nigs.
-WS40	Ih bin mit da̲ Leit do hinna̲ iwèr di̅ Wi̅s ins Korn gfahra̲.
+WS40	Ih bin mit da̲ Leit do hinna̲ iwèr dī Wīs ins Korn gfahra̲.

--- a/34447_Berghausen.csv
+++ b/34447_Berghausen.csv
@@ -11,15 +11,15 @@ Anmerkungen: ''
 WS01	Im Wintér fliega die truggana Blättar in da Luft rum̄.
 WS02	Es hért gleih uf z’ schneea, noor werds Wéttèr widdèr béssèr.
 WS03	Tu Kohla in da Ofa, daß d’Milich ball kocha dud.
-WS04	Dě́r gū̌t’ alt Mann isch mit’ m Gaul durichs Eis brochè un̄ ǐns kalt Wasser g’falla.
-WS05	Er isch vor vīr odděr sechs Wocha g’storawa.
+WS04	Dĕ́r gū̌t’ alt Mann isch mit’ m Gaul durichs Eis brochè un̄ ǐns kalt Wasser g’falla.
+WS05	Er isch vor vīr oddĕr sechs Wocha g’storawa.
 WS06	S’ Feuer isch z’starig gwä, d’ Kucha sen̄ jo unnà ganz schwarz vorbren̄t.
 WS07	Er èßt d’ Eièr allfort ohné Salz unn Pfeffar.
 WS08	D’Füß denn mar so weh, ih glaab, ih heb’sé durchgloffa.
 WS09	Ih bin̄ bei dera̠ Fraa gwä unn hebsa̠ra̠ gsaagt, unn sī hat gsaagt, sie wills āh ihrè Tochdằ̠r sāgĕ̀.
 WS10	Ih wills ah ném̄éé widdar doo.
 WS11	Ih schlag, de gleih mit’m Kochleff’l um d’Ohra, du Aff!
-WS12	Wuh gē̄́sch dann na̰h solla mar mit dar geḛha.
+WS12	Wuh gḗ́sch dann na̰h solla mar mit dar geḛha.
 WS13	Des senn schlèchte Zeita̠.
 WS14	Lībs Kinn, bleib do unna steh̰, die bösa Gens beisa dĕ̍ dōt.
 WS15	Du hasch heit amm menschta g’lèrnt unn bisch artich gwä, du derasch frühar hoim geah’ as die annara.
@@ -43,8 +43,8 @@ WS32	Henn dar koi Stückle weiße Seifa vor mih uf meim Tisch gfunna.
 WS33	Sḛi Brudar will ĕ́m zwai schene Heisar in eiram Gaarta baua.
 WS34	Des Wort isch am von Herza komma!
 WS35	Des isch recht gwä vunnan.
-WS36	Wăß sitza̠ dō fŏr Vé̠ga̠lè d’roba̠ ŭf a̠m Meia̠rlé.
+WS36	Wăß sitza̠ dō fŏr Vé̱ga̠lè d’roba̠ ŭf a̠m Meia̠rlé.
 WS37	D’ Baua̠ra̠ hénn finf Ochsa̠ unn nei Kih unn zwelf Schäflè vors Dorf brŏcht unn hennsĕ́ vorkaafa̠ wélla.
-WS38	D’Leit sěnn heit allě draußa uf’m Féll unn mäha.
+WS38	D’Leit sĕnn heit allĕ draußa uf’m Féll unn mäha.
 WS39	Géh nomma, d’r brau Hunn dud dar nigs.
 WS40	Ih bin mit da̲ Leit do hinna̲ iwèr dī Wīs ins Korn gfahra̲.

--- a/34447_Berghausen.csv
+++ b/34447_Berghausen.csv
@@ -47,4 +47,4 @@ WS36	Wăß sitza̠ dō fŏr Vé̱ga̠lè d’roba̠ ŭf a̠m Meia̠rlé.
 WS37	D’ Baua̠ra̠ hénn finf Ochsa̠ unn nei Kih unn zwelf Schäflè vors Dorf brŏcht unn hennsĕ́ vorkaafa̠ wélla.
 WS38	D’Leit sĕnn heit allĕ draußa uf’m Féll unn mäha.
 WS39	Géh nomma, d’r brau Hunn dud dar nigs.
-WS40	Ih bin mit da̲ Leit do hinna̲ iwèr dī Wīs ins Korn gfahra̲.
+WS40	Ih bin mit da̠ Leit do hinna̠ iwèr dī Wīs ins Korn gfahra̠.

--- a/34734_Massenbachhausen.csv
+++ b/34734_Massenbachhausen.csv
@@ -13,9 +13,9 @@ WS02	S hèrt glai uff ze schnaiche, nōt wärd s Wätter wieder besser.
 WS03	Dhu Kohle en den Ofe, daß d’Milich ball a ze koche fangt.
 WS04	Dr gūt alt Man̄ isch mit ḛ̌m Gaul durch’s Ais broche ṵ̌n̄ in’s kalt Wasser gfalle.
 WS05	Er isch vor vier oder secks Woche gschtorwe.
-WS06	S Faier isch ze schtark gwäßt, d’Kuche sḛ̆n jŏ un̄e ganz schwa̅z bren̄t.
+WS06	S Faier isch ze schtark gwäßt, d’Kuche sḛ̆n jŏ un̄e ganz schwāz bren̄t.
 WS07	Er ißt d’Aier allfort ohne Salz ṵn̄ Pfeffer.
-WS08	D’Füß dũm̄er ǎrǐg weh, i glāb i hab sè durchgloffe.
+WS08	D’Füß dũm̄er ărǐg weh, i glāb i hab sè durchgloffe.
 WS09	I bḛ̆n bai de Frā gwäßt un̄ habs ere gsāgt, un̄ sĕ̀ hat gsāgt, sĕ̀ wills ā ihrer Dochter sage.
 WS10	I wills a ni meh wieder dhu.
 WS11	I schlag dè glai mit em Kochlöffel um d’Ohre, du Aff!

--- a/34734_Massenbachhausen.csv
+++ b/34734_Massenbachhausen.csv
@@ -45,6 +45,6 @@ WS34	Des Wort isch em von Härze kum̄e!
 WS35	Des isch recht gwäßt von en.
 WS36	Was sitze do vor Vegele ŏwe uff dem Maierle?
 WS37	Die Baure hä̆we fenf Ochse u. na̰ḭ Küh un̄ zwelf Schäfle vors Dorf brocht, die hä̆we sè verkāfe gwètt.
-WS38	D’Lait sěn hait all drauße uff em Fäld un̄ mähe.
+WS38	D’Lait sĕn hait all drauße uff em Fäld un̄ mähe.
 WS39	Gèh num̄e, de brau Hund dhut der nix.
 WS40	I bḛ̆n mit de Lait do hḛn̄e iwer d’Wiese ins Korn gfahre.

--- a/35141_Ansbach.csv
+++ b/35141_Ansbach.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Im Winder fliéng die truckna Blétter in der Luft rum.
 WS02	Es härt glei auf zum schning, na werds Wétter wĭeder besser.
 WS03	Thu Kohln nei in Ofen, daß d`Milch bal’ kochen thut. <(z’kochn ofängt.) >
-WS04	Der guta alta Mo̠ is’ mit’n Gaul durchs Eis broch’n und in’s ka̠lta̮ Wasser gfalln.
+WS04	Der guta alta Mo̠ is’ mit’n Gaul durchs Eis broch’n und in’s ka̠lta̬ Wasser gfalln.
 WS05	Er is f`r vier o̬de͡r sechs Wuch’n g’storm.
 WS06	Dés Feuer wor z’stark, die Kung sén̄ ja untn ganz schwarz o̠bren̄t.
 WS07	Er ißt die Gagali im̄er ohna Salz und Pfeffer.

--- a/35141_Ansbach.csv
+++ b/35141_Ansbach.csv
@@ -12,13 +12,13 @@ WS01	Im Winder fliéng die truckna Blétter in der Luft rum.
 WS02	Es härt glei auf zum schning, na werds Wétter wĭeder besser.
 WS03	Thu Kohln nei in Ofen, daß d`Milch bal’ kochen thut. <(z’kochn ofängt.) >
 WS04	Der guta alta Mo̠ is’ mit’n Gaul durchs Eis broch’n und in’s ka̠lta̮ Wasser gfalln.
-WS05	Er is f`r vier o̮de͜r sechs Wuch’n g’storm.
+WS05	Er is f`r vier o̬de͡r sechs Wuch’n g’storm.
 WS06	Dés Feuer wor z’stark, die Kung sén̄ ja untn ganz schwarz o̠bren̄t.
 WS07	Er ißt die Gagali im̄er ohna Salz und Pfeffer.
 WS08	Die Fi̠e̠ß th[e]na mèr recht wäh, i gla̠b, i hobs du[o]chgloff’n.
 WS09	I bin bei di[e] Fra̠ gwäst und habs r gsogt, und sie hat gsogt, sie wills a ihrer Tochter s[oo]g.
 WS10	I wills a nim̄er tho̠.
-WS11	I schlog d[e̮]r glei in Kollöffol um d’Ohrn, du Āff!
+WS11	I schlog d[e̬]r glei in Kollöffol um d’Ohrn, du Āff!
 WS12	Wu ge_hst’n hie, solln mèr mit dèr géh?
 WS13	Es sén schlechta Zeit’n!
 WS14	Mei lie̠bs Kind, bleib do drunt’n stéh, die bäs’n Gens beiß’n di tot.
@@ -34,7 +34,7 @@ WS23	Wer sén miad u. hem Dorscht.
 WS24	Wie mèr géstern Omds zrückkum̄a sén̄, hen die and[er]n scho in Bett gléng u. fést gschlof’n.
 WS25	Dèr Schnä is dia Nacht ba uns leng blieb’n, ober heit früha is èr gschmolz’n.
 WS26	Hinter unsern Haus sen̄ dr[o]i schena Epfélbamli mit rota Épféli.
-WS27	Kén̄tèr nit no an Aungblick afes wa[r]t’n dan̄ gé̠hna̠ mér a̠ mit eich.
+WS27	Kén̄tèr nit no an Aungblick afes wa[r]t’n dan̄ gé̱hna̠ mér a̠ mit eich.
 WS28	Ihr derft nit solcha Kinderoia tr[o]im.
 WS29	Unser Bèrg sén nit arg hoch, eira sén vil hä̠cher.
 WS30	Wie viel Pfund Worscht und Brot wolltèr hobn?

--- a/35337_Fürth.csv
+++ b/35337_Fürth.csv
@@ -17,9 +17,9 @@ WS06	Es Feier is z‘ſchtark gweſn, di Kougn ſenn ja unten ganz ſchwaz brenn
 WS07	Er ißt di Gakeli immer ohna Salz und Pfeffe(r). (e=ä)
 WS08	Di Fëiß denne(?) mer wëih, ih glab, ih hobs durchgloffen (ih  hob Blouſn.)
 WS09	Ih bin ba der Frau gwēn und hobs era gſacht, und ſie hout gſacht, daß ſie’s ihrer Tochter ſog͡a will.
-WS10	Ih wills a nemmer widder douh͡n.
+WS10	Ih wills a nemmer widder douh͜n.
 WS11	Ih ſchlog der glei mit’n Kullöffl um di Ouhern, du Aff.
-WS12	Wou gëihſt’n hi, ſolln mer mid der gëih͡n?
+WS12	Wou gëihſt’n hi, ſolln mer mid der gëih͜n?
 WS13	Es ſenn ſchlechti Zeitn.
 WS14	Mei lëibs Kind, bleib druntn, di böißn Gens beißn di dout.
 WS15	Du houſt heint am maſtn glernt und biſt o͡artli gwēn, du derfſt frëier hamgëihn wëi di andern.

--- a/35337_Fürth.csv
+++ b/35337_Fürth.csv
@@ -17,9 +17,9 @@ WS06	Es Feier is z‘ſchtark gweſn, di Kougn ſenn ja unten ganz ſchwaz brenn
 WS07	Er ißt di Gakeli immer ohna Salz und Pfeffe(r). (e=ä)
 WS08	Di Fëiß denne(?) mer wëih, ih glab, ih hobs durchgloffen (ih  hob Blouſn.)
 WS09	Ih bin ba der Frau gwēn und hobs era gſacht, und ſie hout gſacht, daß ſie’s ihrer Tochter ſog͡a will.
-WS10	Ih wills a nemmer widder douh͜n.
+WS10	Ih wills a nemmer widder douh͡n.
 WS11	Ih ſchlog der glei mit’n Kullöffl um di Ouhern, du Aff.
-WS12	Wou gëihſt’n hi, ſolln mer mid der gëih͜n?
+WS12	Wou gëihſt’n hi, ſolln mer mid der gëih͡n?
 WS13	Es ſenn ſchlechti Zeitn.
 WS14	Mei lëibs Kind, bleib druntn, di böißn Gens beißn di dout.
 WS15	Du houſt heint am maſtn glernt und biſt o͡artli gwēn, du derfſt frëier hamgëihn wëi di andern.

--- a/35484_Hirschau.csv
+++ b/35484_Hirschau.csv
@@ -11,13 +11,13 @@ Anmerkungen: ''
 WS01	Im Winter flög’n die trockenen Bletter in der Luft herum.
 WS02	Es hört gleich auf zu schnei’n dann wird das Wedder wieder besser.
 WS03	Thaū Kohl’n in den Ofen, daß d’Milch bald zu kochen anfangt.
-WS04	Der guate alte Moo̅ ist mit’n Gaul durch’s Eis broch’n, und in’s kal-te Wasser gfall’n.
+WS04	Der guate alte Moō ist mit’n Gaul durch’s Eis broch’n, und in’s kal-te Wasser gfall’n.
 WS05	Er ist voar vai̅r oder sechs Woch’n gstorb’n.
 WS06	Das Feuer war d’z stark, die Kuachen san ja unt’n ganz schwoarz an’brennt.
 WS07	Er ißt die Oier immer ohne Solz und Pfeffer.
 WS08	Die Füi̅s thua̅n  mir weh, ich glaub‘, i hob sie durchglauf’n.
 WS09	I‘ bin bei der Fau gewes’n und hob es ihr g’sagt und sie sagt, sie will es auch ihrer Tochter sog’n.
-WS10	I will es ao̅ nimmer thua̅n.
+WS10	I will es aō nimmer thua̅n.
 WS11	I‘ schlog die glei mit’n Kohlöffel um die Ohren, du Aff!
 WS12	Wo göhst du hi, soll’n mir mit dir göi̅n.
 WS13	Es san schlechte Zeiten.

--- a/35484_Hirschau.csv
+++ b/35484_Hirschau.csv
@@ -12,34 +12,34 @@ WS01	Im Winter flög’n die trockenen Bletter in der Luft herum.
 WS02	Es hört gleich auf zu schnei’n dann wird das Wedder wieder besser.
 WS03	Thaū Kohl’n in den Ofen, daß d’Milch bald zu kochen anfangt.
 WS04	Der guate alte Moō ist mit’n Gaul durch’s Eis broch’n, und in’s kal-te Wasser gfall’n.
-WS05	Er ist voar vai̅r oder sechs Woch’n gstorb’n.
+WS05	Er ist voar vaīr oder sechs Woch’n gstorb’n.
 WS06	Das Feuer war d’z stark, die Kuachen san ja unt’n ganz schwoarz an’brennt.
 WS07	Er ißt die Oier immer ohne Solz und Pfeffer.
-WS08	Die Füi̅s thua̅n  mir weh, ich glaub‘, i hob sie durchglauf’n.
+WS08	Die Füīs thua̅n  mir weh, ich glaub‘, i hob sie durchglauf’n.
 WS09	I‘ bin bei der Fau gewes’n und hob es ihr g’sagt und sie sagt, sie will es auch ihrer Tochter sog’n.
 WS10	I will es aō nimmer thua̅n.
 WS11	I‘ schlog die glei mit’n Kohlöffel um die Ohren, du Aff!
-WS12	Wo göhst du hi, soll’n mir mit dir göi̅n.
+WS12	Wo göhst du hi, soll’n mir mit dir göīn.
 WS13	Es san schlechte Zeiten.
-WS14	Maa̅ liab’s Kind, blei unt’n stöh’n, die böi̅sen Gäns‘ beißen dich taūt.
+WS14	Maa̅ liab’s Kind, blei unt’n stöh’n, die böīsen Gäns‘ beißen dich taūt.
 WS15	Du haūst heut am meisten g’lernt und bist arte g’wes’n, du erfst fria̅h heimgö?n als die Andern.
-WS16	Du bist nu net groß genua̅, um eine Flasche Wein austrinkn, du mua̅st erst nu wachs’n und gröi̅ßer wern.
+WS16	Du bist nu net groß genua̅, um eine Flasche Wein austrinkn, du mua̅st erst nu wachs’n und gröīßer wern.
 WS17	Goh, sei so gua̅t und sag deiner Schwester, sie soll die Kleider für eu´re Mutter ferti nan und mit der Börste reinmachen.
-WS18	Hättest du ihn kennt, dann wär es ander’s kommer, und es thät besser um ihn stöi̅n.
+WS18	Hättest du ihn kennt, dann wär es ander’s kommer, und es thät besser um ihn stöīn.
 WS19	Wer haūt mer meinen Korb mit Fleisch g’stohl’n.
 WS20	Er thua̅t so, als hätt’n sie ihn zum dreschen g’stellt; sie hobn es aber selbst thua̅n.
 WS21	Wem haūt er die neue G’schicht erzählt?
-WS22	Man mua̅ß laut schreier, sunst verstai̅ht er uns net.
-WS23	Wir san möi̅d und hab’n Durst.
+WS22	Man mua̅ß laut schreier, sunst verstaīht er uns net.
+WS23	Wir san möīd und hab’n Durst.
 WS24	Als wir gestern Abend z’rückkamen, da lag’n die Ander’n schon zu Bett‘ und hatt’n fest g’schlof’n.
-WS25	Der Schnöi̅ ist diese Nacht bei uns lieg’n blieb’n aber heut morg’ns wieder gschmolz’n.
-WS26	Hinter unsern Haus stöi̅n drei schöne Äpfelbäumer mit raūten Äpfeln.
+WS25	Der Schnöī ist diese Nacht bei uns lieg’n blieb’n aber heut morg’ns wieder gschmolz’n.
+WS26	Hinter unsern Haus stöīn drei schöne Äpfelbäumer mit raūten Äpfeln.
 WS27	Könnt ihr neirt e noch einen Augenblick auf uns warten, dann geh’n wir mit euch.
 WS28	Ihr derf nirt solche Kindereien treib’n.
 WS29	Uns’re Berg‘ san nirt so hoch, die euren san viel höher.
 WS30	Wieviel Wuost und wieviel Pfund Brot wollt‘ ihr (selber) haben.
 WS31	Ich verstehe eng nirt, ihr müa̅st a weng lauter sprechen.
-WS32	Habt ihr koi̅n Stückl weiße Säi̅fe für mich auf meinen Tisch g’fund’n.
+WS32	Habt ihr koīn Stückl weiße Säīfe für mich auf meinen Tisch g’fund’n.
 WS33	Sein Brua̅der will sich zwoar schöne neue Häuser in euren Gaorten bauen.
 WS34	Das Woa̅rt kam ihm vom Herzen.
 WS35	Des war recht von Ihnen.

--- a/35484_Hirschau.csv
+++ b/35484_Hirschau.csv
@@ -15,21 +15,21 @@ WS04	Der guate alte Moō ist mit’n Gaul durch’s Eis broch’n, und in’s ka
 WS05	Er ist voar vaīr oder sechs Woch’n gstorb’n.
 WS06	Das Feuer war d’z stark, die Kuachen san ja unt’n ganz schwoarz an’brennt.
 WS07	Er ißt die Oier immer ohne Solz und Pfeffer.
-WS08	Die Füīs thua̅n  mir weh, ich glaub‘, i hob sie durchglauf’n.
+WS08	Die Füīs thuān  mir weh, ich glaub‘, i hob sie durchglauf’n.
 WS09	I‘ bin bei der Fau gewes’n und hob es ihr g’sagt und sie sagt, sie will es auch ihrer Tochter sog’n.
-WS10	I will es aō nimmer thua̅n.
+WS10	I will es aō nimmer thuān.
 WS11	I‘ schlog die glei mit’n Kohlöffel um die Ohren, du Aff!
 WS12	Wo göhst du hi, soll’n mir mit dir göīn.
 WS13	Es san schlechte Zeiten.
-WS14	Maa̅ liab’s Kind, blei unt’n stöh’n, die böīsen Gäns‘ beißen dich taūt.
-WS15	Du haūst heut am meisten g’lernt und bist arte g’wes’n, du erfst fria̅h heimgö?n als die Andern.
-WS16	Du bist nu net groß genua̅, um eine Flasche Wein austrinkn, du mua̅st erst nu wachs’n und gröīßer wern.
-WS17	Goh, sei so gua̅t und sag deiner Schwester, sie soll die Kleider für eu´re Mutter ferti nan und mit der Börste reinmachen.
+WS14	Maā liab’s Kind, blei unt’n stöh’n, die böīsen Gäns‘ beißen dich taūt.
+WS15	Du haūst heut am meisten g’lernt und bist arte g’wes’n, du erfst friāh heimgö?n als die Andern.
+WS16	Du bist nu net groß genuā, um eine Flasche Wein austrinkn, du muāst erst nu wachs’n und gröīßer wern.
+WS17	Goh, sei so guāt und sag deiner Schwester, sie soll die Kleider für eu´re Mutter ferti nan und mit der Börste reinmachen.
 WS18	Hättest du ihn kennt, dann wär es ander’s kommer, und es thät besser um ihn stöīn.
 WS19	Wer haūt mer meinen Korb mit Fleisch g’stohl’n.
-WS20	Er thua̅t so, als hätt’n sie ihn zum dreschen g’stellt; sie hobn es aber selbst thua̅n.
+WS20	Er thuāt so, als hätt’n sie ihn zum dreschen g’stellt; sie hobn es aber selbst thuān.
 WS21	Wem haūt er die neue G’schicht erzählt?
-WS22	Man mua̅ß laut schreier, sunst verstaīht er uns net.
+WS22	Man muāß laut schreier, sunst verstaīht er uns net.
 WS23	Wir san möīd und hab’n Durst.
 WS24	Als wir gestern Abend z’rückkamen, da lag’n die Ander’n schon zu Bett‘ und hatt’n fest g’schlof’n.
 WS25	Der Schnöī ist diese Nacht bei uns lieg’n blieb’n aber heut morg’ns wieder gschmolz’n.
@@ -38,13 +38,13 @@ WS27	Könnt ihr neirt e noch einen Augenblick auf uns warten, dann geh’n wir m
 WS28	Ihr derf nirt solche Kindereien treib’n.
 WS29	Uns’re Berg‘ san nirt so hoch, die euren san viel höher.
 WS30	Wieviel Wuost und wieviel Pfund Brot wollt‘ ihr (selber) haben.
-WS31	Ich verstehe eng nirt, ihr müa̅st a weng lauter sprechen.
+WS31	Ich verstehe eng nirt, ihr müāst a weng lauter sprechen.
 WS32	Habt ihr koīn Stückl weiße Säīfe für mich auf meinen Tisch g’fund’n.
-WS33	Sein Brua̅der will sich zwoar schöne neue Häuser in euren Gaorten bauen.
-WS34	Das Woa̅rt kam ihm vom Herzen.
+WS33	Sein Bruāder will sich zwoar schöne neue Häuser in euren Gaorten bauen.
+WS34	Das Woārt kam ihm vom Herzen.
 WS35	Des war recht von Ihnen.
 WS36	Was hocken dao für Vogel ob’n auf der Mauer.
-WS37	Die Bauer´n fünf Ochsen, neun Küa̅h, und zwölf Schoäf vor das  <(Tho)> Dorf ‘bracht, die woll’ns verkauf’n.
+WS37	Die Bauer´n fünf Ochsen, neun Küāh, und zwölf Schoäf vor das  <(Tho)> Dorf ‘bracht, die woll’ns verkauf’n.
 WS38	Die Leut‘ san heut’nt alle draußen auf’n Feld und mah’n.
-WS39	Göi nur, der braune Hund thua̅t dir nichts.
-WS40	I‘ bin mit den Leuten daūhinten über d’Wiesen in’s Koa̅rn g’fahrn.
+WS39	Göi nur, der braune Hund thuāt dir nichts.
+WS40	I‘ bin mit den Leuten daūhinten über d’Wiesen in’s Koārn g’fahrn.

--- a/35484_Hirschau.csv
+++ b/35484_Hirschau.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	Im Winter flög’n die trockenen Bletter in der Luft herum.
 WS02	Es hört gleich auf zu schnei’n dann wird das Wedder wieder besser.
-WS03	Thau̅ Kohl’n in den Ofen, daß d’Milch bald zu kochen anfangt.
+WS03	Thaū Kohl’n in den Ofen, daß d’Milch bald zu kochen anfangt.
 WS04	Der guate alte Moo̅ ist mit’n Gaul durch’s Eis broch’n, und in’s kal-te Wasser gfall’n.
 WS05	Er ist voar vai̅r oder sechs Woch’n gstorb’n.
 WS06	Das Feuer war d’z stark, die Kuachen san ja unt’n ganz schwoarz an’brennt.
@@ -21,19 +21,19 @@ WS10	I will es ao̅ nimmer thua̅n.
 WS11	I‘ schlog die glei mit’n Kohlöffel um die Ohren, du Aff!
 WS12	Wo göhst du hi, soll’n mir mit dir göi̅n.
 WS13	Es san schlechte Zeiten.
-WS14	Maa̅ liab’s Kind, blei unt’n stöh’n, die böi̅sen Gäns‘ beißen dich tau̅t.
-WS15	Du hau̅st heut am meisten g’lernt und bist arte g’wes’n, du erfst fria̅h heimgö?n als die Andern.
+WS14	Maa̅ liab’s Kind, blei unt’n stöh’n, die böi̅sen Gäns‘ beißen dich taūt.
+WS15	Du haūst heut am meisten g’lernt und bist arte g’wes’n, du erfst fria̅h heimgö?n als die Andern.
 WS16	Du bist nu net groß genua̅, um eine Flasche Wein austrinkn, du mua̅st erst nu wachs’n und gröi̅ßer wern.
 WS17	Goh, sei so gua̅t und sag deiner Schwester, sie soll die Kleider für eu´re Mutter ferti nan und mit der Börste reinmachen.
 WS18	Hättest du ihn kennt, dann wär es ander’s kommer, und es thät besser um ihn stöi̅n.
-WS19	Wer hau̅t mer meinen Korb mit Fleisch g’stohl’n.
+WS19	Wer haūt mer meinen Korb mit Fleisch g’stohl’n.
 WS20	Er thua̅t so, als hätt’n sie ihn zum dreschen g’stellt; sie hobn es aber selbst thua̅n.
-WS21	Wem hau̅t er die neue G’schicht erzählt?
+WS21	Wem haūt er die neue G’schicht erzählt?
 WS22	Man mua̅ß laut schreier, sunst verstai̅ht er uns net.
 WS23	Wir san möi̅d und hab’n Durst.
 WS24	Als wir gestern Abend z’rückkamen, da lag’n die Ander’n schon zu Bett‘ und hatt’n fest g’schlof’n.
 WS25	Der Schnöi̅ ist diese Nacht bei uns lieg’n blieb’n aber heut morg’ns wieder gschmolz’n.
-WS26	Hinter unsern Haus stöi̅n drei schöne Äpfelbäumer mit rau̅ten Äpfeln.
+WS26	Hinter unsern Haus stöi̅n drei schöne Äpfelbäumer mit raūten Äpfeln.
 WS27	Könnt ihr neirt e noch einen Augenblick auf uns warten, dann geh’n wir mit euch.
 WS28	Ihr derf nirt solche Kindereien treib’n.
 WS29	Uns’re Berg‘ san nirt so hoch, die euren san viel höher.
@@ -47,4 +47,4 @@ WS36	Was hocken dao für Vogel ob’n auf der Mauer.
 WS37	Die Bauer´n fünf Ochsen, neun Küa̅h, und zwölf Schoäf vor das  <(Tho)> Dorf ‘bracht, die woll’ns verkauf’n.
 WS38	Die Leut‘ san heut’nt alle draußen auf’n Feld und mah’n.
 WS39	Göi nur, der braune Hund thua̅t dir nichts.
-WS40	I‘ bin mit den Leuten dau̅hinten über d’Wiesen in’s Koa̅rn g’fahrn.
+WS40	I‘ bin mit den Leuten daūhinten über d’Wiesen in’s Koa̅rn g’fahrn.

--- a/35687_Weiden.csv
+++ b/35687_Weiden.csv
@@ -10,10 +10,10 @@ Anmerkungen: ''
 ...
 WS01	In Winda fleīg’n die truckan Bladla in da Luft uma.
 WS02	‘s hăīat glei af zun schneia, nacha wirds Weda wieda bessa.
-WS03	Thŏū Kohln in Ōnfn, da̅s d Milch bal zum Kochn a ̰fangt.
-WS04	Dea gu ̆a̅ti alti Mâ ̰ is mid’n Gàl àm Eis à ̰brochn und ins kalt Wassa gfalln.
-WS05	Er is voa̅ we ̆īja oda séchs Wochan gschto ̆a̅rm.
-WS06	‘s Feija is tschto ̆a̅k gwes’n, Ka ̆oūchn san ja untnher alsaganza schwo ̆a̅ts brennt.
+WS03	Thŏū Kohln in Ōnfn, dās d Milch bal zum Kochn a ̰fangt.
+WS04	Dea gu ̆āti alti Mâ ̰ is mid’n Gàl àm Eis à ̰brochn und ins kalt Wassa gfalln.
+WS05	Er is voā we ̆īja oda séchs Wochan gschto ̆ārm.
+WS06	‘s Feija is tschto ̆āk gwes’n, Ka ̆oūchn san ja untnher alsaganza schwo ̆āts brennt.
 WS07	Er ißt d Oija allamal ohni Salz und Pfèffa.
 WS08	Mia the ̆īn d Fe ̆ī ß rècht wo ̆aīh, i glab, i ho mi afganga.
 WS09	I bin wo da Frau gwest u. hos ihr gsagt, und sie hat gsagt, sie wills ihrana Tochta scho ̰ sogn.
@@ -23,28 +23,28 @@ WS12	Wa ̆oū ga ̆īst denn hi ̰, sollma ̰ mit ge ̆ī ̰h?
 WS13	As san schlèchti Zeit’n.
 WS14	Ma ̰ le ̆ībs Kind, blei da ̆oū untn ste ̆i ̰̅h, de ̆ī ba ̆īsi Géns beißn die ta ̆oūt.
 WS15	Du hast heit am meistn glèrnt u. bist bràv gwést, du därfst fre ̆īja ham als die andern.
-WS16	Du bist nu nīa̅t gra ̆oūß gno ̆ūch um a Flaschn We ̰i ̰ asztrinkn, du mo ̆ūßt zèrschtmi ̆ a wengl waksn und gra ̆īßa wèrn.
-WS17	Ga ̆īh, sa so gu ̆a̅t u. sōch deina Schwesta, sie solls Gwand für enka Mudda firtimachen ̆ u. mit da Bürschtn asbutzn.
+WS16	Du bist nu nīāt gra ̆oūß gno ̆ūch um a Flaschn We ̰i ̰ asztrinkn, du mo ̆ūßt zèrschtmi ̆ a wengl waksn und gra ̆īßa wèrn.
+WS17	Ga ̆īh, sa so gu ̆āt u. sōch deina Schwesta, sie solls Gwand für enka Mudda firtimachen ̆ u. mit da Bürschtn asbutzn.
 WS18	Ha ̆īst’n ne ̆a ̰̅ kennt! nacha wàs anderscht kumma, und als stànd bessa um ihn.
-WS19	e ̆a̅ hat ma mein Ko ̆a̅b mit Fleisch gschtohln?
-WS20	E ̆a̅ hat so tho ̆ū ̰, als wenns s’in zum Drèschn bschtellt ha ̆īn, sie hom’s owa selba tho ̆ū ̰.
+WS19	e ̆ā hat ma mein Ko ̆āb mit Fleisch gschtohln?
+WS20	E ̆ā hat so tho ̆ū ̰, als wenns s’in zum Drèschn bschtellt ha ̆īn, sie hom’s owa selba tho ̆ū ̰.
 WS21	Wen hat er de ̆ī neiji Gschicht dazehlt.
-WS22	Mi ̆a̅ mo ̆ū hell schreija, sunst voschta ̆īt a oin niat.
-WS23	Mi ̆a̅ san me ̆īd und hom Du ̆a̅rscht.
+WS22	Mi ̆ā mo ̆ū hell schreija, sunst voschta ̆īt a oin niat.
+WS23	Mi ̆ā san me ̆īd und hom Du ̆ārscht.
 WS24	We ̆ī ma géstarn A ̆oūmds ham kumma san, san die andern scho ̰ in Bétt gleg’n und han fést gschla ̆oūfm.
 WS25	Da Schna ̆ī is in dèra Nacht vo uns liegn bliebm, owa heint fre ̆īh is awieda zganga.
 WS26	Hinta unsern Haus stenga drei sche ̆īni Epflbeimla mit ra ̆oūt’n Epfalan.
 WS27	Kinnts niat nu an Augnblick af uns wartn, acha gehma mit.
-WS28	Detz de ̆a̅rfts ni ̆a̅t secha Kindereien treibm.
+WS28	Detz de ̆ārfts ni ̆āt secha Kindereien treibm.
 WS29	Unser Bèrch san niat rècht ha ̆oūch, die enkan san viel ha ̆īcha.
 WS30	We ̆īviel Pfund Wurscht und we ̆iviel Bra ̆oūt wellts denn.
-WS31	I vosta ̆īh enk ni ̆a̅t, detz me ̆ītz abißl hella redn.
+WS31	I vosta ̆īh enk ni ̆āt, detz me ̆ītz abißl hella redn.
 WS32	Hats ko ̰ Trüml weißi Saifm für mi af meim Tisch gfuna.
 WS33	Sa ̰ Bro ̆ūda will sa zwoa sche ̆īni, neiji Heisa in enkan Gartn bauan.
-WS34	Des Wo ̆a̅rt is’n von Hèrzn ke?mma
+WS34	Des Wo ̆ārt is’n von Hèrzn ke?mma
 WS35	Des is rècht von ihnen gewèst
 WS36	Wos istz’n da ̆oū für Vegala afm Meiala drobm.
-WS37	Bauren han fünf Ochsn und ne ̰i ̰ Ke ̆īh und zwölf Lammla vo ̆a̅s s Do ̆a̅f bracht, de ̆ī homs vokafm wèlln.
-WS38	D Leit san heint alle am Feld draß und ma̅hn.
+WS37	Bauren han fünf Ochsn und ne ̰i ̰ Ke ̆īh und zwölf Lammla vo ̆ās s Do ̆āf bracht, de ̆ī homs vokafm wèlln.
+WS38	D Leit san heint alle am Feld draß und māhn.
 WS39	Ga ̆ī ne ̆a ̰, da brau ̰ Hund to ̆ūt da nix.
-WS40	I bin mit’n Leitn da ̆oū hintn üwa d Wiesn ins Ko ̆a̅n gfo ̆a̅hn.
+WS40	I bin mit’n Leitn da ̆oū hintn üwa d Wiesn ins Ko ̆ān gfo ̆āhn.

--- a/35687_Weiden.csv
+++ b/35687_Weiden.csv
@@ -10,41 +10,41 @@ Anmerkungen: ''
 ...
 WS01	In Winda flei̅g’n die truckan Bladla in da Luft uma.
 WS02	‘s hăi̅at glei af zun schneia, nacha wirds Weda wieda bessa.
-WS03	Thŏu̅ Kohln in O̅nfn, da̅s d Milch bal zum Kochn a ̰fangt.
+WS03	Thŏū Kohln in O̅nfn, da̅s d Milch bal zum Kochn a ̰fangt.
 WS04	Dea gu ̆a̅ti alti Mâ ̰ is mid’n Gàl àm Eis à ̰brochn und ins kalt Wassa gfalln.
 WS05	Er is voa̅ we ̆i̅ja oda séchs Wochan gschto ̆a̅rm.
-WS06	‘s Feija is tschto ̆a̅k gwes’n, Ka ̆ou̅chn san ja untnher alsaganza schwo ̆a̅ts brennt.
+WS06	‘s Feija is tschto ̆a̅k gwes’n, Ka ̆oūchn san ja untnher alsaganza schwo ̆a̅ts brennt.
 WS07	Er ißt d Oija allamal ohni Salz und Pfèffa.
 WS08	Mia the ̆i̅n d Fe ̆i̅ ß rècht wo ̆ai̅h, i glab, i ho mi afganga.
 WS09	I bin wo da Frau gwest u. hos ihr gsagt, und sie hat gsagt, sie wills ihrana Tochta scho ̰ sogn.
-WS10	I wills nimma to ̆u̅ ̰.
-WS11	Ich schloch di glei mit’n Kolöffl um d   A ̆ou̅rn, du Aff.
-WS12	Wa ̆ou̅ ga ̆i̅st denn hi ̰, sollma ̰ mit ge ̆i̅ ̰h?
+WS10	I wills nimma to ̆ū ̰.
+WS11	Ich schloch di glei mit’n Kolöffl um d   A ̆oūrn, du Aff.
+WS12	Wa ̆oū ga ̆i̅st denn hi ̰, sollma ̰ mit ge ̆i̅ ̰h?
 WS13	As san schlèchti Zeit’n.
-WS14	Ma ̰ le ̆i̅bs Kind, blei da ̆ou̅ untn ste ̆i ̰̅h, de ̆i̅ ba ̆i̅si Géns beißn die ta ̆ou̅t.
+WS14	Ma ̰ le ̆i̅bs Kind, blei da ̆oū untn ste ̆i ̰̅h, de ̆i̅ ba ̆i̅si Géns beißn die ta ̆oūt.
 WS15	Du hast heit am meistn glèrnt u. bist bràv gwést, du därfst fre ̆i̅ja ham als die andern.
-WS16	Du bist nu ni̅a̅t gra ̆ou̅ß gno ̆u̅ch um a Flaschn We ̰i ̰ asztrinkn, du mo ̆u̅ßt zèrschtmi ̆ a wengl waksn und gra ̆i̅ßa wèrn.
+WS16	Du bist nu ni̅a̅t gra ̆oūß gno ̆ūch um a Flaschn We ̰i ̰ asztrinkn, du mo ̆ūßt zèrschtmi ̆ a wengl waksn und gra ̆i̅ßa wèrn.
 WS17	Ga ̆i̅h, sa so gu ̆a̅t u. so̅ch deina Schwesta, sie solls Gwand für enka Mudda firtimachen ̆ u. mit da Bürschtn asbutzn.
 WS18	Ha ̆i̅st’n ne ̆a ̰̅ kennt! nacha wàs anderscht kumma, und als stànd bessa um ihn.
 WS19	e ̆a̅ hat ma mein Ko ̆a̅b mit Fleisch gschtohln?
-WS20	E ̆a̅ hat so tho ̆u̅ ̰, als wenns s’in zum Drèschn bschtellt ha ̆i̅n, sie hom’s owa selba tho ̆u̅ ̰.
+WS20	E ̆a̅ hat so tho ̆ū ̰, als wenns s’in zum Drèschn bschtellt ha ̆i̅n, sie hom’s owa selba tho ̆ū ̰.
 WS21	Wen hat er de ̆i̅ neiji Gschicht dazehlt.
-WS22	Mi ̆a̅ mo ̆u̅ hell schreija, sunst voschta ̆i̅t a oin niat.
+WS22	Mi ̆a̅ mo ̆ū hell schreija, sunst voschta ̆i̅t a oin niat.
 WS23	Mi ̆a̅ san me ̆i̅d und hom Du ̆a̅rscht.
-WS24	We ̆i̅ ma géstarn A ̆ou̅mds ham kumma san, san die andern scho ̰ in Bétt gleg’n und han fést gschla ̆ou̅fm.
+WS24	We ̆i̅ ma géstarn A ̆oūmds ham kumma san, san die andern scho ̰ in Bétt gleg’n und han fést gschla ̆oūfm.
 WS25	Da Schna ̆i̅ is in dèra Nacht vo uns liegn bliebm, owa heint fre ̆i̅h is awieda zganga.
-WS26	Hinta unsern Haus stenga drei sche ̆i̅ni Epflbeimla mit ra ̆ou̅t’n Epfalan.
+WS26	Hinta unsern Haus stenga drei sche ̆i̅ni Epflbeimla mit ra ̆oūt’n Epfalan.
 WS27	Kinnts niat nu an Augnblick af uns wartn, acha gehma mit.
 WS28	Detz de ̆a̅rfts ni ̆a̅t secha Kindereien treibm.
-WS29	Unser Bèrch san niat rècht ha ̆ou̅ch, die enkan san viel ha ̆i̅cha.
-WS30	We ̆i̅viel Pfund Wurscht und we ̆iviel Bra ̆ou̅t wellts denn.
+WS29	Unser Bèrch san niat rècht ha ̆oūch, die enkan san viel ha ̆i̅cha.
+WS30	We ̆i̅viel Pfund Wurscht und we ̆iviel Bra ̆oūt wellts denn.
 WS31	I vosta ̆i̅h enk ni ̆a̅t, detz me ̆i̅tz abißl hella redn.
 WS32	Hats ko ̰ Trüml weißi Saifm für mi af meim Tisch gfuna.
-WS33	Sa ̰ Bro ̆u̅da will sa zwoa sche ̆i̅ni, neiji Heisa in enkan Gartn bauan.
+WS33	Sa ̰ Bro ̆ūda will sa zwoa sche ̆i̅ni, neiji Heisa in enkan Gartn bauan.
 WS34	Des Wo ̆a̅rt is’n von Hèrzn ke?mma
 WS35	Des is rècht von ihnen gewèst
-WS36	Wos istz’n da ̆ou̅ für Vegala afm Meiala drobm.
+WS36	Wos istz’n da ̆oū für Vegala afm Meiala drobm.
 WS37	Bauren han fünf Ochsn und ne ̰i ̰ Ke ̆i̅h und zwölf Lammla vo ̆a̅s s Do ̆a̅f bracht, de ̆i̅ homs vokafm wèlln.
 WS38	D Leit san heint alle am Feld draß und ma̅hn.
-WS39	Ga ̆i̅ ne ̆a ̰, da brau ̰ Hund to ̆u̅t da nix.
-WS40	I bin mit’n Leitn da ̆ou̅ hintn üwa d Wiesn ins Ko ̆a̅n gfo ̆a̅hn.
+WS39	Ga ̆i̅ ne ̆a ̰, da brau ̰ Hund to ̆ūt da nix.
+WS40	I bin mit’n Leitn da ̆oū hintn üwa d Wiesn ins Ko ̆a̅n gfo ̆a̅hn.

--- a/35687_Weiden.csv
+++ b/35687_Weiden.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: REDE
 Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
-WS01	In Winda flei̅g’n die truckan Bladla in da Luft uma.
-WS02	‘s hăi̅at glei af zun schneia, nacha wirds Weda wieda bessa.
+WS01	In Winda fleīg’n die truckan Bladla in da Luft uma.
+WS02	‘s hăīat glei af zun schneia, nacha wirds Weda wieda bessa.
 WS03	Thŏū Kohln in Ōnfn, da̅s d Milch bal zum Kochn a ̰fangt.
 WS04	Dea gu ̆a̅ti alti Mâ ̰ is mid’n Gàl àm Eis à ̰brochn und ins kalt Wassa gfalln.
-WS05	Er is voa̅ we ̆i̅ja oda séchs Wochan gschto ̆a̅rm.
+WS05	Er is voa̅ we ̆īja oda séchs Wochan gschto ̆a̅rm.
 WS06	‘s Feija is tschto ̆a̅k gwes’n, Ka ̆oūchn san ja untnher alsaganza schwo ̆a̅ts brennt.
 WS07	Er ißt d Oija allamal ohni Salz und Pfèffa.
-WS08	Mia the ̆i̅n d Fe ̆i̅ ß rècht wo ̆ai̅h, i glab, i ho mi afganga.
+WS08	Mia the ̆īn d Fe ̆ī ß rècht wo ̆aīh, i glab, i ho mi afganga.
 WS09	I bin wo da Frau gwest u. hos ihr gsagt, und sie hat gsagt, sie wills ihrana Tochta scho ̰ sogn.
 WS10	I wills nimma to ̆ū ̰.
 WS11	Ich schloch di glei mit’n Kolöffl um d   A ̆oūrn, du Aff.
-WS12	Wa ̆oū ga ̆i̅st denn hi ̰, sollma ̰ mit ge ̆i̅ ̰h?
+WS12	Wa ̆oū ga ̆īst denn hi ̰, sollma ̰ mit ge ̆ī ̰h?
 WS13	As san schlèchti Zeit’n.
-WS14	Ma ̰ le ̆i̅bs Kind, blei da ̆oū untn ste ̆i ̰̅h, de ̆i̅ ba ̆i̅si Géns beißn die ta ̆oūt.
-WS15	Du hast heit am meistn glèrnt u. bist bràv gwést, du därfst fre ̆i̅ja ham als die andern.
-WS16	Du bist nu ni̅a̅t gra ̆oūß gno ̆ūch um a Flaschn We ̰i ̰ asztrinkn, du mo ̆ūßt zèrschtmi ̆ a wengl waksn und gra ̆i̅ßa wèrn.
-WS17	Ga ̆i̅h, sa so gu ̆a̅t u. sōch deina Schwesta, sie solls Gwand für enka Mudda firtimachen ̆ u. mit da Bürschtn asbutzn.
-WS18	Ha ̆i̅st’n ne ̆a ̰̅ kennt! nacha wàs anderscht kumma, und als stànd bessa um ihn.
+WS14	Ma ̰ le ̆ībs Kind, blei da ̆oū untn ste ̆i ̰̅h, de ̆ī ba ̆īsi Géns beißn die ta ̆oūt.
+WS15	Du hast heit am meistn glèrnt u. bist bràv gwést, du därfst fre ̆īja ham als die andern.
+WS16	Du bist nu nīa̅t gra ̆oūß gno ̆ūch um a Flaschn We ̰i ̰ asztrinkn, du mo ̆ūßt zèrschtmi ̆ a wengl waksn und gra ̆īßa wèrn.
+WS17	Ga ̆īh, sa so gu ̆a̅t u. sōch deina Schwesta, sie solls Gwand für enka Mudda firtimachen ̆ u. mit da Bürschtn asbutzn.
+WS18	Ha ̆īst’n ne ̆a ̰̅ kennt! nacha wàs anderscht kumma, und als stànd bessa um ihn.
 WS19	e ̆a̅ hat ma mein Ko ̆a̅b mit Fleisch gschtohln?
-WS20	E ̆a̅ hat so tho ̆ū ̰, als wenns s’in zum Drèschn bschtellt ha ̆i̅n, sie hom’s owa selba tho ̆ū ̰.
-WS21	Wen hat er de ̆i̅ neiji Gschicht dazehlt.
-WS22	Mi ̆a̅ mo ̆ū hell schreija, sunst voschta ̆i̅t a oin niat.
-WS23	Mi ̆a̅ san me ̆i̅d und hom Du ̆a̅rscht.
-WS24	We ̆i̅ ma géstarn A ̆oūmds ham kumma san, san die andern scho ̰ in Bétt gleg’n und han fést gschla ̆oūfm.
-WS25	Da Schna ̆i̅ is in dèra Nacht vo uns liegn bliebm, owa heint fre ̆i̅h is awieda zganga.
-WS26	Hinta unsern Haus stenga drei sche ̆i̅ni Epflbeimla mit ra ̆oūt’n Epfalan.
+WS20	E ̆a̅ hat so tho ̆ū ̰, als wenns s’in zum Drèschn bschtellt ha ̆īn, sie hom’s owa selba tho ̆ū ̰.
+WS21	Wen hat er de ̆ī neiji Gschicht dazehlt.
+WS22	Mi ̆a̅ mo ̆ū hell schreija, sunst voschta ̆īt a oin niat.
+WS23	Mi ̆a̅ san me ̆īd und hom Du ̆a̅rscht.
+WS24	We ̆ī ma géstarn A ̆oūmds ham kumma san, san die andern scho ̰ in Bétt gleg’n und han fést gschla ̆oūfm.
+WS25	Da Schna ̆ī is in dèra Nacht vo uns liegn bliebm, owa heint fre ̆īh is awieda zganga.
+WS26	Hinta unsern Haus stenga drei sche ̆īni Epflbeimla mit ra ̆oūt’n Epfalan.
 WS27	Kinnts niat nu an Augnblick af uns wartn, acha gehma mit.
 WS28	Detz de ̆a̅rfts ni ̆a̅t secha Kindereien treibm.
-WS29	Unser Bèrch san niat rècht ha ̆oūch, die enkan san viel ha ̆i̅cha.
-WS30	We ̆i̅viel Pfund Wurscht und we ̆iviel Bra ̆oūt wellts denn.
-WS31	I vosta ̆i̅h enk ni ̆a̅t, detz me ̆i̅tz abißl hella redn.
+WS29	Unser Bèrch san niat rècht ha ̆oūch, die enkan san viel ha ̆īcha.
+WS30	We ̆īviel Pfund Wurscht und we ̆iviel Bra ̆oūt wellts denn.
+WS31	I vosta ̆īh enk ni ̆a̅t, detz me ̆ītz abißl hella redn.
 WS32	Hats ko ̰ Trüml weißi Saifm für mi af meim Tisch gfuna.
-WS33	Sa ̰ Bro ̆ūda will sa zwoa sche ̆i̅ni, neiji Heisa in enkan Gartn bauan.
+WS33	Sa ̰ Bro ̆ūda will sa zwoa sche ̆īni, neiji Heisa in enkan Gartn bauan.
 WS34	Des Wo ̆a̅rt is’n von Hèrzn ke?mma
 WS35	Des is rècht von ihnen gewèst
 WS36	Wos istz’n da ̆oū für Vegala afm Meiala drobm.
-WS37	Bauren han fünf Ochsn und ne ̰i ̰ Ke ̆i̅h und zwölf Lammla vo ̆a̅s s Do ̆a̅f bracht, de ̆i̅ homs vokafm wèlln.
+WS37	Bauren han fünf Ochsn und ne ̰i ̰ Ke ̆īh und zwölf Lammla vo ̆a̅s s Do ̆a̅f bracht, de ̆ī homs vokafm wèlln.
 WS38	D Leit san heint alle am Feld draß und ma̅hn.
-WS39	Ga ̆i̅ ne ̆a ̰, da brau ̰ Hund to ̆ūt da nix.
+WS39	Ga ̆ī ne ̆a ̰, da brau ̰ Hund to ̆ūt da nix.
 WS40	I bin mit’n Leitn da ̆oū hintn üwa d Wiesn ins Ko ̆a̅n gfo ̆a̅hn.

--- a/35687_Weiden.csv
+++ b/35687_Weiden.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	In Winda flei̅g’n die truckan Bladla in da Luft uma.
 WS02	‘s hăi̅at glei af zun schneia, nacha wirds Weda wieda bessa.
-WS03	Thŏū Kohln in O̅nfn, da̅s d Milch bal zum Kochn a ̰fangt.
+WS03	Thŏū Kohln in Ōnfn, da̅s d Milch bal zum Kochn a ̰fangt.
 WS04	Dea gu ̆a̅ti alti Mâ ̰ is mid’n Gàl àm Eis à ̰brochn und ins kalt Wassa gfalln.
 WS05	Er is voa̅ we ̆i̅ja oda séchs Wochan gschto ̆a̅rm.
 WS06	‘s Feija is tschto ̆a̅k gwes’n, Ka ̆oūchn san ja untnher alsaganza schwo ̆a̅ts brennt.
@@ -24,7 +24,7 @@ WS13	As san schlèchti Zeit’n.
 WS14	Ma ̰ le ̆i̅bs Kind, blei da ̆oū untn ste ̆i ̰̅h, de ̆i̅ ba ̆i̅si Géns beißn die ta ̆oūt.
 WS15	Du hast heit am meistn glèrnt u. bist bràv gwést, du därfst fre ̆i̅ja ham als die andern.
 WS16	Du bist nu ni̅a̅t gra ̆oūß gno ̆ūch um a Flaschn We ̰i ̰ asztrinkn, du mo ̆ūßt zèrschtmi ̆ a wengl waksn und gra ̆i̅ßa wèrn.
-WS17	Ga ̆i̅h, sa so gu ̆a̅t u. so̅ch deina Schwesta, sie solls Gwand für enka Mudda firtimachen ̆ u. mit da Bürschtn asbutzn.
+WS17	Ga ̆i̅h, sa so gu ̆a̅t u. sōch deina Schwesta, sie solls Gwand für enka Mudda firtimachen ̆ u. mit da Bürschtn asbutzn.
 WS18	Ha ̆i̅st’n ne ̆a ̰̅ kennt! nacha wàs anderscht kumma, und als stànd bessa um ihn.
 WS19	e ̆a̅ hat ma mein Ko ̆a̅b mit Fleisch gschtohln?
 WS20	E ̆a̅ hat so tho ̆ū ̰, als wenns s’in zum Drèschn bschtellt ha ̆i̅n, sie hom’s owa selba tho ̆ū ̰.

--- a/35687_Weiden.csv
+++ b/35687_Weiden.csv
@@ -11,40 +11,40 @@ Anmerkungen: ''
 WS01	In Winda fleīg’n die truckan Bladla in da Luft uma.
 WS02	‘s hăīat glei af zun schneia, nacha wirds Weda wieda bessa.
 WS03	Thŏū Kohln in Ōnfn, dās d Milch bal zum Kochn a ̰fangt.
-WS04	Dea gu ̆āti alti Mâ ̰ is mid’n Gàl àm Eis à ̰brochn und ins kalt Wassa gfalln.
-WS05	Er is voā we ̆īja oda séchs Wochan gschto ̆ārm.
-WS06	‘s Feija is tschto ̆āk gwes’n, Ka ̆oūchn san ja untnher alsaganza schwo ̆āts brennt.
+WS04	Dea gŭāti alti Mâ ̰ is mid’n Gàl àm Eis à ̰brochn und ins kalt Wassa gfalln.
+WS05	Er is voā wĕīja oda séchs Wochan gschtŏārm.
+WS06	‘s Feija is tschtŏāk gwes’n, Kăoūchn san ja untnher alsaganza schwŏāts brennt.
 WS07	Er ißt d Oija allamal ohni Salz und Pfèffa.
-WS08	Mia the ̆īn d Fe ̆ī ß rècht wo ̆aīh, i glab, i ho mi afganga.
+WS08	Mia thĕīn d Fĕī ß rècht wŏaīh, i glab, i ho mi afganga.
 WS09	I bin wo da Frau gwest u. hos ihr gsagt, und sie hat gsagt, sie wills ihrana Tochta scho ̰ sogn.
-WS10	I wills nimma to ̆ū ̰.
-WS11	Ich schloch di glei mit’n Kolöffl um d   A ̆oūrn, du Aff.
-WS12	Wa ̆oū ga ̆īst denn hi ̰, sollma ̰ mit ge ̆ī ̰h?
+WS10	I wills nimma tŏū ̰.
+WS11	Ich schloch di glei mit’n Kolöffl um d   Ăoū̌rn, du Aff.
+WS12	Wăoū găīst denn hi ̰, sollma ̰ mit gĕī ̰h?
 WS13	As san schlèchti Zeit’n.
-WS14	Ma ̰ le ̆ībs Kind, blei da ̆oū untn ste ̆i ̰̅h, de ̆ī ba ̆īsi Géns beißn die ta ̆oūt.
-WS15	Du hast heit am meistn glèrnt u. bist bràv gwést, du därfst fre ̆īja ham als die andern.
-WS16	Du bist nu nīāt gra ̆oūß gno ̆ūch um a Flaschn We ̰i ̰ asztrinkn, du mo ̆ūßt zèrschtmi ̆ a wengl waksn und gra ̆īßa wèrn.
-WS17	Ga ̆īh, sa so gu ̆āt u. sōch deina Schwesta, sie solls Gwand für enka Mudda firtimachen ̆ u. mit da Bürschtn asbutzn.
-WS18	Ha ̆īst’n ne ̆a ̰̅ kennt! nacha wàs anderscht kumma, und als stànd bessa um ihn.
-WS19	e ̆ā hat ma mein Ko ̆āb mit Fleisch gschtohln?
-WS20	E ̆ā hat so tho ̆ū ̰, als wenns s’in zum Drèschn bschtellt ha ̆īn, sie hom’s owa selba tho ̆ū ̰.
-WS21	Wen hat er de ̆ī neiji Gschicht dazehlt.
-WS22	Mi ̆ā mo ̆ū hell schreija, sunst voschta ̆īt a oin niat.
-WS23	Mi ̆ā san me ̆īd und hom Du ̆ārscht.
-WS24	We ̆ī ma géstarn A ̆oūmds ham kumma san, san die andern scho ̰ in Bétt gleg’n und han fést gschla ̆oūfm.
-WS25	Da Schna ̆ī is in dèra Nacht vo uns liegn bliebm, owa heint fre ̆īh is awieda zganga.
-WS26	Hinta unsern Haus stenga drei sche ̆īni Epflbeimla mit ra ̆oūt’n Epfalan.
+WS14	Ma ̰ lĕībs Kind, blei dăoū untn stĕi ̰̅h, dĕī băīsi Géns beißn die tăoūt.
+WS15	Du hast heit am meistn glèrnt u. bist bràv gwést, du därfst frĕīja ham als die andern.
+WS16	Du bist nu nīāt grăoūß gnŏūch um a Flaschn We ̰i ̰ asztrinkn, du mŏūßt zèrschtmĭ a wengl waksn und grăīßa wèrn.
+WS17	Găīh, sa so gŭāt u. sōch deina Schwesta, sie solls Gwand für enka Mudda firtimachen ŭ. mit da Bürschtn asbutzn.
+WS18	Hăīst’n nĕa ̰̅ kennt! nacha wàs anderscht kumma, und als stànd bessa um ihn.
+WS19	ĕā hat ma mein Kŏāb mit Fleisch gschtohln?
+WS20	Ĕā hat so thŏū ̰, als wenns s’in zum Drèschn bschtellt hăīn, sie hom’s owa selba thŏū ̰.
+WS21	Wen hat er dĕī neiji Gschicht dazehlt.
+WS22	Mĭā mŏū hell schreija, sunst voschtăīt a oin niat.
+WS23	Mĭā san mĕīd und hom Dŭārscht.
+WS24	Wĕī ma géstarn Ăoūmds ham kumma san, san die andern scho ̰ in Bétt gleg’n und han fést gschlăoūfm.
+WS25	Da Schnăī is in dèra Nacht vo uns liegn bliebm, owa heint frĕīh is awieda zganga.
+WS26	Hinta unsern Haus stenga drei schĕīni Epflbeimla mit răoūt’n Epfalan.
 WS27	Kinnts niat nu an Augnblick af uns wartn, acha gehma mit.
-WS28	Detz de ̆ārfts ni ̆āt secha Kindereien treibm.
-WS29	Unser Bèrch san niat rècht ha ̆oūch, die enkan san viel ha ̆īcha.
-WS30	We ̆īviel Pfund Wurscht und we ̆iviel Bra ̆oūt wellts denn.
-WS31	I vosta ̆īh enk ni ̆āt, detz me ̆ītz abißl hella redn.
+WS28	Detz dĕārfts nĭāt secha Kindereien treibm.
+WS29	Unser Bèrch san niat rècht hăoūch, die enkan san viel hăīcha.
+WS30	Wĕīviel Pfund Wurscht und wĕiviel Brăoūt wellts denn.
+WS31	I vostăīh enk nĭāt, detz mĕītz abißl hella redn.
 WS32	Hats ko ̰ Trüml weißi Saifm für mi af meim Tisch gfuna.
-WS33	Sa ̰ Bro ̆ūda will sa zwoa sche ̆īni, neiji Heisa in enkan Gartn bauan.
-WS34	Des Wo ̆ārt is’n von Hèrzn ke?mma
+WS33	Sa ̰ Brŏūda will sa zwoa schĕīni, neiji Heisa in enkan Gartn bauan.
+WS34	Des Wŏārt is’n von Hèrzn ke?mma
 WS35	Des is rècht von ihnen gewèst
-WS36	Wos istz’n da ̆oū für Vegala afm Meiala drobm.
-WS37	Bauren han fünf Ochsn und ne ̰i ̰ Ke ̆īh und zwölf Lammla vo ̆ās s Do ̆āf bracht, de ̆ī homs vokafm wèlln.
+WS36	Wos istz’n dăoū für Vegala afm Meiala drobm.
+WS37	Bauren han fünf Ochsn und ne ̰i ̰ Kĕīh und zwölf Lammla vŏās s Dŏāf bracht, dĕī homs vokafm wèlln.
 WS38	D Leit san heint alle am Feld draß und māhn.
-WS39	Ga ̆ī ne ̆a ̰, da brau ̰ Hund to ̆ūt da nix.
-WS40	I bin mit’n Leitn da ̆oū hintn üwa d Wiesn ins Ko ̆ān gfo ̆āhn.
+WS39	Găī nĕa ̰, da brau ̰ Hund tŏūt da nix.
+WS40	I bin mit’n Leitn dăoū hintn üwa d Wiesn ins Kŏān gfŏāhn.

--- a/35850_Bamberg.csv
+++ b/35850_Bamberg.csv
@@ -9,7 +9,7 @@ Transliterent: Victoria Schaub
 Anmerkungen: <Genau übertragen. Bamberg, 11. Oktober 1887. Henrika Beck, Lehrerin
   [I.] St. M.>
 ...
-WS01	Än̺ Wintä fliḛng die truckna Bléttä in dä Luft rü̬m̄.
+WS01	Än̬ Wintä fliḛng die truckna Bléttä in dä Luft rü̬m̄.
 WS02	Es höät glei auf zä̺ schneia, nochèt wéäds Wéhtä widdä béssä.
 WS03	Thu Kulln nein U̠fn, dass die Milli ball o̰ zä̺ siedn fengt.
 WS04	Dä̺ gut alt Mo̰h is mit sein Gaul durchs Eis gä̺brochn u. neis ko̰lt Wassä̺ gfalln.
@@ -32,20 +32,20 @@ WS20	E͡ä ho̬t gä̺tho̬h, als héttn siena̺ zä̺n Drèschn bäschtellt; si
 WS21	Wen hottä̺ die neu Gschicht dä̺zillt?
 WS22	Mä̺ muß laut schreia, sünst vä̺schtiehtä⁀runs nétt.
 WS23	Miä̺ senn müd ud ho̰m Du͡oscht.
-WS24	Wi͜e mä̺ géstä̺n ombst zärück kumma senn, do̬ wo̰ä̺n die andän scho̬̰ in Bett gä̺léng u. ho̬̰m fest gschlofn.
+WS24	Wi͡e mä̺ géstä̺n ombst zärück kumma senn, do̬ wo̰ä̺n die andän scho̬̰ in Bett gä̺léng u. ho̬̰m fest gschlofn.
 WS25	Dä Schnieh is in dera No̰cht bei uns ling gä̺blien, obä̺ heut früh is͡ ä̺ gschmolzn.
 WS26	Hintä̺ unän Haus schtenn drei schöna Öpflbamla mit ruta̺ Öpfä̺la̺.
 WS27	Könntä̺ nétt nu an Aungblick auf uns wa̺tn, noch ge̺hmä̺ a̠ mit euch.
 WS28	Ihä̺ dä̺ft ka̺ söda̺ Ki̺nèrei treim.
 WS29	Unä̺ Berch senn nétt o̰rch hu̠ch, euä̺ra̺ senn viel hö̬chä̺.
-WS30	Wie vill Pfund Wö̬͡ä̺scht und wi͜e vill Bru̠d wölltä̺ ho̠m?
+WS30	Wie vill Pfund Wö̬͡ä̺scht und wi͡e vill Bru̠d wölltä̺ ho̠m?
 WS31	Ich väschti̺h euch nét, ihä̺ müßt a̺ bißla̺ lautä̺ plaudä̺n.
 WS32	Ho̰ttä̺ ka̺ Stückla weißa Sa̠fn [fo̰] miä̺ auf mein  Ti̠sch gfunna̺?
 WS33	Sei Brudä̺ will si̺ zwa̠ schö̠na̺ neua̺ Häusä̺ nei euän Gattn baua.
 WS34	Des Wo͡ä̺t isn von He͡ä̺zn kumma.
 WS35	Des woä̺ recht vo̬̰nä̺na̺.
 WS36	Wos höckn denn do̠ fo̬̰ Vögä̺la̺ um aufn Mäuä̺la̺?
-WS37	Die Bauä̺n ho̬m fümf Ochsn und neu Küh und zwölf Scho̠fbätzn vo͡äs Do͡äf gä̺bro̬cht, die ho̬m si͜e väkafn wölln.
+WS37	Die Bauä̺n ho̬m fümf Ochsn und neu Küh und zwölf Scho̠fbätzn vo͡äs Do͡äf gä̺bro̬cht, die ho̬m si͡e väkafn wölln.
 WS38	Die Leut senn heut alla drauß aufn Félld und méha̺.
 WS39	Gieh nä̺ zu̠ de̺ä̺ brau Hund thu̬t dä̺ né̺chs.
-WS40	I̠ch bi̺ mitn Leutna̺ do̬ hintn übä̺ die Wiesn neis Ko͡än gfo̠hä̺n.
+WS40	I̱ch bi̺ mitn Leutna̺ do̬ hintn übä̺ die Wiesn neis Ko͡än gfo̠hä̺n.

--- a/35850_Bamberg.csv
+++ b/35850_Bamberg.csv
@@ -23,9 +23,9 @@ WS11	Ich schlo̠ch di glei mitn Ku̠cha̺löffl auf die Oähn, du Aff!
 WS12	Wu giehstn hie, söllmä̺ra̠ mit dä géh?
 WS13	Ä̺s senn schlächta̺ Zeitn!
 WS14	Mei libbs Kind, bleib do̺ druntn stéh, die büsn Géns beißn di̺ sünst tu̠ht.
-WS15	Du̺ ho̺st heut o̰m mö̺͡ä̺schtn gä̺le͡änt und bist o͡ändli̺ gä̺wést, du deäffst ah ehra̺ ha̠m wie die andä̺n.
-WS16	Du bist no̰ni gru̠ß gä̺nuch, üm a Flaschn Wei auszä̺trinkn, du mußt öäscht nu̺ a̠ wéng waksn un grö̺ßä̺ we͡än.
-WS17	Sei su̺ gut, gi̠eh no̰h und so̠ch deinera Schwestä̺, sie säll die Kla̠dä̺ fo̰ euera̺ Mu̺rrä fe͡äti néha̺ und mit dä̺ Bö͡äschtn saubä̺ machn.
+WS15	Du̬ ho̺st heut o̰m mö̺͡ä̺schtn gä̺le͡änt und bist o͡ändli̺ gä̺wést, du deäffst ah ehra̺ ha̠m wie die andä̺n.
+WS16	Du bist no̰ni gru̠ß gä̺nuch, üm a Flaschn Wei auszä̺trinkn, du mußt öäscht nu̬ a̠ wéng waksn un grö̺ßä̺ we͡än.
+WS17	Sei su̬ gut, gi̠eh no̰h und so̠ch deinera Schwestä̺, sie säll die Kla̠dä̺ fo̰ euera̺ Mu̬rrä fe͡äti néha̺ und mit dä̺ Bö͡äschtn saubä̺ machn.
 WS18	Héstna du gäkennt, no̰chet wö͡äs andä̺sch kumma und es thèt bessä̺ ümma̺ schté̠h.
 WS19	We͡ä̺ ho̺t mä̺ mein Korb mit Flahsch gschtulln?
 WS20	E͡ä ho̺t gä̺tho̺h, als héttn siena̺ zä̺n Drèschn bäschtellt; sie ho̰nds o̺bä̺ sèlbä̺ gä̺tho̰h.
@@ -47,5 +47,5 @@ WS35	Des woä̺ recht vo̺̰nä̺na̺.
 WS36	Wos höckn denn do̠ fo̺̰ Vögä̺la̺ um aufn Mäuä̺la̺?
 WS37	Die Bauä̺n ho̺m fümf Ochsn und neu Küh und zwölf Scho̠fbätzn vo͡äs Do͡äf gä̺bro̺cht, die ho̺m si͜e väkafn wölln.
 WS38	Die Leut senn heut alla drauß aufn Félld und méha̺.
-WS39	Gieh nä̺ zu̠ de̺ä̺ brau Hund thu̺t dä̺ né̺chs.
+WS39	Gieh nä̺ zu̠ de̺ä̺ brau Hund thu̬t dä̺ né̺chs.
 WS40	I̠ch bi̺ mitn Leutna̺ do̺ hintn übä̺ die Wiesn neis Ko͡än gfo̠hä̺n.

--- a/35850_Bamberg.csv
+++ b/35850_Bamberg.csv
@@ -9,7 +9,7 @@ Transliterent: Victoria Schaub
 Anmerkungen: <Genau übertragen. Bamberg, 11. Oktober 1887. Henrika Beck, Lehrerin
   [I.] St. M.>
 ...
-WS01	Än̺ Wintä fliḛng die truckna Bléttä in dä Luft rü̺m̄.
+WS01	Än̺ Wintä fliḛng die truckna Bléttä in dä Luft rü̬m̄.
 WS02	Es höät glei auf zä̺ schneia, nochèt wéäds Wéhtä widdä béssä.
 WS03	Thu Kulln nein U̠fn, dass die Milli ball o̰ zä̺ siedn fengt.
 WS04	Dä̺ gut alt Mo̰h is mit sein Gaul durchs Eis gä̺brochn u. neis ko̰lt Wassä̺ gfalln.
@@ -17,35 +17,35 @@ WS05	E͡ä is vo̰ vie͡ä ödä sechs Wochn gschtorm.
 WS06	Äs Feuä̺ wo͡ä zä̺ schtorik, die Kung sen jo untn ganz schwoa̺z gäbrennt.
 WS07	Eä ißt sei Eiä̺ ümmä̺ ohnä So̰lz un Pfäffä̺.
 WS08	Die Füß thomä̺ wieh, ich gla̠b, ich hobb sie durchgaloffn <= (aufgägnieft)>.
-WS09	Ich bi̺ bei dä̺ Fra̠ gä̺wést und hobb sera gsocht, und sie hot gso̺cht, sie wills a̰ ihra Tochtä̺ song.
+WS09	Ich bi̺ bei dä̺ Fra̠ gä̺wést und hobb sera gsocht, und sie hot gso̬cht, sie wills a̰ ihra Tochtä̺ song.
 WS10	Ich wills a nümmä̺ widdä̺ tho̰.
 WS11	Ich schlo̠ch di glei mitn Ku̠cha̺löffl auf die Oähn, du Aff!
 WS12	Wu giehstn hie, söllmä̺ra̠ mit dä géh?
 WS13	Ä̺s senn schlächta̺ Zeitn!
-WS14	Mei libbs Kind, bleib do̺ druntn stéh, die büsn Géns beißn di̺ sünst tu̠ht.
-WS15	Du̬ ho̺st heut o̰m mö̺͡ä̺schtn gä̺le͡änt und bist o͡ändli̺ gä̺wést, du deäffst ah ehra̺ ha̠m wie die andä̺n.
-WS16	Du bist no̰ni gru̠ß gä̺nuch, üm a Flaschn Wei auszä̺trinkn, du mußt öäscht nu̬ a̠ wéng waksn un grö̺ßä̺ we͡än.
+WS14	Mei libbs Kind, bleib do̬ druntn stéh, die büsn Géns beißn di̺ sünst tu̠ht.
+WS15	Du̬ ho̬st heut o̰m mö̬͡ä̺schtn gä̺le͡änt und bist o͡ändli̺ gä̺wést, du deäffst ah ehra̺ ha̠m wie die andä̺n.
+WS16	Du bist no̰ni gru̠ß gä̺nuch, üm a Flaschn Wei auszä̺trinkn, du mußt öäscht nu̬ a̠ wéng waksn un grö̬ßä̺ we͡än.
 WS17	Sei su̬ gut, gi̠eh no̰h und so̠ch deinera Schwestä̺, sie säll die Kla̠dä̺ fo̰ euera̺ Mu̬rrä fe͡äti néha̺ und mit dä̺ Bö͡äschtn saubä̺ machn.
 WS18	Héstna du gäkennt, no̰chet wö͡äs andä̺sch kumma und es thèt bessä̺ ümma̺ schté̠h.
-WS19	We͡ä̺ ho̺t mä̺ mein Korb mit Flahsch gschtulln?
-WS20	E͡ä ho̺t gä̺tho̺h, als héttn siena̺ zä̺n Drèschn bäschtellt; sie ho̰nds o̺bä̺ sèlbä̺ gä̺tho̰h.
+WS19	We͡ä̺ ho̬t mä̺ mein Korb mit Flahsch gschtulln?
+WS20	E͡ä ho̬t gä̺tho̬h, als héttn siena̺ zä̺n Drèschn bäschtellt; sie ho̰nds o̬bä̺ sèlbä̺ gä̺tho̰h.
 WS21	Wen hottä̺ die neu Gschicht dä̺zillt?
 WS22	Mä̺ muß laut schreia, sünst vä̺schtiehtä⁀runs nétt.
 WS23	Miä̺ senn müd ud ho̰m Du͡oscht.
-WS24	Wi͜e mä̺ géstä̺n ombst zärück kumma senn, do̺ wo̰ä̺n die andän scho̺̰ in Bett gä̺léng u. ho̺̰m fest gschlofn.
+WS24	Wi͜e mä̺ géstä̺n ombst zärück kumma senn, do̬ wo̰ä̺n die andän scho̬̰ in Bett gä̺léng u. ho̬̰m fest gschlofn.
 WS25	Dä Schnieh is in dera No̰cht bei uns ling gä̺blien, obä̺ heut früh is͡ ä̺ gschmolzn.
 WS26	Hintä̺ unän Haus schtenn drei schöna Öpflbamla mit ruta̺ Öpfä̺la̺.
 WS27	Könntä̺ nétt nu an Aungblick auf uns wa̺tn, noch ge̺hmä̺ a̠ mit euch.
 WS28	Ihä̺ dä̺ft ka̺ söda̺ Ki̺nèrei treim.
-WS29	Unä̺ Berch senn nétt o̰rch hu̠ch, euä̺ra̺ senn viel hö̺chä̺.
-WS30	Wie vill Pfund Wö̺͡ä̺scht und wi͜e vill Bru̠d wölltä̺ ho̠m?
+WS29	Unä̺ Berch senn nétt o̰rch hu̠ch, euä̺ra̺ senn viel hö̬chä̺.
+WS30	Wie vill Pfund Wö̬͡ä̺scht und wi͜e vill Bru̠d wölltä̺ ho̠m?
 WS31	Ich väschti̺h euch nét, ihä̺ müßt a̺ bißla̺ lautä̺ plaudä̺n.
 WS32	Ho̰ttä̺ ka̺ Stückla weißa Sa̠fn [fo̰] miä̺ auf mein  Ti̠sch gfunna̺?
 WS33	Sei Brudä̺ will si̺ zwa̠ schö̠na̺ neua̺ Häusä̺ nei euän Gattn baua.
 WS34	Des Wo͡ä̺t isn von He͡ä̺zn kumma.
-WS35	Des woä̺ recht vo̺̰nä̺na̺.
-WS36	Wos höckn denn do̠ fo̺̰ Vögä̺la̺ um aufn Mäuä̺la̺?
-WS37	Die Bauä̺n ho̺m fümf Ochsn und neu Küh und zwölf Scho̠fbätzn vo͡äs Do͡äf gä̺bro̺cht, die ho̺m si͜e väkafn wölln.
+WS35	Des woä̺ recht vo̬̰nä̺na̺.
+WS36	Wos höckn denn do̠ fo̬̰ Vögä̺la̺ um aufn Mäuä̺la̺?
+WS37	Die Bauä̺n ho̬m fümf Ochsn und neu Küh und zwölf Scho̠fbätzn vo͡äs Do͡äf gä̺bro̬cht, die ho̬m si͜e väkafn wölln.
 WS38	Die Leut senn heut alla drauß aufn Félld und méha̺.
 WS39	Gieh nä̺ zu̠ de̺ä̺ brau Hund thu̬t dä̺ né̺chs.
-WS40	I̠ch bi̺ mitn Leutna̺ do̺ hintn übä̺ die Wiesn neis Ko͡än gfo̠hä̺n.
+WS40	I̠ch bi̺ mitn Leutna̺ do̬ hintn übä̺ die Wiesn neis Ko͡än gfo̠hä̺n.

--- a/35850_Bamberg.csv
+++ b/35850_Bamberg.csv
@@ -26,7 +26,7 @@ WS14	Mei libbs Kind, bleib do̬ druntn stéh, die büsn Géns beißn di̺ sünst
 WS15	Du̬ ho̬st heut o̰m mö̬͡ä̺schtn gä̺le͡änt und bist o͡ändli̺ gä̺wést, du deäffst ah ehra̺ ha̠m wie die andä̺n.
 WS16	Du bist no̰ni gru̠ß gä̺nuch, üm a Flaschn Wei auszä̺trinkn, du mußt öäscht nu̬ a̠ wéng waksn un grö̬ßä̺ we͡än.
 WS17	Sei su̬ gut, gi̠eh no̰h und so̠ch deinera Schwestä̺, sie säll die Kla̠dä̺ fo̰ euera̺ Mu̬rrä fe͡äti néha̺ und mit dä̺ Bö͡äschtn saubä̺ machn.
-WS18	Héstna du gäkennt, no̰chet wö͡äs andä̺sch kumma und es thèt bessä̺ ümma̺ schté̠h.
+WS18	Héstna du gäkennt, no̰chet wö͡äs andä̺sch kumma und es thèt bessä̺ ümma̺ schté̱h.
 WS19	We͡ä̺ ho̬t mä̺ mein Korb mit Flahsch gschtulln?
 WS20	E͡ä ho̬t gä̺tho̬h, als héttn siena̺ zä̺n Drèschn bäschtellt; sie ho̰nds o̬bä̺ sèlbä̺ gä̺tho̰h.
 WS21	Wen hottä̺ die neu Gschicht dä̺zillt?

--- a/36043_Nagel.csv
+++ b/36043_Nagel.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	N’Winda flö ͡ign di drukna Bladla in da Luf umananada.
 WS02	S höja ̆rt glei zan schneia af, naha wirds Weda wieder bessa.
 WS03	Dou Kuhla in̅ Ua ̆fa, das d’Milch bals Kochn a ̃nfangt.
-WS04	Da go̅ud alt Ma ̃ is midn Pfa durchs Eis brochn und ins kalt Wassa gfalln.
+WS04	Da gōud alt Ma ̃ is midn Pfa durchs Eis brochn und ins kalt Wassa gfalln.
 WS05	Vö ͡ar vöja oda sechs Wochn is a gschtárm.
 WS06	S Feia is z schtark gwesn, d’Kuchn san ja unda ganz schwárz bren???
 WS07	Ea ißt d Aja im̅a ohne Solz u. Pfeffa.

--- a/36043_Nagel.csv
+++ b/36043_Nagel.csv
@@ -10,14 +10,14 @@ Anmerkungen: ''
 ...
 WS01	N’Winda flö ͡ign di drukna Bladla in da Luf umananada.
 WS02	S höja ̆rt glei zan schneia af, naha wirds Weda wieder bessa.
-WS03	Dou Kuhla in̅ Ua ̆fa, das d’Milch bals Kochn a ̃nfangt.
+WS03	Dou Kuhla in̄ Ua ̆fa, das d’Milch bals Kochn a ̃nfangt.
 WS04	Da gōud alt Ma ̃ is midn Pfa durchs Eis brochn und ins kalt Wassa gfalln.
 WS05	Vö ͡ar vöja oda sechs Wochn is a gschtárm.
 WS06	S Feia is z schtark gwesn, d’Kuchn san ja unda ganz schwárz bren???
-WS07	Ea ißt d Aja im̅a ohne Solz u. Pfeffa.
+WS07	Ea ißt d Aja im̄a ohne Solz u. Pfeffa.
 WS08	D’Föiß douma wäi´, i glab, i hos durchgloffn.
 WS09	I bin bei da Frau gwesn u hob ?ras geságt, u. sie háut gsagt, s will a ihra Dochta sogn.
-WS10	I will a nim̅a wieda dou ̃n.
+WS10	I will a nim̄a wieda dou ̃n.
 WS11	I schlo ͡a di glei middn Kuchlöffl uma d’Óurn, du Aff du!
 WS12	Wáu göissn hin ̃, sollma mit di ͡a göin ̃?
 WS13	‘s san schläadde Zeiddn.
@@ -25,24 +25,24 @@ WS14	O ma ̃ löibs Kind, bleib dáu undn stöin ̃, dö böisn Gäns beißn di 
 WS15	Du háust heuet s am meist glernt d. bist oardde gwesn, du derfst äjenda ho ͡am göin als di andern.
 WS16	Du bist nu nöt gráus gno ͡u, daßt a Flaschn We ̃i ̃n astrinkast , du maußt äjerscht eu ebbes waxe u gröißer were.
 WS17	Gö ͡i sa su goud u. sog deina Schwesta, sie soll d’Kloda fü ͡a enka Mudda ferte nahn u. midda Bürschtn saba machn.
-WS18	O wen̅stn kent höist, nacha wars anderst kuma u. s taht bessa um i ̃hn stö ̃i ̃n.
+WS18	O wen̄stn kent höist, nacha wars anderst kuma u. s taht bessa um i ̃hn stö ̃i ̃n.
 WS19	We ͡a há ͡ut ma mein Korb mide Fleisch gestuln?
 WS20	Ea hóut su ͡a do ̃u ̃n, als hoinsn zum dreschn beschellt, ‘s homs oba sälba do ̃u ̃n.
 WS21	Wen háuda di neu Gschicht dazielt?
 WS22	Ma mouß laut schreia, suast vaschtäit a ues niut.
 WS23	Mia ̃ san mö ͡id u. hom Durscht.
-WS24	Wöima gestan Àumz zruk kum̅a san, san die Andera scha im Bett glegn u. hom fest geschlaffn.
+WS24	Wöima gestan Àumz zruk kum̄a san, san die Andera scha im Bett glegn u. hom fest geschlaffn.
 WS25	Da Schnai ès döi Nacht bei uns liegn bliebm, ob heuet mo ͡argn is er gschmolzn.
 WS26	Hindda unsan Haus stögna drei schöi ̃n Eplbaimla mit ráudn Epferln.
 WS27	Kainz nnöit nu a Bisserl af uns warddn, nacha gömma a mit.
-WS28	Enks derfz nöit solchene Kin̅ereién dreibm.
+WS28	Enks derfz nöit solchene Kin̄ereién dreibm.
 WS29	Ansa Berch san nöit háuch, die enkere san viél höicha.
 WS30	Wöivül Pfund Wurscht u. wöifül Bráud wölz hom?
 WS31	I verstöi enk nöit, s moißz a bißl laudder sprechn.
 WS32	Habz ko ̃a ̃n Stückl weiße Sáüfn füa mi ̃ af mein Disch gfuna?
 WS33	Sa ̃n Broudda will si zwo ̃a ̃ schäine neue Kaüha in enkam Gartn baua.
 WS34	Dös Wort is ihm von Herzen kuma.
-WS35	Dös ist re ͡ad gwesn von in̅en.
+WS35	Dös ist re ͡ad gwesn von in̄en.
 WS36	W[?]s füa Vüaga ̆la sitzn dóu unun afm Majala?
 WS37	De Bauere han fén Ochs u. ne ̃u ̃n Köü u. zwölf Schöifla vors Dorf brunga khabbt, döi hons vakafn wölle.
 WS38	D’Leudd san heuet alle draßn afm Feld u. mahn.

--- a/36043_Nagel.csv
+++ b/36043_Nagel.csv
@@ -9,8 +9,8 @@ Transliterent: Philipp Spang
 Anmerkungen: ''
 ...
 WS01	N’Winda flö ͡ign di drukna Bladla in da Luf umananada.
-WS02	S höja ̆rt glei zan schneia af, naha wirds Weda wieder bessa.
-WS03	Dou Kuhla in̄ Ua ̆fa, das d’Milch bals Kochn a ̃nfangt.
+WS02	S höjărt glei zan schneia af, naha wirds Weda wieder bessa.
+WS03	Dou Kuhla in̄ Uăfa, das d’Milch bals Kochn a ̃nfangt.
 WS04	Da gōud alt Ma ̃ is midn Pfa durchs Eis brochn und ins kalt Wassa gfalln.
 WS05	Vö ͡ar vöja oda sechs Wochn is a gschtárm.
 WS06	S Feia is z schtark gwesn, d’Kuchn san ja unda ganz schwárz bren???
@@ -43,8 +43,8 @@ WS32	Habz ko ̃a ̃n Stückl weiße Sáüfn füa mi ̃ af mein Disch gfuna?
 WS33	Sa ̃n Broudda will si zwo ̃a ̃ schäine neue Kaüha in enkam Gartn baua.
 WS34	Dös Wort is ihm von Herzen kuma.
 WS35	Dös ist re ͡ad gwesn von in̄en.
-WS36	W[?]s füa Vüaga ̆la sitzn dóu unun afm Majala?
+WS36	W[?]s füa Vüagăla sitzn dóu unun afm Majala?
 WS37	De Bauere han fén Ochs u. ne ̃u ̃n Köü u. zwölf Schöifla vors Dorf brunga khabbt, döi hons vakafn wölle.
 WS38	D’Leudd san heuet alle draßn afm Feld u. mahn.
-WS39	Göi näa, da bra ̃u ̃ ̆n Hund do udda nix.
+WS39	Göi näa, da braŭ͡n Hund do udda nix.
 WS40	I bin midde Beuddn däu hinddn üba? d’Wies ins Korn gfahrn.

--- a/36158_Niederehnheim.csv
+++ b/36158_Niederehnheim.csv
@@ -18,7 +18,7 @@ WS07	Er éßt d’Eier allewill ohne Salz o Pfaffer.
 WS08	D’Füeß düā-mer weh, i glauib, i ha-ſe dorchg’loffe.
 WS09	‚Ech be bi-der Fraui gſé on haſere g‘ſait, on ſe hätt gſait, ſé wélls aui ehrer Dochter ſaÿe.
 WS10	I wélls aui ném mache.
-WS11	Éch ſchlä͞ der glich mé dem Kochlöffel éwer d’Ohre reom, dü Aff!
+WS11	Éch ſchlǟ der glich mé dem Kochlöffel éwer d’Ohre reom, dü Aff!
 WS12	Wü géhſch onne, ſälle mer mé-der geh‘?
 WS13	S’én ſchlāchti Zitte.
 WS14	Mi liabs Khäid, blief ëihne ſteh, d‘béſe Geus biſſe di dot.
@@ -27,7 +27,7 @@ WS16	Dü béſch nonét groß gnüa, om-e Bodall Win üs-ze-trenke, dü müaſch
 WS17	Geh, ſé ſo güāt on ſaui dinnere Schweſter, ſie ſäll d’Kleider fer äÿeri Moder ferti mache, on mé-der Bérſcht ſǖhfer mache.
 WS18	Hatſch düh-ne kannt, ſo wahr’s anderſch komme, on-es gath beſſer med-em ſteh!
 WS19	Wér hätt mer minne Korb med Fleiſch gvchtohle?
-WS20	Er hätt g’macht, wè wèmmer-ne züam Dreſche bſtellt hatt, ſe hans awer ſa̅lbſt gmacht.
+WS20	Er hätt g’macht, wè wèmmer-ne züam Dreſche bſtellt hatt, ſe hans awer ſālbſt gmacht.
 WS21	Wamm hätt-er d’nei gſchécht erzählt?
 WS22	Me müaß lütt ſchreye, ſonſcht verſteht er öüs nétt.
 WS23	Mer ſén müad o han Dorſcht.
@@ -37,12 +37,12 @@ WS26	Häiner öuſerem Hüß ſchtehn dräi Äpfelbaimle met rothe n’Äpfele.
 WS27	Kennen-ner nétt noch e Auebleik of öüs worte, dernoh geh-mer met-ech.
 WS28	Ehr därfe känn ſo Khäinerdengs triewe.
 WS29	Öüſere B?rrÿe ſé nétt ahri hoch, äyeri ſé viel húher.
-WS30	Wia viel Pföid Wérſcht on wia viel Brot welle-ner ha̅h?
+WS30	Wia viel Pföid Wérſcht on wia viel Brot welle-ner hāh?
 WS31	Éch verſteh äich nétt, éhr müan-a béſſel lütter rede.
 WS32	Han-er nét a Stékel wiſſi Saif ver mich of minnem Déſch gföine?
 WS33	Sinner Brüader wéll ſich zwei ſchéni näie Hieſer én äierem Garte böie.
 WS34	Dèß Wort eſch-em vom Harze komme.
-WS35	Daß éſch ra̅cht gſen von Äich.
+WS35	Daß éſch rācht gſen von Äich.
 WS36	Was ſétze do fer Väÿele owe nofem Mierl?
 WS37	D’Bühre hah fenf Ochſe on nin Kiahi on zwälf Schéfle vors Dorf gebrocht, dia han-ſe wèlle verkauife.
 WS38	D’Litt ſén hitt alli drüſſe offem Fald o mahÿe.

--- a/36158_Niederehnheim.csv
+++ b/36158_Niederehnheim.csv
@@ -12,7 +12,7 @@ WS01	Ém Wäȳter fliāye d’dérre Blätter é-der Loft erom.
 WS02	S’halt glich met ſchnäye of, dernōh words Watter wédder bèſſer.
 WS03	Mach Kohle é-de n’Offe, daß d’Mélich ball āfangt zú koche.
 WS04	Der güāt alt Mann éſch mé-dem Roß dorchs Iß gebroche on éſch és kalt Waſſer g’falle.
-WS05	Er eſch vor vi͞ar oder ſechs Woche g‘ſtōrwe.
+WS05	Er eſch vor vi͡ar oder ſechs Woche g‘ſtōrwe.
 WS06	S’Fiehr éſch ze ſtōrik gſé, d’Kuāche ſen jo eihne gäüs verbrannt.
 WS07	Er éßt d’Eier allewill ohne Salz o Pfaffer.
 WS08	D’Füeß düā-mer weh, i glauib, i ha-ſe dorchg’loffe.

--- a/36158_Niederehnheim.csv
+++ b/36158_Niederehnheim.csv
@@ -24,7 +24,7 @@ WS13	S’én ſchlāchti Zitte.
 WS14	Mi liabs Khäid, blief ëihne ſteh, d‘béſe Geus biſſe di dot.
 WS15	Dü häſch hitt am mēdelſchte g’lehrt, on béſch artli gſé, dü därfſch énder heim als d’Andre.
 WS16	Dü béſch nonét groß gnüa, om-e Bodall Win üs-ze-trenke, dü müaſch zérſcht noch-e-bëſſel wachſe o grehſer wahre.
-WS17	Geh, ſé ſo güāt on ſaui dinnere Schweſter, ſie ſäll d’Kleider fer äÿeri Moder ferti mache, on mé-der Bérſcht ſü̅hfer mache.
+WS17	Geh, ſé ſo güāt on ſaui dinnere Schweſter, ſie ſäll d’Kleider fer äÿeri Moder ferti mache, on mé-der Bérſcht ſǖhfer mache.
 WS18	Hatſch düh-ne kannt, ſo wahr’s anderſch komme, on-es gath beſſer med-em ſteh!
 WS19	Wér hätt mer minne Korb med Fleiſch gvchtohle?
 WS20	Er hätt g’macht, wè wèmmer-ne züam Dreſche bſtellt hatt, ſe hans awer ſa̅lbſt gmacht.

--- a/36159_Meistratzheim.csv
+++ b/36159_Meistratzheim.csv
@@ -12,9 +12,9 @@ WS01	Em Wender fliaje di drogene Blädder e der Luft erum.
 WS02	s’ hörd gli uf ze schneije, dernoh wurd’s Wadder widder besser.
 WS03	Mach’ Kohle e de n’Offe aß d’Melich bal kocht.
 WS04	D’r guet alt Mann isch med’m Roß durch’s Iß gebroche an eß kalt Wasser g’falle.
-WS05	ǎrr esch vorr viǎrr edder sechs Wǔche g’storwe.
+WS05	ărr esch vorr viărr edder sechs Wǔche g’storwe.
 WS06	s’ Fīr esch ze storrig g’sinn, d’ Kuache se joh unde gans schwŏrz gābrannt.
-WS07	ǎrr eßt d’ Eier alewill uhne Salz a Pfaffer.
+WS07	ărr eßt d’ Eier alewill uhne Salz a Pfaffer.
 WS08	D’ Fiaß duam’r weh, i glaub’ i ho se durich geloffe.
 WS09	Ech be bi d’r Frau g’senn, a ho se re g’seit, si seit, si well’s au ehre Dōchter saue.
 WS10	I well’s gor nemm mache.

--- a/36178_Müllen.csv
+++ b/36178_Müllen.csv
@@ -12,16 +12,16 @@ WS01	Ĭm Wĭnter fliègè̆ dĭ trŭckenè̆ in d’r Luft rŭm.
 WS02	’s hé̄rt glich ŭf z’schnéiè̆ dérnŏ wŭrd ’s Wè̆tter wĭder bésser.
 WS03	Duo Kohle in den Ofe, daß d’Milch bald an z’koche fangt.
 WS04	D’r guat alt ǎlt Mann ǐsch mit’m Rŏß dǔrchs Īs brŏchè̌ ǔn in’s kǎlt Wasser gfallè̌.
-WS05	È̌r ǐsch vŏr viér ŏder séx Wochè̌ gschtŏrbè̌.
+WS05	È̆r ǐsch vŏr viér ŏder séx Wochè̌ gschtŏrbè̌.
 WS06	’s Fiir wār z’schtărk, d’ Kuèchè sĭn jŏ undă gănz schwărz brènnt.
-WS07	È̌r iß̬t d’ Aier allè̌wīl ǔnǐ Sǎlz ǔn Pfèffer.
+WS07	È̆r iß̬t d’ Aier allè̌wīl ǔnǐ Sǎlz ǔn Pfèffer.
 WS08	D’ Fièß diémr wéh, i glaub, i hab si durch gloffè. 
 WS09	I bĭn bĭ d’r Frau gsĭn ŭn hăb’ è̆r è̆s gsait ŭn sĭ hé̆t gsait, sĭ will’s au ihrer Dóchter săgè̆.
 WS10	I will’s au nimm wider dièn.
 WS11	I schlăg dĭ glich mit’m Kŏchléffel ŭm d’ Ohrè, dŭ Aff.
 WS12	Wo géscht du ănna, sollè m’r mĭt d’r géhn?
 WS13	È̆s sĭn schlè̄chtĭ Zĭtè̆.
-WS14	Mĭ lĩèbs Kind blī dŏ ŭndĕ ste̒hn, d’ bēsĭ Gä̆ns bissè̆ dĭ dōd.
+WS14	Mĭ lĩèbs Kind blī dŏ ŭndĕ stéhn, d’ bēsĭ Gä̆ns bissè̆ dĭ dōd.
 WS15	Dŭ hé̆sch hĭt ăm maischtè̆ g’léhrt ŭn bĭsch ōrdlĭ gsĭn, dŭ dä̆rfsch frīä̆jér haim géhn ăls d’ănd’rĭ.
 WS16	Dŭ bĭsch nŏch nĭt grōß g’nūă ům ă Flăsch Wīn ūs z’trĭnkè, du muŏsch é̄rscht nŏch méh wăxè̆ ŭn gré̄ßer wǟrè̆.
 WS17	Géh séi sŏ guăt ŭn săg dīnerè̆ Schwé̆schter, sĭ soll d’ Glaider fĭr éier Muèter fè̆rtig naiè̆ ŭn mit d’r Bīrscht rain măchè̆.

--- a/36178_Müllen.csv
+++ b/36178_Müllen.csv
@@ -11,8 +11,8 @@ Anmerkungen: ''
 WS01	Ĭm Wĭnter fliègè̆ dĭ trŭckenè̆ in d’r Luft rŭm.
 WS02	’s hé̄rt glich ŭf z’schnéiè̆ dérnŏ wŭrd ’s Wè̆tter wĭder bésser.
 WS03	Duo Kohle in den Ofe, daß d’Milch bald an z’koche fangt.
-WS04	D’r guat alt ǎlt Mann ǐsch mit’m Rǒß dǔrchs Īs brǒchè̌ ǔn in’s kǎlt Wasser gfallè̌.
-WS05	È̌r ǐsch vǒr viér ǒder séx Wochè̌ gschtǒrbè̌.
+WS04	D’r guat alt ǎlt Mann ǐsch mit’m Rŏß dǔrchs Īs brŏchè̌ ǔn in’s kǎlt Wasser gfallè̌.
+WS05	È̌r ǐsch vŏr viér ŏder séx Wochè̌ gschtŏrbè̌.
 WS06	’s Fiir wār z’schtărk, d’ Kuèchè sĭn jŏ undă gănz schwărz brènnt.
 WS07	È̌r iß̬t d’ Aier allè̌wīl ǔnǐ Sǎlz ǔn Pfèffer.
 WS08	D’ Fièß diémr wéh, i glaub, i hab si durch gloffè. 

--- a/36178_Müllen.csv
+++ b/36178_Müllen.csv
@@ -14,7 +14,7 @@ WS03	Duo Kohle in den Ofe, daß d’Milch bald an z’koche fangt.
 WS04	D’r guat alt ǎlt Mann ǐsch mit’m Rǒß dǔrchs Īs brǒchè̌ ǔn in’s kǎlt Wasser gfallè̌.
 WS05	È̌r ǐsch vǒr viér ǒder séx Wochè̌ gschtǒrbè̌.
 WS06	’s Fiir wār z’schtărk, d’ Kuèchè sĭn jŏ undă gănz schwărz brènnt.
-WS07	È̌r iß̮t d’ Aier allè̌wīl ǔnǐ Sǎlz ǔn Pfèffer.
+WS07	È̌r iß̬t d’ Aier allè̌wīl ǔnǐ Sǎlz ǔn Pfèffer.
 WS08	D’ Fièß diémr wéh, i glaub, i hab si durch gloffè. 
 WS09	I bĭn bĭ d’r Frau gsĭn ŭn hăb’ è̆r è̆s gsait ŭn sĭ hé̆t gsait, sĭ will’s au ihrer Dóchter săgè̆.
 WS10	I will’s au nimm wider dièn.

--- a/36178_Müllen.csv
+++ b/36178_Müllen.csv
@@ -11,10 +11,10 @@ Anmerkungen: ''
 WS01	Ĭm Wĭnter fliègè̆ dĭ trŭckenè̆ in d’r Luft rŭm.
 WS02	’s hé̄rt glich ŭf z’schnéiè̆ dérnŏ wŭrd ’s Wè̆tter wĭder bésser.
 WS03	Duo Kohle in den Ofe, daß d’Milch bald an z’koche fangt.
-WS04	D’r guat alt ǎlt Mann ǐsch mit’m Rŏß dǔrchs Īs brŏchè̌ ǔn in’s kǎlt Wasser gfallè̌.
+WS04	D’r guat alt ălt Mann ǐsch mit’m Rŏß dǔrchs Īs brŏchè̌ ǔn in’s kălt Wasser gfallè̌.
 WS05	È̆r ǐsch vŏr viér ŏder séx Wochè̌ gschtŏrbè̌.
 WS06	’s Fiir wār z’schtărk, d’ Kuèchè sĭn jŏ undă gănz schwărz brènnt.
-WS07	È̆r iß̬t d’ Aier allè̌wīl ǔnǐ Sǎlz ǔn Pfèffer.
+WS07	È̆r iß̬t d’ Aier allè̌wīl ǔnǐ Sălz ǔn Pfèffer.
 WS08	D’ Fièß diémr wéh, i glaub, i hab si durch gloffè. 
 WS09	I bĭn bĭ d’r Frau gsĭn ŭn hăb’ è̆r è̆s gsait ŭn sĭ hé̆t gsait, sĭ will’s au ihrer Dóchter săgè̆.
 WS10	I will’s au nimm wider dièn.

--- a/36202_Kniebis.csv
+++ b/36202_Kniebis.csv
@@ -12,16 +12,16 @@ WS01	Em Wénder fliĕgḛt de druckénḛ̆(an) Blédder en dr Luft romm.
 WS02	S’ hé̄rt glei uf mit schneiḛ̆(an), no(a) wurd s’ Wèdder wider bésser.
 WS03	Duer Kole en Ofe, daß d’ Millich ball afangt koche.
 WS04	D’r gu͡ǎt alt Mā̰ ischt mit’m Roß dur s’ Eis (nā=)brochḛ̌ onn éns kalt Wasser gefallḛ̌.
-WS05	E(a)r ischt vo(a)r vi͜ǎr oder sex Wochḛ̌ gschdo(a)rbḛ̌.
+WS05	E(a)r ischt vo(a)r vi͡ǎr oder sex Wochḛ̌ gschdo(a)rbḛ̌.
 WS06	S’ Fīr ischt zschdark gsei, d’Kuăchĕ sénn jo(a) onnĕ ganz schwārz brännt.
 WS07	E(a)r ißt d’ Āejer ällḛweil aone Salz onn Pfèffer.
 WS08	D’ Fias deã mer waeh, i glãob, i haos durgloffě.
-WS09	I bḛi bei d’r Fră͜o gsḛi onn hă̰o=r=ĕs gsāet, onn se ho(a)t gsāet, se wélls a͜o ĭ͜arer Dōchder sagḛ̆.
+WS09	I bḛi bei d’r Fră͜o gsḛi onn hă̰o=r=ĕs gsāet, onn se ho(a)t gsāet, se wélls a͜o ī͡arer Dōchder sagḛ̆.
 WS10	I wills ao némmé dao.
 WS11	I schlā de <(gao)> glei mit’m Kochléffel om d’Ōhrĕ <(röm)>, du Aff.
 WS12	Wo go(a)scht nā, sollě mĕr mit d’r găo?
 WS13	S’ sén schlè̄chde Zeitĕ̠!
-WS14	Mḛi li͜ăbs Kénd, bleib do(a) honn̰̆e sta̰o̰, di͜ḛ bāese Gḛ̄s beißḛ̄ de zda͜od.
+WS14	Mḛi li͡ăbs Kénd, bleib do(a) honn̰̆ sta̰o̰, di͡ḛ bāese Gḛ̄s beißḛ̄ de zda͜od.
 WS15	Dau ho(a)st hḛit am māeschdḛ̆ glèrnt onn bischt ārdich gsḛi, dau därscht bélder hā̰em ga̰o als de Andĕre.
 WS16	Dau bischt no̰ net graos gmu͡a̰, om a̰ Flasch Wḛi auszdrénget, dḛ̆ mŭ͡ascht zerstḛ̆ no̰ māe wāsḛ̆ on grāeser wärḛ̆.
 WS17	Gang, sei so gue(a)t on sag dḛirḛ̆ Schweschder, se soll diă Klāeder <(des Häs)> fīre eier Mu͡ăder fērdich năjḛ̆ on mit dr Birscht sauber machḛ̆.
@@ -37,14 +37,14 @@ WS26	Hender eisrem Haus stean drei schene Epflbämmle mit raode Epfele.
 WS27	Kénne̟(ǎ)der net no̰ a̰ <(klḛḭs)> Weile uf ich <(od. ḛḭs)> wārtḛ̌, no(a) gḛ̌a̰ mĕr mit ich.
 WS28	E(a)r dérfet kāene so Kéndereiḛ̆ treibḛ̆.
 WS29	Ḛisere Bèrg senn net so arg hoch, de eire sénn veil hécher.
-WS30	Wi͜ăvl Pfond Wūrscht onn wi͜ăvl Brōt wéllet=ĕ(a)r ha̰o?
-WS31	I verschdand ich net, ĕ(a)r mi͜ăßet ă̰ bißle lauder schwätzḛ̆.
+WS30	Wi͡ăvl Pfond Wūrscht onn wi͡ăvl Brōt wéllet=ĕ(a)r ha̰o?
+WS31	I verschdand ich net, ĕ(a)r mi͡ăßet ă̰ bißle lauder schwätzḛ̆.
 WS32	Hänn=er kei Schtickle weiße Saepfe fir mi uf meim Disch gfonde.
 WS33	Sḛi Bru͡ăder will=e(a)m zwāe schéne neié Heiser in eurĕm Gartḛ̆ bauḛ̆.
 WS34	S’ <(als hinw. Fürw. dēs)> Wo(a)rt ischt=em vom Hèrzḛ̆ kom̄ḛ̆.
 WS35	Des ischt recht gsei vao=n=ene.
 WS36	Was sitzet do(a) fir Végḗlé uf de͜ăm Meiĕrle dobḛ̆?
-WS37	D’ <(od. di͜ă̰)> Baurḛ̆ hänn fenf Oxḛ̆ onn nḛḭ Ki͜ă̰ onn zwélf Schäfle vo(a)rs Do(a)rf bro(a)cht ghett, di͜ă̰ hänn se verkaufḛ̆ wellḛ̆.
+WS37	D’ <(od. di͡ă̰)> Baurḛ̆ hänn fenf Oxḛ̆ onn nḛḭ Ki͡ă̰ onn zwélf Schäfle vo(a)rs Do(a)rf bro(a)cht ghett, di͡ă̰ hänn se verkaufḛ̆ wellḛ̆.
 WS38	D’ Leit senn heit älle uf’m Fèld dussě onn mājet.
 WS39	Gang nao, d’r brao Hond duat d’r nix.
-WS40	I bḛi mit de Leit do(a) hennḛ̆ iber d’ Wi̅s ens Ko(a)rn gfa̅rḛ.
+WS40	I bḛi mit de Leit do(a) hennḛ̆ iber d’ Wīs ens Ko(a)rn gfa̅rḛ.

--- a/36202_Kniebis.csv
+++ b/36202_Kniebis.csv
@@ -15,17 +15,17 @@ WS04	D’r gu͡ǎt alt Mā̰ ischt mit’m Roß dur s’ Eis (nā=)brochḛ̌ on
 WS05	E(a)r ischt vo(a)r vi͡ǎr oder sex Wochḛ̌ gschdo(a)rbḛ̌.
 WS06	S’ Fīr ischt zschdark gsei, d’Kuăchĕ sénn jo(a) onnĕ ganz schwārz brännt.
 WS07	E(a)r ißt d’ Āejer ällḛweil aone Salz onn Pfèffer.
-WS08	D’ Fias deã mer waeh, i glãob, i haos durgloffě.
+WS08	D’ Fias deã mer waeh, i glãob, i haos durgloffĕ.
 WS09	I bḛi bei d’r Fră͜o gsḛi onn hă̰o=r=ĕs gsāet, onn se ho(a)t gsāet, se wélls a͜o ī͡arer Dōchder sagḛ̆.
 WS10	I wills ao némmé dao.
 WS11	I schlā de <(gao)> glei mit’m Kochléffel om d’Ōhrĕ <(röm)>, du Aff.
-WS12	Wo go(a)scht nā, sollě mĕr mit d’r găo?
+WS12	Wo go(a)scht nā, sollĕ mĕr mit d’r găo?
 WS13	S’ sén schlè̄chde Zeitĕ̠!
 WS14	Mḛi li͡ăbs Kénd, bleib do(a) honn̰̆ sta̰o̰, di͡ḛ bāese Gḛ̄s beißḛ̄ de zda͜od.
 WS15	Dau ho(a)st hḛit am māeschdḛ̆ glèrnt onn bischt ārdich gsḛi, dau därscht bélder hā̰em ga̰o als de Andĕre.
 WS16	Dau bischt no̰ net graos gmu͡a̰, om a̰ Flasch Wḛi auszdrénget, dḛ̆ mŭ͡ascht zerstḛ̆ no̰ māe wāsḛ̆ on grāeser wärḛ̆.
 WS17	Gang, sei so gue(a)t on sag dḛirḛ̆ Schweschder, se soll diă Klāeder <(des Häs)> fīre eier Mu͡ăder fērdich năjḛ̆ on mit dr Birscht sauber machḛ̆.
-WS18	Hátscht dau nă̰ (na̰o̰) kännt! no(a) wärs anderscht kommě̠ on s’dät bésser om ǎ̰ stǎ̰o.
+WS18	Hátscht dau nă̰ (na̰o̰) kännt! no(a) wärs anderscht kommĕ̠ on s’dät bésser om ǎ̰ stǎ̰o.
 WS19	Wèr ho(a)t miăr mein Ko(a)rb <(Grattĕ)> vōl Flāesch gschdolĕ?
 WS20	E(a)r ho(a)t <(nao)> so dao, wia wenn se ehn zuam Dresche bschdellt <(agschdellt)> heddet, se hänz aber sèlber dao.
 WS21	Weăm ho(a)t’r diă nei Gschīchd verzēhld?
@@ -34,7 +34,7 @@ WS23	Mer senn miad on hänn durscht.
 WS24	Wo mer geschdert zo(a)bed <(nächt)> zruckkomme senn, no(a) senn de andere schao em Bett glege on hänn fescht gschlo(a)fe.
 WS25	Dr Schnae ischt dia Nacht bei eis leige blibe, aber dea <(dean)> Mo(a)rge ischt e(a)r gschmolze.
 WS26	Hender eisrem Haus stean drei schene Epflbämmle mit raode Epfele.
-WS27	Kénne̟(ǎ)der net no̰ a̰ <(klḛḭs)> Weile uf ich <(od. ḛḭs)> wārtḛ̌, no(a) gḛ̌a̰ mĕr mit ich.
+WS27	Kénne̩̠(ǎ)der net no̰ a̰ <(klḛḭs)> Weile uf ich <(od. ḛḭs)> wārtḛ̌, no(a) gḛ̌a̰ mĕr mit ich.
 WS28	E(a)r dérfet kāene so Kéndereiḛ̆ treibḛ̆.
 WS29	Ḛisere Bèrg senn net so arg hoch, de eire sénn veil hécher.
 WS30	Wi͡ăvl Pfond Wūrscht onn wi͡ăvl Brōt wéllet=ĕ(a)r ha̰o?
@@ -43,8 +43,8 @@ WS32	Hänn=er kei Schtickle weiße Saepfe fir mi uf meim Disch gfonde.
 WS33	Sḛi Bru͡ăder will=e(a)m zwāe schéne neié Heiser in eurĕm Gartḛ̆ bauḛ̆.
 WS34	S’ <(als hinw. Fürw. dēs)> Wo(a)rt ischt=em vom Hèrzḛ̆ kom̄ḛ̆.
 WS35	Des ischt recht gsei vao=n=ene.
-WS36	Was sitzet do(a) fir Végḗlé uf de͜ăm Meiĕrle dobḛ̆?
+WS36	Was sitzet do(a) fir Végḗlé uf de͡ăm Meiĕrle dobḛ̆?
 WS37	D’ <(od. di͡ă̰)> Baurḛ̆ hänn fenf Oxḛ̆ onn nḛḭ Ki͡ă̰ onn zwélf Schäfle vo(a)rs Do(a)rf bro(a)cht ghett, di͡ă̰ hänn se verkaufḛ̆ wellḛ̆.
-WS38	D’ Leit senn heit älle uf’m Fèld dussě onn mājet.
+WS38	D’ Leit senn heit älle uf’m Fèld dussĕ onn mājet.
 WS39	Gang nao, d’r brao Hond duat d’r nix.
 WS40	I bḛi mit de Leit do(a) hennḛ̆ iber d’ Wīs ens Ko(a)rn gfa̅rḛ.

--- a/36202_Kniebis.csv
+++ b/36202_Kniebis.csv
@@ -11,21 +11,21 @@ Anmerkungen: ''
 WS01	Em Wénder fliĕgḛt de druckénḛ̆(an) Blédder en dr Luft romm.
 WS02	S’ hé̄rt glei uf mit schneiḛ̆(an), no(a) wurd s’ Wèdder wider bésser.
 WS03	Duer Kole en Ofe, daß d’ Millich ball afangt koche.
-WS04	D’r gu͡ǎt alt Mā̰ ischt mit’m Roß dur s’ Eis (nā=)brochḛ̌ onn éns kalt Wasser gefallḛ̌.
-WS05	E(a)r ischt vo(a)r vi͡ǎr oder sex Wochḛ̌ gschdo(a)rbḛ̌.
+WS04	D’r gu͡ăt alt Mā̰ ischt mit’m Roß dur s’ Eis (nā=)brochḛ̌ onn éns kalt Wasser gefallḛ̌.
+WS05	E(a)r ischt vo(a)r vi͡ăr oder sex Wochḛ̌ gschdo(a)rbḛ̌.
 WS06	S’ Fīr ischt zschdark gsei, d’Kuăchĕ sénn jo(a) onnĕ ganz schwārz brännt.
 WS07	E(a)r ißt d’ Āejer ällḛweil aone Salz onn Pfèffer.
 WS08	D’ Fias deã mer waeh, i glãob, i haos durgloffĕ.
-WS09	I bḛi bei d’r Fră͜o gsḛi onn hă̰o=r=ĕs gsāet, onn se ho(a)t gsāet, se wélls a͜o ī͡arer Dōchder sagḛ̆.
+WS09	I bḛi bei d’r Fră͡o gsḛi onn hă̰o=r=ĕs gsāet, onn se ho(a)t gsāet, se wélls a͡o ī͡arer Dōchder sagḛ̆.
 WS10	I wills ao némmé dao.
 WS11	I schlā de <(gao)> glei mit’m Kochléffel om d’Ōhrĕ <(röm)>, du Aff.
 WS12	Wo go(a)scht nā, sollĕ mĕr mit d’r găo?
 WS13	S’ sén schlè̄chde Zeitĕ̠!
-WS14	Mḛi li͡ăbs Kénd, bleib do(a) honn̰̆ sta̰o̰, di͡ḛ bāese Gḛ̄s beißḛ̄ de zda͜od.
+WS14	Mḛi li͡ăbs Kénd, bleib do(a) honn̰̆ sta̰o̰, di͡ḛ bāese Gḛ̄s beißḛ̄ de zda͡od.
 WS15	Dau ho(a)st hḛit am māeschdḛ̆ glèrnt onn bischt ārdich gsḛi, dau därscht bélder hā̰em ga̰o als de Andĕre.
 WS16	Dau bischt no̰ net graos gmu͡a̰, om a̰ Flasch Wḛi auszdrénget, dḛ̆ mŭ͡ascht zerstḛ̆ no̰ māe wāsḛ̆ on grāeser wärḛ̆.
 WS17	Gang, sei so gue(a)t on sag dḛirḛ̆ Schweschder, se soll diă Klāeder <(des Häs)> fīre eier Mu͡ăder fērdich năjḛ̆ on mit dr Birscht sauber machḛ̆.
-WS18	Hátscht dau nă̰ (na̰o̰) kännt! no(a) wärs anderscht kommĕ̠ on s’dät bésser om ǎ̰ stǎ̰o.
+WS18	Hátscht dau nă̰ (na̰o̰) kännt! no(a) wärs anderscht kommĕ̠ on s’dät bésser om ă̰ stă̰o.
 WS19	Wèr ho(a)t miăr mein Ko(a)rb <(Grattĕ)> vōl Flāesch gschdolĕ?
 WS20	E(a)r ho(a)t <(nao)> so dao, wia wenn se ehn zuam Dresche bschdellt <(agschdellt)> heddet, se hänz aber sèlber dao.
 WS21	Weăm ho(a)t’r diă nei Gschīchd verzēhld?
@@ -34,7 +34,7 @@ WS23	Mer senn miad on hänn durscht.
 WS24	Wo mer geschdert zo(a)bed <(nächt)> zruckkomme senn, no(a) senn de andere schao em Bett glege on hänn fescht gschlo(a)fe.
 WS25	Dr Schnae ischt dia Nacht bei eis leige blibe, aber dea <(dean)> Mo(a)rge ischt e(a)r gschmolze.
 WS26	Hender eisrem Haus stean drei schene Epflbämmle mit raode Epfele.
-WS27	Kénne̩̠(ǎ)der net no̰ a̰ <(klḛḭs)> Weile uf ich <(od. ḛḭs)> wārtḛ̌, no(a) gḛ̌a̰ mĕr mit ich.
+WS27	Kénne̩̠(ă)der net no̰ a̰ <(klḛḭs)> Weile uf ich <(od. ḛḭs)> wārtḛ̌, no(a) gḛ̌a̰ mĕr mit ich.
 WS28	E(a)r dérfet kāene so Kéndereiḛ̆ treibḛ̆.
 WS29	Ḛisere Bèrg senn net so arg hoch, de eire sénn veil hécher.
 WS30	Wi͡ăvl Pfond Wūrscht onn wi͡ăvl Brōt wéllet=ĕ(a)r ha̰o?
@@ -47,4 +47,4 @@ WS36	Was sitzet do(a) fir Végḗlé uf de͡ăm Meiĕrle dobḛ̆?
 WS37	D’ <(od. di͡ă̰)> Baurḛ̆ hänn fenf Oxḛ̆ onn nḛḭ Ki͡ă̰ onn zwélf Schäfle vo(a)rs Do(a)rf bro(a)cht ghett, di͡ă̰ hänn se verkaufḛ̆ wellḛ̆.
 WS38	D’ Leit senn heit älle uf’m Fèld dussĕ onn mājet.
 WS39	Gang nao, d’r brao Hond duat d’r nix.
-WS40	I bḛi mit de Leit do(a) hennḛ̆ iber d’ Wīs ens Ko(a)rn gfa̅rḛ.
+WS40	I bḛi mit de Leit do(a) hennḛ̆ iber d’ Wīs ens Ko(a)rn gfārḛ.

--- a/36202_Kniebis.csv
+++ b/36202_Kniebis.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Em Wénder fliĕgḛt de druckénḛ̆(an) Blédder en dr Luft romm.
 WS02	S’ hé̄rt glei uf mit schneiḛ̆(an), no(a) wurd s’ Wèdder wider bésser.
 WS03	Duer Kole en Ofe, daß d’ Millich ball afangt koche.
-WS04	D’r gu͜ǎt alt Mā̰ ischt mit’m Roß dur s’ Eis (nā=)brochḛ̌ onn éns kalt Wasser gefallḛ̌.
+WS04	D’r gu͡ǎt alt Mā̰ ischt mit’m Roß dur s’ Eis (nā=)brochḛ̌ onn éns kalt Wasser gefallḛ̌.
 WS05	E(a)r ischt vo(a)r vi͜ǎr oder sex Wochḛ̌ gschdo(a)rbḛ̌.
 WS06	S’ Fīr ischt zschdark gsei, d’Kuăchĕ sénn jo(a) onnĕ ganz schwārz brännt.
 WS07	E(a)r ißt d’ Āejer ällḛweil aone Salz onn Pfèffer.
@@ -23,13 +23,13 @@ WS12	Wo go(a)scht nā, sollě mĕr mit d’r găo?
 WS13	S’ sén schlè̄chde Zeitĕ̠!
 WS14	Mḛi li͜ăbs Kénd, bleib do(a) honn̰̆e sta̰o̰, di͜ḛ bāese Gḛ̄s beißḛ̄ de zda͜od.
 WS15	Dau ho(a)st hḛit am māeschdḛ̆ glèrnt onn bischt ārdich gsḛi, dau därscht bélder hā̰em ga̰o als de Andĕre.
-WS16	Dau bischt no̰ net graos gmu͜a̰, om a̰ Flasch Wḛi auszdrénget, dḛ̆ mŭ͜ascht zerstḛ̆ no̰ māe wāsḛ̆ on grāeser wärḛ̆.
-WS17	Gang, sei so gue(a)t on sag dḛirḛ̆ Schweschder, se soll diă Klāeder <(des Häs)> fīre eier Mu͜ăder fērdich năjḛ̆ on mit dr Birscht sauber machḛ̆.
+WS16	Dau bischt no̰ net graos gmu͡a̰, om a̰ Flasch Wḛi auszdrénget, dḛ̆ mŭ͡ascht zerstḛ̆ no̰ māe wāsḛ̆ on grāeser wärḛ̆.
+WS17	Gang, sei so gue(a)t on sag dḛirḛ̆ Schweschder, se soll diă Klāeder <(des Häs)> fīre eier Mu͡ăder fērdich năjḛ̆ on mit dr Birscht sauber machḛ̆.
 WS18	Hátscht dau nă̰ (na̰o̰) kännt! no(a) wärs anderscht kommě̠ on s’dät bésser om ǎ̰ stǎ̰o.
 WS19	Wèr ho(a)t miăr mein Ko(a)rb <(Grattĕ)> vōl Flāesch gschdolĕ?
 WS20	E(a)r ho(a)t <(nao)> so dao, wia wenn se ehn zuam Dresche bschdellt <(agschdellt)> heddet, se hänz aber sèlber dao.
 WS21	Weăm ho(a)t’r diă nei Gschīchd verzēhld?
-WS22	Mă̰ mu͜ăs laut (naus-)schreiḛ̆ <(plǟrḛ̆)>, suscht verschdō(a)t e(a)r ich <(ḛis)> nét.
+WS22	Mă̰ mu͡ăs laut (naus-)schreiḛ̆ <(plǟrḛ̆)>, suscht verschdō(a)t e(a)r ich <(ḛis)> nét.
 WS23	Mer senn miad on hänn durscht.
 WS24	Wo mer geschdert zo(a)bed <(nächt)> zruckkomme senn, no(a) senn de andere schao em Bett glege on hänn fescht gschlo(a)fe.
 WS25	Dr Schnae ischt dia Nacht bei eis leige blibe, aber dea <(dean)> Mo(a)rge ischt e(a)r gschmolze.
@@ -40,7 +40,7 @@ WS29	Ḛisere Bèrg senn net so arg hoch, de eire sénn veil hécher.
 WS30	Wi͜ăvl Pfond Wūrscht onn wi͜ăvl Brōt wéllet=ĕ(a)r ha̰o?
 WS31	I verschdand ich net, ĕ(a)r mi͜ăßet ă̰ bißle lauder schwätzḛ̆.
 WS32	Hänn=er kei Schtickle weiße Saepfe fir mi uf meim Disch gfonde.
-WS33	Sḛi Bru͜ăder will=e(a)m zwāe schéne neié Heiser in eurĕm Gartḛ̆ bauḛ̆.
+WS33	Sḛi Bru͡ăder will=e(a)m zwāe schéne neié Heiser in eurĕm Gartḛ̆ bauḛ̆.
 WS34	S’ <(als hinw. Fürw. dēs)> Wo(a)rt ischt=em vom Hèrzḛ̆ kom̄ḛ̆.
 WS35	Des ischt recht gsei vao=n=ene.
 WS36	Was sitzet do(a) fir Végḗlé uf de͜ăm Meiĕrle dobḛ̆?

--- a/36202_Kniebis.csv
+++ b/36202_Kniebis.csv
@@ -40,7 +40,7 @@ WS29	Ḛisere Bèrg senn net so arg hoch, de eire sénn veil hécher.
 WS30	Wi͜ăvl Pfond Wūrscht onn wi͜ăvl Brōt wéllet=ĕ(a)r ha̰o?
 WS31	I verschdand ich net, ĕ(a)r mi͜ăßet ă̰ bißle lauder schwätzḛ̆.
 WS32	Hänn=er kei Schtickle weiße Saepfe fir mi uf meim Disch gfonde.
-WS33	Sḛi Bru͜ӑder will=e(a)m zwāe schéne neié Heiser in eurĕm Gartḛ̆ bauḛ̆.
+WS33	Sḛi Bru͜ăder will=e(a)m zwāe schéne neié Heiser in eurĕm Gartḛ̆ bauḛ̆.
 WS34	S’ <(als hinw. Fürw. dēs)> Wo(a)rt ischt=em vom Hèrzḛ̆ kom̄ḛ̆.
 WS35	Des ischt recht gsei vao=n=ene.
 WS36	Was sitzet do(a) fir Végḗlé uf de͜ăm Meiĕrle dobḛ̆?

--- a/36272_Ödsbach.csv
+++ b/36272_Ödsbach.csv
@@ -20,10 +20,10 @@ WS09	I’ bin bi de͜r Frau g’si, un hab’ e͜r e͜s g’sait, un sie het g�
 WS10	I’ will’s aber nimmi wider do.
 WS11	I’ schla’ di glich mit em Kochlöffel um d’ Ohre, du Aff!
 WS12	Wo gehscht no, solle mer mit der geh’.
-WS13	S’ si̮n schlechti Zitte!
+WS13	S’ si̬n schlechti Zitte!
 WS14	Mi liebs Kind, blib do unde schte̱h, die bösi Gäns’ bisse di tod.
 WS15	Du hesch hit am menschte g’lärt un bischt artig g’si, du derfscht ender hoim wieder d’ anderi.
-WS16	Du bischt no nit groß gnue, um e’ Flasch’ Wi͜n usz’trinke, du muescht z’erscht nome waxe un größer wäre.
+WS16	Du bischt no nit groß gnue, um e’ Flasch’ Wi͡n usz’trinke, du muescht z’erscht nome waxe un größer wäre.
 WS17	Geh’, sei so guet un sag’ di̠nere Schweschter, si soll die Kleider fü̠r eueri Mueter fertig na̠ie un mit de̠r Bürscht sufer moche. 
 WS18	Hä̮tsch’ ne kennt, no̠ wär e̮s andersch kumme, un ’s thät besser umen schteh!
 WS19	Wer het mer mi Korb voll Fleisch g’schtohle?
@@ -34,7 +34,7 @@ WS23	Mer sin müed un hen durscht.
 WS24	Wo mer nächtig hoim kumme sin, sin d’ anderi scho im Bett g’lege un hen scho fescht g’schlofe.
 WS25	Der Schnä ischt dis Nacht leie blibe, aber hit morge isch’ er g’schmolze.
 WS26	Hinder unserem Hus schtehn drei schöni Epfelbaum mit rote Epfeli. 
-WS27	Ki̮ne ne̮r nit no e Wi̠li uf is wa̠rte, no̠ gen me̮r mit î.
+WS27	Ki̬ne ne̮r nit no e Wi̠li uf is wa̠rte, no̠ gen me̮r mit î.
 WS28	Ir dörfe nit so Kindereie tribe.
 WS29	D’ unseri Berg sin nit so hoch, d’ eueri sin hächer.
 WS30	Wie viel Pfund Würscht un wie viel Brod welle nér ho?

--- a/36272_Ödsbach.csv
+++ b/36272_Ödsbach.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: SyHD
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Im Winter fliege d’ truckeni Bletter in de͜r Luft rum.
+WS01	Im Winter fliege d’ truckeni Bletter in de͡r Luft rum.
 WS02	Es härt glich u̬f z’ schneie, no̬r wurd’s’ Wätter wider besser.
 WS03	Thue Kohle in d’r Ofe, daß d’ Milch bald ofongt z’ koche.
 WS04	D’r guet alt’ Monn isch’ mit ’em Roß durchs Is broche un ins kalt Wasser keit.
@@ -16,25 +16,25 @@ WS05	E̮r isch vor vier oder sex Woche g’schtorbe.
 WS06	S’ Für isch’ z’ stark g’si, d Kueche sin jo unde gonz schwarz brennt.
 WS07	E̮r ißt d’ Eier uni Salz un Pfäffer.
 WS08	D’ Füeß dien mer so wäh, i’ glaub’, daß i’ sie durchg’loffe ha.
-WS09	I’ bin bi de͜r Frau g’si, un hab’ e͜r e͜s g’sait, un sie het g’sait, sie wells der Do̠chter sage.
+WS09	I’ bin bi de͡r Frau g’si, un hab’ e͡r e͡s g’sait, un sie het g’sait, sie wells der Do̠chter sage.
 WS10	I’ will’s aber nimmi wider do.
 WS11	I’ schla’ di glich mit em Kochlöffel um d’ Ohre, du Aff!
 WS12	Wo gehscht no, solle mer mit der geh’.
 WS13	S’ si̬n schlechti Zitte!
-WS14	Mi liebs Kind, blib do unde schte̱h, die bösi Gäns’ bisse di tod.
+WS14	Mi liebs Kind, blib do unde schte̠h, die bösi Gäns’ bisse di tod.
 WS15	Du hesch hit am menschte g’lärt un bischt artig g’si, du derfscht ender hoim wieder d’ anderi.
 WS16	Du bischt no nit groß gnue, um e’ Flasch’ Wi͡n usz’trinke, du muescht z’erscht nome waxe un größer wäre.
 WS17	Geh’, sei so guet un sag’ di̠nere Schweschter, si soll die Kleider fü̠r eueri Mueter fertig na̠ie un mit de̠r Bürscht sufer moche. 
-WS18	Hä̮tsch’ ne kennt, no̠ wär e̮s andersch kumme, un ’s thät besser umen schteh!
+WS18	Hä̮tsch’ ne kennt, no̠ wär e̬s andersch kumme, un ’s thät besser umen schteh!
 WS19	Wer het mer mi Korb voll Fleisch g’schtohle?
 WS20	Er het d’ gliche do, als hätte si ne zum Dresche b’schtellt’, si hen’s aber selber do.
 WS21	Wem het er d’ nei G’schicht verzehlt?
-WS22	Me̮ mueß lu̬t schreie, sunscht verschteht e̮r is nit.
+WS22	Me̬ mueß lu̬t schreie, sunscht verschteht e̬r is nit.
 WS23	Mer sin müed un hen durscht.
 WS24	Wo mer nächtig hoim kumme sin, sin d’ anderi scho im Bett g’lege un hen scho fescht g’schlofe.
 WS25	Der Schnä ischt dis Nacht leie blibe, aber hit morge isch’ er g’schmolze.
 WS26	Hinder unserem Hus schtehn drei schöni Epfelbaum mit rote Epfeli. 
-WS27	Ki̬ne ne̮r nit no e Wi̠li uf is wa̠rte, no̠ gen me̮r mit î.
+WS27	Ki̬ne ne̬r nit no e Wi̠li uf is wa̠rte, no̠ gen me̬r mit î.
 WS28	Ir dörfe nit so Kindereie tribe.
 WS29	D’ unseri Berg sin nit so hoch, d’ eueri sin hächer.
 WS30	Wie viel Pfund Würscht un wie viel Brod welle nér ho?
@@ -44,7 +44,7 @@ WS33	Si Brueder will zwai schini neii Hiser in euer Garte baue.
 WS34	S’ Wort isch’ em vom Herze kumme.
 WS35	Des isch recht voni.
 WS36	Was sitze do für Vögeli uf dem Mürli?
-WS37	D’ Bu̠re hen fünf Oxe un nün Küe un zwölf Scho̠f vors Dorf brocht, die he̮n sie verkaufe welle.
+WS37	D’ Bu̠re hen fünf Oxe un nün Küe un zwölf Scho̠f vors Dorf brocht, die he̬n sie verkaufe welle.
 WS38	D’ Litt sin hit alli duß uf em Feld un dien maie.
 WS39	Geh’ nur, der brun Hund duet der nix.
-WS40	I’ bin mit de̮ Litte do hinde über d’ Matte ins Korn g’fahre. 
+WS40	I’ bin mit de̬ Litte do hinde über d’ Matte ins Korn g’fahre. 

--- a/36272_Ödsbach.csv
+++ b/36272_Ödsbach.csv
@@ -29,7 +29,7 @@ WS18	Hä̮tsch’ ne kennt, no̠ wär e̮s andersch kumme, un ’s thät besser 
 WS19	Wer het mer mi Korb voll Fleisch g’schtohle?
 WS20	Er het d’ gliche do, als hätte si ne zum Dresche b’schtellt’, si hen’s aber selber do.
 WS21	Wem het er d’ nei G’schicht verzehlt?
-WS22	Me̮ mueß lu̮t schreie, sunscht verschteht e̮r is nit.
+WS22	Me̮ mueß lu̬t schreie, sunscht verschteht e̮r is nit.
 WS23	Mer sin müed un hen durscht.
 WS24	Wo mer nächtig hoim kumme sin, sin d’ anderi scho im Bett g’lege un hen scho fescht g’schlofe.
 WS25	Der Schnä ischt dis Nacht leie blibe, aber hit morge isch’ er g’schmolze.

--- a/36309_Furdenheim.csv
+++ b/36309_Furdenheim.csv
@@ -14,13 +14,13 @@ WS03	Mach Kohle en de n’ Ofen, daß d’ Melich kocht.
 WS04	D’r güet ald Mann esch mét sammt m Roß durch’s Is g’broche un én’s kalt Wāser g’héit.
 WS05	Er esch vor vér od’r sechs Wuchen g’schtorwe
 WS06	S’ Fir esch ze starik gewān, d’ Küechen sin unden jo gänz schworz g’brannt.
-WS07	Er éßt d’ Eier allewiel une Salz un Pfa̮ffer.
+WS07	Er éßt d’ Eier allewiel une Salz un Pfa̬ffer.
 WS08	D’ Fès dön m’r ari wéh éch gläuw ech hob se durig’läufe.
-WS09	Éch bén bīe d’r Fräu g’wa͜n un hob’s ere g’sa͜ïd un sie het g’sa͜it sie wélls au ehrer Docht’r säuwe.
+WS09	Éch bén bīe d’r Fräu g’wa͡n un hob’s ere g’sa͡ïd un sie het g’sa͡it sie wélls au ehrer Docht’r säuwe.
 WS10	Ech wélls awer aü némm noch emol dön.
 WS11	Éch hau d’r glich de Kochleffel uf d’ Ohren, dü Aff.
 WS12	Wü gésch ane, selle m’r met d’r géhe.
-WS13	S’en schla̮gdi Zitte.
+WS13	S’en schla̬gdi Zitte.
 WS14	Mien lieewes Kénd, blī dou hétte stéhe, d’ bése Gäns bisse déch tot.
 WS15	Dü hesch hit z’mérkelst g’léhrt un bésch ardi g’wan, dü därfsch au fréïer hä̠m as d’ ǟndre.
 WS16	Dü bésch no nit gruß g’nüe für e Bouda̬ll Wi͡en üszedrinken, dü müesch zérscht noch e wénele wosen, un gréser wa̬re.
@@ -41,8 +41,8 @@ WS30	Wie vél Pföünd Wurschd un wie vél Brud welle n’r hän.
 WS31	Éch verschteh i nitt éhr mén e wenele lüdder redde.
 WS32	Hän ehr nit e stéckele wisi Säif fer mech uf miem Desch g’funge.
 WS33	Sien Brüeder wéll séch zwei schéni neji Hiser én öwre Gorden böwe.
-WS34	Dés Word ésch ém vum Ha̮rzen kumme.
-WS35	Des esch ra̮cht g’wa̮n vun Éhne.
+WS34	Dés Word ésch ém vum Ha̬rzen kumme.
+WS35	Des esch ra̬cht g’wa̬n vun Éhne.
 WS36	Was sétze du vér Va̠ïele owe uf dem Mirel.
 WS37	D’ Büre hän fénf Ochse un ni̠e̠n Kéïh un zwelf Schéfle vérs Dorf gebrocht un hän se welle verkäufen.
 WS38	Alli Litt sén hitt drüsse uf em Fald un maje.

--- a/36334_Ruprechtsau.csv
+++ b/36334_Ruprechtsau.csv
@@ -45,6 +45,6 @@ WS34	Das Wort is ĕm von Herze kumme.
 WS35	Das isch rè̄cht von īne.
 WS36	Was sitze do for Vöjelle owe uff dem Mǖrl?
 WS37	Dĭe Būre hăn fünf Ochse un ni͡en Küj un zwölf Schǟfele vor dăs Dorf gebrōcht gehĕtt, die hăn sĕ welle verkāfe.
-WS38	Die Litt sin hitt alle druße uff ěm Fäld un mäje.
+WS38	Die Litt sin hitt alle druße uff ĕm Fäld un mäje.
 WS39	Geh nur, der brun Hund dhud dér nix.
 WS40	Ich bin mĕtt dĕ Lĭtt dō hinde ü̆bĕr dĭe Mădde ins Korn gĕfa̅hre.

--- a/36334_Ruprechtsau.csv
+++ b/36334_Ruprechtsau.csv
@@ -47,4 +47,4 @@ WS36	Was sitze do for Vöjelle owe uff dem Mǖrl?
 WS37	Dĭe Būre hăn fünf Ochse un ni͡en Küj un zwölf Schǟfele vor dăs Dorf gebrōcht gehĕtt, die hăn sĕ welle verkāfe.
 WS38	Die Litt sin hitt alle druße uff ĕm Fäld un mäje.
 WS39	Geh nur, der brun Hund dhud dér nix.
-WS40	Ich bin mĕtt dĕ Lĭtt dō hinde ü̆bĕr dĭe Mădde ins Korn gĕfa̅hre.
+WS40	Ich bin mĕtt dĕ Lĭtt dō hinde ü̆bĕr dĭe Mădde ins Korn gĕfāhre.

--- a/36334_Ruprechtsau.csv
+++ b/36334_Ruprechtsau.csv
@@ -47,4 +47,4 @@ WS36	Was sitze do for Vöjelle owe uff dem Mǖrl?
 WS37	Dĭe Būre hăn fünf Ochse un ni͞en Küj un zwölf Schǟfele vor dăs Dorf gebrōcht gehĕtt, die hăn sĕ welle verkāfe.
 WS38	Die Litt sin hitt alle druße uff ěm Fäld un mäje.
 WS39	Geh nur, der brun Hund dhud dér nix.
-WS40	Ich bin mĕtt dĕ Lĭtt do̅ hinde ü̆bĕr dĭe Mădde ins Korn gĕfa̅hre.
+WS40	Ich bin mĕtt dĕ Lĭtt dō hinde ü̆bĕr dĭe Mădde ins Korn gĕfa̅hre.

--- a/36334_Ruprechtsau.csv
+++ b/36334_Ruprechtsau.csv
@@ -11,10 +11,10 @@ Anmerkungen: ''
 WS01	Im Windĕr flieje d’ druggĕdĕ Blédder in d’r Luft erŭm. <(erumm)>
 WS02	’s hè̄rd glĭch uff zĕ schneije, d’rnō wurds Wèddĕr wider bé̆ssĕr.
 WS03	Mach Kohle in de Offe, daß d’ Milch anfangt ze koche.
-WS04	D’r güëd ald Mann iß met̬ d’m Roß durch’s Ǐhs gebroche un in’s kald Wasser g’heijd.
+WS04	D’r güëd ald Mann iß met̬ d’m Roß durch’s Ĭhs gebroche un in’s kald Wasser g’heijd.
 WS05	Er isch vor viėr oder sechs Wǔche geschtōrwe.
 WS06	D’s Fir war ze schtark, d’ Kuëche sin jo unde ganz schwarz gebrènnd.
-WS07	Er essd dǐe Eier allewi͞el ohne Salz un Pfäffer.
+WS07	Er essd dǐe Eier allewi͡el ohne Salz un Pfäffer.
 WS08	D’ Füeß dhun mer weh, ich glaub, ich hån se durchgeloffe. 
 WS09	Ich bin bī d’r Frau g’sinn un hån s èhre gesākt, un sĕ hĕtt gesākt, sĕ will’s wĭder in ihrer Dochder sāge
 WS10	Ich will’s nĕtt nŏch ĕ mōl dhun.
@@ -44,7 +44,7 @@ WS33	Sīn Bruder will sich zwei schene neije Hīser in eierem Garde boije.
 WS34	Das Wort is ĕm von Herze kumme.
 WS35	Das isch rè̄cht von īne.
 WS36	Was sitze do for Vöjelle owe uff dem Mǖrl?
-WS37	Dĭe Būre hăn fünf Ochse un ni͞en Küj un zwölf Schǟfele vor dăs Dorf gebrōcht gehĕtt, die hăn sĕ welle verkāfe.
+WS37	Dĭe Būre hăn fünf Ochse un ni͡en Küj un zwölf Schǟfele vor dăs Dorf gebrōcht gehĕtt, die hăn sĕ welle verkāfe.
 WS38	Die Litt sin hitt alle druße uff ěm Fäld un mäje.
 WS39	Geh nur, der brun Hund dhud dér nix.
 WS40	Ich bin mĕtt dĕ Lĭtt dō hinde ü̆bĕr dĭe Mădde ins Korn gĕfa̅hre.

--- a/36334_Ruprechtsau.csv
+++ b/36334_Ruprechtsau.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Im Windĕr flieje d’ druggĕdĕ Blédder in d’r Luft erŭm. <(erumm)>
 WS02	’s hè̄rd glĭch uff zĕ schneije, d’rnō wurds Wèddĕr wider bé̆ssĕr.
 WS03	Mach Kohle in de Offe, daß d’ Milch anfangt ze koche.
-WS04	D’r güëd ald Mann iß met̮ d’m Roß durch’s Ǐhs gebroche un in’s kald Wasser g’heijd.
+WS04	D’r güëd ald Mann iß met̬ d’m Roß durch’s Ǐhs gebroche un in’s kald Wasser g’heijd.
 WS05	Er isch vor viėr oder sechs Wǔche geschtōrwe.
 WS06	D’s Fir war ze schtark, d’ Kuëche sin jo unde ganz schwarz gebrènnd.
 WS07	Er essd dǐe Eier allewi͞el ohne Salz un Pfäffer.

--- a/36594_Bad-Rotenfels.csv
+++ b/36594_Bad-Rotenfels.csv
@@ -14,7 +14,7 @@ WS03	Thu Kohle in de Offe, daß d’ Milich bald kocht.
 WS04	Der gute, alte Monn isch mit dem Roß durch’s Iss broche und isch in’s kalt Wasser g’falle.
 WS05	Er isch vor 4 oder 6 Woche g’storbe.
 WS06	s Für isch z’stark gwäa, d’ Kuche sin unge gonz schwarz worre.
-WS07	Er éßt d’ Eier im̄er uhne Sǎlz und Peffer.
+WS07	Er éßt d’ Eier im̄er uhne Sălz und Peffer.
 WS08	D’ Füß dämer arg weh, i glaub, i häb sie durchgloffe.
 WS09	Ich bin bi d’r Frā gwäa und häb’ sere gsāgt, und sie gsāgt, sie will’s a ihrer Tochter sāge.
 WS10	I will’s ā nim̄e dua.

--- a/36772_Lichtenberg.csv
+++ b/36772_Lichtenberg.csv
@@ -11,10 +11,10 @@ Anmerkungen: ''
 WS01	Em Wendar fléja d’ rugănā Bléddār én d’r Luft rumm.
 WS02	As hért glich uff zé schnejă, no wărds s’ Wāddăr wéddăr béssăr. 
 WS03	Düa Kohla en de Offa, daß d’ Melich bahl an za Kocha fangd.
-WS04	D’r güåt alt Mann ésch medd’m Párd durichs Iß gǎbrochǎ, un ens kalt Wassǎr gfállǎ.
-WS05	Ár esch f’r veār od’r sechs Wuchå gschdorwǎ.
+WS04	D’r güåt alt Mann ésch medd’m Párd durichs Iß găbrochă, un ens kalt Wassăr gfállă.
+WS05	Ár esch f’r veār od’r sechs Wuchå gschdorwă.
 WS06	S’ Fïr esch ze schdarick găwähn, d’ Küachă senn ju unda ganz schwarz găbrännd.
-WS07	Ār eßt d’ Eiǎr emmǎr uhnå Salz un Paff’r.
+WS07	Ār eßt d’ Eiăr emmăr uhnå Salz un Paff’r.
 WS08	D’ Fiaß dhüan m’r wéh, ech glaub, ech hab sa durichgeloffa. 
 WS09	Ech ben bi d’r Frau găwähn un habs éhră xaïd, un sĕe hett xaïd, sĕe wélls au èhră Dōchdăr sájă.
 WS10	Ech well’s au nemmă wéddă duhn!
@@ -45,6 +45,6 @@ WS34	Déß Woărd kummt ehm vum Hārză!
 WS35	Deß esch rācht vun énnă g’wähn!
 WS36	Was setză do fer Vājelă uffm Mirälă? 
 WS37	D’ Büră hann fénf Ochsă un nien Kiha un zwelf Schäffelă fer s Dărf gebrocht gebrocht, de hann sā wellă verkaufă.
-WS38	D’ Lidd senn hidd alli drüssǎ uffm Fāld un mājǎ.
+WS38	D’ Lidd senn hidd alli drüssă uffm Fāld un mājă.
 WS39	Geh numma, d’r brün Hund machdr néx.
-WS40	Ech benn med dă Lidd do héngă üwăr d’ Maddă éns Karn gfa̅hră.
+WS40	Ech benn med dă Lidd do héngă üwăr d’ Maddă éns Karn gfāhră.

--- a/36898_Maleck.csv
+++ b/36898_Maleck.csv
@@ -16,7 +16,7 @@ WS05	Er isch vor vier oder sechs Wuche g’storbe.
 WS06	S’ Für z’stark g’si d’ Kuche sin jo unte ganz schwarz brennt.
 WS07	Er ißt d’ Eier allewil ohni Salz un Pfäffer.
 WS08	D’ Füäß dun mer weh, i glaub, i ha sie durglaufe. 
-WS09	I bi͜e bi der Frau gsi un han er es gsait, un sie het gseit sie well’s ihrer Dochter au sage.
+WS09	I bi͡e bi der Frau gsi un han er es gsait, un sie het gseit sie well’s ihrer Dochter au sage.
 WS10	I will’s nimme meh due.
 WS11	I schlag’ dir gli mit em Chochlöffel um d Ohre, du Aff.
 WS12	Wo gosch du hi, solle mer mit der goh?

--- a/36904_Sexau.csv
+++ b/36904_Sexau.csv
@@ -16,8 +16,8 @@ WS05	Er isch vor vier od̆er sechs Woche g’storbe.
 WS06	S’Fieer isch z’stark g’sie, d‘Kuḛche sinn jo unte ganz schwarz brennt!
 WS07	Er ißt d’Eier allewiel uni Salz un Pfeffer.
 WS08	D‘ Füeß dieen mĕr arg weh, i glŏaib, i han sie durgloffe.
-WS09	I bih bi d’r Fraű g’sie, un hon er es gsait, un sie het gsait, sie wells oaű ihre Dochter sage.
-WS10	I will’s aű nimmi wieder dhue.
+WS09	I bih bi d’r Fraü g’sie, un hon er es gsait, un sie het gsait, sie wells oaü ihre Dochter sage.
+WS10	I will’s aü nimmi wieder dhue.
 WS11	I schlag di glich mit’m Koochlöffel um d‘ Ohre, du Aff!
 WS12	Wu gohsch du hḭ, solle mir au mit’r gueh?
 WS13	Es sinn schlechti Zitte!

--- a/36911_Yach.csv
+++ b/36911_Yach.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: SyHD
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Im Wintr fl̄iaga die trukana Bléttr in dr Luft rum.
+WS01	Im Wintr fłiaga die trukana Bléttr in dr Luft rum.
 WS02	s härt gli uf zschnéia, d̆rnā wirds Wättr widr béssr.
 WS03	Thu Kohla in Ofa, aß d Milich bal z kocha afangt.
 WS04	der gut alt Mann isch mit èm Pfärd durs Is brocha un ins kalt Wassr gfalla.
@@ -47,4 +47,4 @@ WS36	Was sitza da für Vögili owa uf dèm Mürli?
 WS37	D Bura häng fümf Oksa un nü Küei un zwölf Schäfli vor s Dorf bracht, di häng si vrkaufa wélla. <(meistens di häng si wella verkaufa)>
 WS38	D Lüt sin hüt alli dussa uf èm Fäld un mäia.
 WS39	Gang nur, dr bru Hung dut dr ninnt!
-WS40	I bin mit da Lüta da hinta üwr d Wi̅sa <(mehr Matta)> ins Korn gfahra.
+WS40	I bin mit da Lüta da hinta üwr d Wīsa <(mehr Matta)> ins Korn gfahra.

--- a/36933_Orschwiller.csv
+++ b/36933_Orschwiller.csv
@@ -42,7 +42,7 @@ WS31	Ech v’rschteh äich nitt, èhr mia stäriker rédde.
 WS32	Han’r kä Stèckel Seif ferr mech uf ’m Tesch g’funde?
 WS33	Si Bruadĕr well sî zwei schèni näi Hisĕr in äirem Garde böje.
 WS34	Dass Wort isch ’m vo Ha̱rze komme.
-WS35	Dass isch ra̱cht vo’n äi̱ch g’se!
+WS35	Dass isch ra̱cht vo’n äi̠ch g’se!
 WS36	Wass setze do ferr Vä̠je̺le̺ owe uff damm Mîre̺l.
 WS37	D’ Bu̠re ha finf Okse u ninn Kä̠i u zwälf Schèffle vor’s Dorf gebro̠cht, dia ha’se wö̠lle ve̮rka̠ufe̮.
 WS38	D’ Litt sinn hitt alli drusse of ’m Fald un maje.

--- a/36933_Orschwiller.csv
+++ b/36933_Orschwiller.csv
@@ -21,7 +21,7 @@ WS10	I well’s au nimm mache.
 WS11	I schlau d’e glich met d’m Kochläffel um d’ Ohre, Du Aff.
 WS12	Wo gehsch de anne, sälle m’r mitter geh?
 WS13	S’ enn schle̠chti Zi̠tta.
-WS14	Mi līa̱bs Kè̱nd, bli do onte ste̠h, dia be̠sa̮ Ga̱nz bissa di to̠d.
+WS14	Mi līa̠bs Kè̱nd, bli do onte ste̠h, dia be̠sa̬ Ga̠nz bissa di to̠d.
 WS15	Du hǟsch hit am mèste gele̠hrt un besch a̠rtli g’sè, du dä̠rfsch frijar heim ge̠h as d’ Andere.
 WS16	Du besch no nitt gross genua, fer a Botell Winn uszatrinke, Du musch zerst no a wéni wagse un grèser ware.
 WS17	Geh, säi so gu̠at un sa̠u dine̺r Schwä̠schter, si säll d’ Kleider ferr äiri Mu̠ater ferti na̠je̺, un mit d’r Be̠rscht rein mache. 
@@ -41,10 +41,10 @@ WS30	Wiavill Pfund Wèrschtlé̺ un wiavill Brod wällen ’r.
 WS31	Ech v’rschteh äich nitt, èhr mia stäriker rédde.
 WS32	Han’r kä Stèckel Seif ferr mech uf ’m Tesch g’funde?
 WS33	Si Bruadĕr well sî zwei schèni näi Hisĕr in äirem Garde böje.
-WS34	Dass Wort isch ’m vo Ha̱rze komme.
-WS35	Dass isch ra̱cht vo’n äi̠ch g’se!
+WS34	Dass Wort isch ’m vo Ha̠rze komme.
+WS35	Dass isch ra̠cht vo’n äi̠ch g’se!
 WS36	Wass setze do ferr Vä̠je̺le̺ owe uff damm Mîre̺l.
 WS37	D’ Bu̠re ha finf Okse u ninn Kä̠i u zwälf Schèffle vor’s Dorf gebro̠cht, dia ha’se wö̠lle ve̬rka̠ufe̬.
 WS38	D’ Litt sinn hitt alli drusse of ’m Fald un maje.
 WS39	Geh nurr, d’r brunn Hond macht d’r nix.
-WS40	Ech bè mit da̲nne Litte do üwer d’ Ma̲tte g’fa̲hre iss Ko̠rn.
+WS40	Ech bè mit da̠nne Litte do üwer d’ Ma̠tte g’fa̠hre iss Ko̠rn.

--- a/36933_Orschwiller.csv
+++ b/36933_Orschwiller.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: SyHD
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Em Wénter flija d’ trocke͜ne͜ Blätter i d’r Luft erum.
+WS01	Em Wénter flija d’ trocke͡ne͡ Blätter i d’r Luft erum.
 WS02	S’ hèrt glich uf za schnéia, derno wurd s’ Watter bésser.
 WS03	Mach Kohle i de Offe, dass d’ Melich bal afangt za koche.
 WS04	D’r guat alt Mann isch met em Pfard durch’s Iss gebroche un is kalt Wasser k_äiht
@@ -21,20 +21,20 @@ WS10	I well’s au nimm mache.
 WS11	I schlau d’e glich met d’m Kochläffel um d’ Ohre, Du Aff.
 WS12	Wo gehsch de anne, sälle m’r mitter geh?
 WS13	S’ enn schle̠chti Zi̠tta.
-WS14	Mi līa̱bs Kè̱nd, bli do onte ste̱h, dia be̱sa̮ Ga̱nz bissa di to̠d.
+WS14	Mi līa̱bs Kè̱nd, bli do onte ste̠h, dia be̠sa̮ Ga̱nz bissa di to̠d.
 WS15	Du hǟsch hit am mèste gele̠hrt un besch a̠rtli g’sè, du dä̠rfsch frijar heim ge̠h as d’ Andere.
 WS16	Du besch no nitt gross genua, fer a Botell Winn uszatrinke, Du musch zerst no a wéni wagse un grèser ware.
 WS17	Geh, säi so gu̠at un sa̠u dine̺r Schwä̠schter, si säll d’ Kleider ferr äiri Mu̠ater ferti na̠je̺, un mit d’r Be̠rscht rein mache. 
-WS18	Hatsch Du èhn̬e gè̬kannt! de̬rno war’s andersch komme, un s’ that besser met èhne stèh.
+WS18	Hatsch Du èhn̬e gè̮kannt! de̬rno war’s andersch komme, un s’ that besser met èhne stèh.
 WS19	War hét m’r mine Korb mèt Fleisch g’stohle.
 WS20	Er hétt so gemacht, ass wa’ se ne zuam Dräsche b’stellt hatte; se hans aber salbscht gemacht.
 WS21	Wamm hétt ’r die néi G’schicht erzählt.
-WS22	Mann muass starik schräje̮, sosch ve̮rsteht ’r uns nètt.
+WS22	Mann muass starik schräje̬, sosch ve̬rsteht ’r uns nètt.
 WS23	M’r se miatt un hann Durscht.
 WS24	Wo m’r gäschter im’ Obe zaruck komme se, sinn d’ andre scho im Bett gelaje un hann starik g’schlofe.
 WS25	D’r Schnee isch henicht läje bliwe, awer hitt am Morje isch ’r g’schmolza.
 WS26	Henter onserm Huss steh dräi scheni Äpfelbaimle mit rote Äpfele.
-WS27	Kä̠nnen ’r nit no e Bissel of ons wa̠rte̮, derno geh m’r mit äich.
+WS27	Kä̠nnen ’r nit no e Bissel of ons wa̠rte̬, derno geh m’r mit äich.
 WS28	Ehr därfe kä so Dummheite triwe.
 WS29	Onseri Bari sinn nit gar hoch, äeri sinn vill hèchér.
 WS30	Wiavill Pfund Wèrschtlé̺ un wiavill Brod wällen ’r.
@@ -44,7 +44,7 @@ WS33	Si Bruadĕr well sî zwei schèni näi Hisĕr in äirem Garde böje.
 WS34	Dass Wort isch ’m vo Ha̱rze komme.
 WS35	Dass isch ra̱cht vo’n äi̠ch g’se!
 WS36	Wass setze do ferr Vä̠je̺le̺ owe uff damm Mîre̺l.
-WS37	D’ Bu̠re ha finf Okse u ninn Kä̠i u zwälf Schèffle vor’s Dorf gebro̠cht, dia ha’se wö̠lle ve̮rka̠ufe̮.
+WS37	D’ Bu̠re ha finf Okse u ninn Kä̠i u zwälf Schèffle vor’s Dorf gebro̠cht, dia ha’se wö̠lle ve̬rka̠ufe̬.
 WS38	D’ Litt sinn hitt alli drusse of ’m Fald un maje.
 WS39	Geh nurr, d’r brunn Hond macht d’r nix.
 WS40	Ech bè mit da̲nne Litte do üwer d’ Ma̲tte g’fa̲hre iss Ko̠rn.

--- a/36933_Orschwiller.csv
+++ b/36933_Orschwiller.csv
@@ -21,7 +21,7 @@ WS10	I well’s au nimm mache.
 WS11	I schlau d’e glich met d’m Kochläffel um d’ Ohre, Du Aff.
 WS12	Wo gehsch de anne, sälle m’r mitter geh?
 WS13	S’ enn schle̠chti Zi̠tta.
-WS14	Mi līa̱bs Kè̱nd, bli do onte ste̱h, dia be̱sa̮ Ga̱nz bissa di to̱d.
+WS14	Mi līa̱bs Kè̱nd, bli do onte ste̱h, dia be̱sa̮ Ga̱nz bissa di to̠d.
 WS15	Du hǟsch hit am mèste gele̠hrt un besch a̠rtli g’sè, du dä̠rfsch frijar heim ge̠h as d’ Andere.
 WS16	Du besch no nitt gross genua, fer a Botell Winn uszatrinke, Du musch zerst no a wéni wagse un grèser ware.
 WS17	Geh, säi so gu̠at un sa̠u dine̺r Schwä̠schter, si säll d’ Kleider ferr äiri Mu̠ater ferti na̠je̺, un mit d’r Be̠rscht rein mache. 
@@ -47,4 +47,4 @@ WS36	Wass setze do ferr Vä̠je̺le̺ owe uff damm Mîre̺l.
 WS37	D’ Bu̠re ha finf Okse u ninn Kä̠i u zwälf Schèffle vor’s Dorf gebro̠cht, dia ha’se wö̠lle ve̮rka̠ufe̮.
 WS38	D’ Litt sinn hitt alli drusse of ’m Fald un maje.
 WS39	Geh nurr, d’r brunn Hond macht d’r nix.
-WS40	Ech bè mit da̲nne Litte do üwer d’ Ma̲tte g’fa̲hre iss Ko̲rn.
+WS40	Ech bè mit da̲nne Litte do üwer d’ Ma̲tte g’fa̲hre iss Ko̠rn.

--- a/36971_Ottoschwanden.csv
+++ b/36971_Ottoschwanden.csv
@@ -11,7 +11,7 @@ Anmerkungen: '<Bemk: an wird fast wie on gesprochen, wie in Handxx.> {´und ` is
   eingetragen}'
 ...
 WS01	Im Winder fliega dieh dru[g]ene Bledder in de̺r Luft rum.
-WS02	Shärt gli̺ch u̺f mit schneie, druo̠f wird s’We̺der wieder besser.
+WS02	Shärt gli̺ch u̬f mit schneie, druo̠f wird s’We̺der wieder besser.
 WS03	Due̠hn (?) Kòhle in Ofe, daß d’Milch bal afangt z’koche.
 WS04	Dèr gueht ald Mann isch mitèm Roß dur’s Is broche un ins kald Wasse̺r keiht.
 WS05	Er isch vor viehr oder sex Woche gschtorwe.
@@ -26,7 +26,7 @@ WS13	S’sin schlächdi Zidde!
 WS14	Mi li̺e̠hb Kínd, blib do unde stuh, dieh bäses Gens bisse ’di do̠d.
 WS15	Du hesch hüt am me̠sté g’lehrt un bisch ardig gsieh, de̺ derfsch früehjer heim guh als di̺e̠h Andre̺.
 WS16	De bisch no nit groß gnueh, zuane̠re̠ Flasche Wi̠ usz’trinke, de muesch no n’weng wachse un größer wäre.
-WS17	Gang, sei so guet un sag dinere <(Mueder)> Schwester, si soll d’Kleider für euer Mueder ferdig [n]äje un mit dr Bürst̠e suber mach[e].
+WS17	Gang, sei so guet un sag dinere <(Mueder)> Schwester, si soll d’Kleider für euer Mueder ferdig [n]äje un mit dr Bürst̬e suber mach[e].
 WS18	Hätsch du ihn kennt! Dernoh wär’s anderst kumme̠, un s’de̠t besser [umn stoh].
 WS19	Wer het mer mi Kórb voll Fléisch gstohle̠.
 WS20	Er duet, wi wenn si ne zum Dresche bschellt hätte; sie hänns aber sälwer dueh.
@@ -40,7 +40,7 @@ WS27	Kine ihr nit noch ’ä Augeblickli warde, no gänn mer mit euch.
 WS28	Ihr därfe keini e so Kindereie̠ tri̠we.
 WS29	Unseri Berg sin nit so hoch, eieri sin viel höcher.
 WS30	Wieh viel Pfund Wurscht un wieh viel Brot wänn’er ha.
-WS31	I’ verstand ei nit, ihr nien e weng lu̺der schwäze̠.
+WS31	I’ verstand ei nit, ihr nien e weng lu̬der schwäze̠.
 WS32	Hän ihr kei Stickli wissi Seipfe für mich uf mim Disch gfunde̠.
 WS33	Si Brueder will’em zwei scheni neui Hi̠ser in eurem Garte b[o]ue.
 WS34	Des Wort isch ihm vu Härze kumme!

--- a/37007_Bindernheim.csv
+++ b/37007_Bindernheim.csv
@@ -19,7 +19,7 @@ WS08	D’ Fäaß dea mr wè, i glâib, i hâb si durichglâifa.
 WS09	I be bi dr Frâ̄i gsé̆ un hâb’s ara gsait, un si hĕt gsait, sé wells âi erm Maidl sâia.
 WS10	I well’s âi ném wédr mâcha.
 WS11	I hâi dr glī mét dm Kochlèffl uf d’ Ōra, dü Âff!
-WS12	Wo gèsch âna, solla mr med dr gěh?
+WS12	Wo gèsch âna, solla mr med dr gĕh?
 WS13	’S sé schlachdi Zida!
 WS14	Mi leabs Kend, blī do unda schdĕ̄, d bäsa Gans bissa di dod.
 WS15	Dü hĕsch hĭt âm mĕschda glǟrd u bésch ârdig gsé, da dĕrfsch ĕndr haim gĕ̄ âs d’ Ândara.

--- a/37025_Schmieheim.csv
+++ b/37025_Schmieheim.csv
@@ -16,7 +16,7 @@ WS05	Ä̮r isch vor viar odder segs Wocha g’storba.
 WS06	S’ Fiir isch z’stark gsi, d’ Kuacha sin̄ jo unta ganz schwarz brän̄t.
 WS07	Är ißt dia Eier allewil un̄i Salz un̄ Pfäffer.
 WS08	D’ Füaß dia mr weh, i glaub, i ha si durgloffa. 
-WS09	I͜ bin bi̠ d’r Frau gsi un̄ hab s’ra gsait, s͡i hett gsait, s͡i well’s au ihrer Dochter saga.
+WS09	I͡ bin bi̠ d’r Frau gsi un̄ hab s’ra gsait, s͡i hett gsait, s͡i well’s au ihrer Dochter saga.
 WS10	I will’s äu nim̄i widder dua.
 WS11	I schlag di glich mit’m Kochlöffel um d’ Ohra, dü Aff!
 WS12	Wu gehsch dü hi, solla mar mit d’r geh?
@@ -29,7 +29,7 @@ WS18	Hättsch Dü ihn kän̄t! no̠ wär’s anderscht kum̄a, un̄ s’ dät be
 WS19	Wer het m’r mi Korb mit Fleisch gschtohla?
 WS20	Är het so dua, as hätta si in zuam drescha bschtellt; si hen̄’s aber selber dua.
 WS21	Wäm̄ het ’r dia neu G’schicht verzählt?
-WS22	M’r muaß lütt schreia, suscht verschteht ’r uns ni̮t.
+WS22	M’r muaß lütt schreia, suscht verschteht ’r uns ni̬t.
 WS23	M’r sin̄ miad un hen̄ Durscht.
 WS24	Als m’r geschtert z’ Oba z’ruckkom̄a sin̄, do sin̄ dia Andera schun̄ im Bett g’läga un̄ hen̄ scho fescht g’schlofa.
 WS25	D’r Schnee isch dia Nacht bi uns lige blieba, abber hitta Morgen isch ’r g’schmulza.
@@ -40,7 +40,7 @@ WS29	Unsri Bärg sin̄ nit so hoch, euri sin̄ vill höcher.
 WS30	Wiaviel Pfund Wurscht un̄ wiaviel Brod wella’n ihr?
 WS31	Ich v’rschteh euch nit, ihr mian a bissli lütter reda.
 WS32	Hän̄ ihr käi Stickli wissi Saipfi fir mich uff mim̄ Disch g’funda?
-WS33	Si̮ Bruader will sich zwei schöni neui Hi̱ser in euram Garta baua.
+WS33	Si̬ Bruader will sich zwei schöni neui Hi̠ser in euram Garta baua.
 WS34	De̱s Wort isch ihm vum̄ Härza kum̄a!
 WS35	Des isch rächt gsi von Ihna.
 WS36	Was sitza do für Vögeli oben uff däm Mi̠arli?

--- a/37025_Schmieheim.csv
+++ b/37025_Schmieheim.csv
@@ -12,7 +12,7 @@ WS01	Im Winter fliaga dia truckene Blätter in der Luft rum̄.
 WS02	S’ hört glich uff z’schneie, d’rno wurd s’ Wätter widder besser.
 WS03	Dua Kohla in da n’ Ofa, daß d’ Milch ball anfangt z’kocha.
 WS04	D’r guat alt Man̄ ísch mit’m Roß dur’s Is brocha un̄ in’s kalt Wasser g’falla.
-WS05	Ä̮r isch vor viar odder segs Wocha g’storba.
+WS05	Ä̬r isch vor viar odder segs Wocha g’storba.
 WS06	S’ Fiir isch z’stark gsi, d’ Kuacha sin̄ jo unta ganz schwarz brän̄t.
 WS07	Är ißt dia Eier allewil un̄i Salz un̄ Pfäffer.
 WS08	D’ Füaß dia mr weh, i glaub, i ha si durgloffa. 

--- a/37025_Schmieheim.csv
+++ b/37025_Schmieheim.csv
@@ -41,7 +41,7 @@ WS30	Wiaviel Pfund Wurscht un̄ wiaviel Brod wella’n ihr?
 WS31	Ich v’rschteh euch nit, ihr mian a bissli lütter reda.
 WS32	Hän̄ ihr käi Stickli wissi Saipfi fir mich uff mim̄ Disch g’funda?
 WS33	Si̬ Bruader will sich zwei schöni neui Hi̠ser in euram Garta baua.
-WS34	De̱s Wort isch ihm vum̄ Härza kum̄a!
+WS34	De̠s Wort isch ihm vum̄ Härza kum̄a!
 WS35	Des isch rächt gsi von Ihna.
 WS36	Was sitza do für Vögeli oben uff däm Mi̠arli?
 WS37	Dia Bu̠ra hän̄ fünf Ochsa un̄ ni̠n Küah un̄ zwölf Schäfli vor s’ Dorf bro̠cht, dia hän̄ si v’rkaufa wella.

--- a/37025_Schmieheim.csv
+++ b/37025_Schmieheim.csv
@@ -16,7 +16,7 @@ WS05	Ä̮r isch vor viar odder segs Wocha g’storba.
 WS06	S’ Fiir isch z’stark gsi, d’ Kuacha sin̄ jo unta ganz schwarz brän̄t.
 WS07	Är ißt dia Eier allewil un̄i Salz un̄ Pfäffer.
 WS08	D’ Füaß dia mr weh, i glaub, i ha si durgloffa. 
-WS09	I͜ bin bi̠ d’r Frau gsi un̄ hab s’ra gsait, s͜i hett gsait, s͜i well’s au ihrer Dochter saga.
+WS09	I͜ bin bi̠ d’r Frau gsi un̄ hab s’ra gsait, s͡i hett gsait, s͡i well’s au ihrer Dochter saga.
 WS10	I will’s äu nim̄i widder dua.
 WS11	I schlag di glich mit’m Kochlöffel um d’ Ohra, dü Aff!
 WS12	Wu gehsch dü hi, solla mar mit d’r geh?

--- a/37035_Bollenbach.csv
+++ b/37035_Bollenbach.csv
@@ -20,12 +20,12 @@ WS09	I bin bi der Frau gsi und hab ihra gsait un si het gsait, sie wolls au ihra
 WS10	I wills au nimi dua.
 WS11	I schlag di gli mit dm Kochlöffl um d’ Ohra, du Aff.
 WS12	Wo gosch na, solla mar mit dr goh?
-WS13	Sin schlechti Zitta̮!
+WS13	Sin schlechti Zitta̬!
 WS14	Mi liabs Kind, bliab do hunta stoh, dia bäsa Gnigs bisa di dod.
 WS15	Du hesch hit am maista glärt un bisch ardig gsi, du darfsch früer haim ge as di andera.
 WS16	Du bisch nit groß gnuag, um a Flasch Wi usztrinka, du muascht erst no waxa un gräßr wära.
 WS17	Gang, sei so gua̠t un sag diner Schwestr, si soll Glaidr für eur Mua̠tr fertig naia̠ un mit dr Bürscht sufr macha̠.
-WS18	Hätsch du ihn kinnt’, no wärs anders kumma̮ un s’ tät bessr umma̮ stoh.
+WS18	Hätsch du ihn kinnt’, no wärs anders kumma̬ un s’ tät bessr umma̬ stoh.
 WS19	Wer het mr mi Korb mi Flaisch gschtola.
 WS20	Er het so dua, als hätamr ihn zuam drescha bstellt, si hinz abr selbr dua.
 WS21	Wem hetr di neu Gschicht verzellt?
@@ -44,7 +44,7 @@ WS33	 Si Bruadr will sich zwei schini neii Hisr in euern Garta baua.
 WS34	Des Wort ischm vum Herza kumma.
 WS35	Des isch recht funana gsi!
 WS36	Was sitza̠ do fur Vogili oma̠ uf dem Mirli?
-WS37	Dia̮ Bura̮ hän fünf Oxa̮ un ni Küa̮ un zwölf Schäfli vors Dorf brocht un hän sie verkaufa̮ wella̮.
+WS37	Dia̬ Bura̬ hän fünf Oxa̬ un ni Küa̬ un zwölf Schäfli vors Dorf brocht un hän sie verkaufa̬ wella̬.
 WS38	D’ Lüt sin hit alli dus ufem Feld un maia.
 WS39	Gang un dr bru Hund duat dr nix.
 WS40	I bi mit da Lit do hinta über d’ Matt ins Korn gfara.

--- a/37058_Le-Hohwald.csv
+++ b/37058_Le-Hohwald.csv
@@ -42,7 +42,7 @@ WS31	I verstèh ich nèt, ar mian a bès’l lüdder rèdda.
 WS32	Hanar ké Stèck’l wissi Säif fer mi uf mim Desch gfunda?
 WS33	Si Brüad’r wèll am zwäi schnéni nèji Hisar i èjaram Garda böja.
 WS34	S’ Wort èsch am vu Harza kumma.
-WS35	De̮s èsch racht von a gsè.
+WS35	De̬s èsch racht von a gsè.
 WS36	Was huka do fèr Väjala owa of dam Mirala?
 WS37	D’ Büra ha fèmf Ochsa u nin Kia u zwélf Schèfla vors Dorf gabrocht, dia hassi wélla v’rkeufa.
 WS38	D’ Lit sè hit alli drüßa ùf’m Stèck u maja.

--- a/37119_Buchenberg.csv
+++ b/37119_Buchenberg.csv
@@ -43,7 +43,7 @@ WS32	Hen da koa wieß’ Soapfa für mich uf mim Disch gfunda.
 WS33	S’n Bruădă will sich zwoă neiwa Hüser in eiwăram Gārtă bauwa.
 WS34	Das Wort isch’ am us am Herză kumma.
 WS35	Sell isch reacht von nă nă gs̰i.
-WS36	Wa huka da vor kleina Vögeli uf der klo͜a Muar.
+WS36	Wa huka da vor kleina Vögeli uf der klo͡a Muar.
 WS37	Die Buără hen fünf Ochsa un ne’n Kühă un zwölf Schäflĭ vor’s Dorf broăcht die <(sie)> hen’s wolla văkaufă.
 WS38	Die Litt sen hitt älli uffam Feld druß un meiǎ.
 WS39	Gang nua, der brun Hund duatda nints.

--- a/37119_Buchenberg.csv
+++ b/37119_Buchenberg.csv
@@ -45,6 +45,6 @@ WS34	Das Wort isch’ am us am Herză kumma.
 WS35	Sell isch reacht von nă nă gs̰i.
 WS36	Wa huka da vor kleina Vögeli uf der klo͡a Muar.
 WS37	Die Buără hen fünf Ochsa un ne’n Kühă un zwölf Schäflĭ vor’s Dorf broăcht die <(sie)> hen’s wolla văkaufă.
-WS38	Die Litt sen hitt älli uffam Feld druß un meiǎ.
+WS38	Die Litt sen hitt älli uffam Feld druß un meiă.
 WS39	Gang nua, der brun Hund duatda nints.
 WS40	I bin mit dr Litt de hina durrt Wiesa ins Korn gfăhră.

--- a/37119_Buchenberg.csv
+++ b/37119_Buchenberg.csv
@@ -40,7 +40,7 @@ WS29	Isără Berg sen net so hoch, die eiwară sen viel höher.
 WS30	Wie viel Pfund Wärscht und Brot wena ha̰u.
 WS31	Ĭ verstand ’i nittă, ihr müßt ă weng luttă sprecha <(schwätza)>.
 WS32	Hen da koa wieß’ Soapfa für mich uf mim Disch gfunda.
-WS33	S’n Bruӑdӑ will sich zwoӑ neiwa Hüser in eiwӑram Gārtӑ bauwa.
+WS33	S’n Bruădă will sich zwoă neiwa Hüser in eiwăram Gārtă bauwa.
 WS34	Das Wort isch’ am us am Herză kumma.
 WS35	Sell isch reacht von nă nă gs̰i.
 WS36	Wa huka da vor kleina Vögeli uf der klo͜a Muar.

--- a/37388_Schenkenzell.csv
+++ b/37388_Schenkenzell.csv
@@ -47,4 +47,4 @@ WS36	Was sitze d͜o fiër Vegeli obe uf dem Miërli.
 WS37	Di Bure hen̄ finf Ogse un̄ nei Kië un̄ zwelf Schäfli fiërs Dorf brocht; dië hen̄ si verkaufe welle.
 WS38	di Leit sin̄ hitt äll uf em Feld usse un̄ maie.
 WS39	Gang nau, dr brau Hund duet dr nint.
-WS40	I bḛi mit͜ dene Leit do hin̄e über dië Wies ins Korn gfahre.
+WS40	I bḛi mit͡ dene Leit do hin̄e über dië Wies ins Korn gfahre.

--- a/37388_Schenkenzell.csv
+++ b/37388_Schenkenzell.csv
@@ -34,11 +34,11 @@ WS23	Mier sin̄ mied un̄ hen̄ durscht.
 WS24	Wo mer geschdert z’ Obe zrukum̄e sin̄, no sin̄ die andere schau im Bett gläge un̄ hen̄ feschd g’schlofe.
 WS25	Dr Schnä isch die Nacht bei eis leige bliebe, awer hidde morge isch er gschmolze.
 WS26	Hinter aiserem Haus schden drei schene Epfelbem̄li mit rodde Epfeli.
-WS27	Ken̄ed ’er nitt no en Augeblick uf‿is wārdde; no gem̄er midd ’i.
+WS27	Ken̄ed ’er nitt no en Augeblick uf⁀is wārdde; no gem̄er midd ’i.
 WS28	’r därfe kaini so Kindereie treiwe.
 WS29	Eiseri Berg sin̄ nitt arg hō; di eiere sin̄ vḛil haier.
 WS30	Wi vḛil Pfund Wurschd un̄ wi veil Brôt wen̄ er ha̰u?
-WS31	I verschda̰u i nitt; er miëted e bisli lauter schwā̈ze.
+WS31	I verschda̰u i nitt; er miëted e bisli lauter schwǟze.
 WS32	Hen̄ er kei Stickli weißi Saipfe fier mi uf meim Disch gfunde? 
 WS33	Sei Brueder will em zwai schäni neä Heiser ni eierem Gārdde baue.
 WS34	Des Wort isch em von Herze kom̄e.

--- a/37388_Schenkenzell.csv
+++ b/37388_Schenkenzell.csv
@@ -21,7 +21,7 @@ WS10	I will’s au nim̄i dua!
 WS11	I schla di glei mit ’em Kochleffl um d’ Ohre, du Aff!
 WS12	Wo gōsch nā, solle mer middr gau?
 WS13	’s sin̄ schlechti Zeidde!
-WS14	Ma̰i liëbs Kind, bleib do hun̄e stau, di bǟse Gä̰is beisse di do̱d.
+WS14	Ma̰i liëbs Kind, bleib do hun̄e stau, di bǟse Gä̰is beisse di do̠d.
 WS15	Da̰u hosch hait am mǟschde glehrt un̄ bisch arti’ gsai. De därsch belder haim as di andere.
 WS16	Da̰u bisch no nit gro̰hs gnueg, um {Blatt abgerissen!} Flasch Wei auszdringge, da̰u muesch zersch no mè wāse u. grǟhser wǟre.
 WS17	Gang, sei so guet un̄ sag da̰iere Schweschder, si sott d’ Klaider fiër d’ Muedder fertig naie un̄ midder Bürschd saufer mache.

--- a/37748_Lehr.csv
+++ b/37748_Lehr.csv
@@ -40,11 +40,11 @@ WS29	Õsèré Berg sénd éd arg hau, dé uiré sénd viel haier.
 WS30	Wièviel Pfõd Wūrschd ond wièviel Brȭd wänd’r hau?
 WS31	I v’rschdand ui ed, ’r müèßd a bißl´s läud’r schwätza.
 WS32	Hènd’r koi Schdügle <(Brögale)> weißa Soif für mi uf meim Dīsch gfonda.
-WS33	Sei Bruader will’m zwõi schöène nuie Häu?’r en uirén Găda̴ nai baua.
+WS33	Sei Bruader will’m zwõi schöène nuie Häu?’r en uirén Găda̰ nai baua.
 WS34	Dees Wõãd ischd’m vom Hèza komma.
 WS35	Dèschd reachd gwea vo ?éhné.
 WS36	Was sitzad dau für Vögala oba uf deam Mäuèrlé?
-WS37	Dia Baura händ fa̰ḭf Ogsa ond na̴i Küha ond zwölf Schäfla võars Dõ̴rf hear brõcht, dia wänd se v’rkaufa.
+WS37	Dia Baura händ fa̰ḭf Ogsa ond na̰i Küha ond zwölf Schäfla võars Dõ̴rf hear brõcht, dia wänd se v’rkaufa.
 WS38	Dia Leud send haid älle uf’m Feă̄ld dußa ond mähad.
 WS39	Gang no, dear brãu Hȭd duad’r nèx.
 WS40	I be mid deane Leud über dia Wiesa dõ hénda é̆ns Koara gfahra.

--- a/37947_Schönaich.csv
+++ b/37947_Schönaich.csv
@@ -19,7 +19,7 @@ WS04	Deă̰r gūă̰t alt Mā̰ ist <(ischt)> mit(d)am Gaul durs Eis brochă̰ u
 WS05	Ăr(r) ist vour viar oder sechs <(sēks)> Wochă̰ gstorbă̰.
 WS06	’SFuiă̰r ist z’stark gweă̰, d’ Kuachă̰ send jō̰ ganz schwārz brennt.
 WS07	Ăr(r) ißt d’Oiă̰r ällă̰weil <(od. ender)> ohne Salz u. <(ond)> Pfeffer.
-WS08	D’Füă̰ß deand mă̰r waih, ih glaub, ih ha̰ṵ̆s durre g’loffă̰.
+WS08	D’Füă̰ß deand mă̰r waih, ih glaub, ih ha̰ṵ̌s durre g’loffă̰.
 WS09	Ih bē bei deară̰ Frau gweă̰ u. <(ond)> ha̰ṵners g’sait, ond sĕ ho̰t gsait, se wölls au ihară̰r Tochter sagă̰.
 WS10	Ih wills au nemme wieder do̰ă̰ <(tho̰ă̰)>.
 WS11	Ih schlā dr glei mit (d)am Kuchelöffel om d’ Auhră̰ <(rŏm)>, du Ăff’!
@@ -31,7 +31,7 @@ WS16	Dă̰ bist no et grauß gnuă̰g, [ŏm] ă̰ Flasch Weḭ aus z’trenkă̰
 WS17	Gang, se so guă̰t ond sāg deiră̰ Schwester, si soll diă̰ Kloadă̰r für [uiă̰r] Muată̰r fērtech nähă̰ ond mit der Bǖrst sauber machă̰ <(ausbutză̰)>.
 WS18	Hättst dă̰ ken̄t, no̰ wǟrs andă̰rst kom̄ă̰ ond’s thät <(dǟt)> besser om <(um)> en staṵh.
 WS19	Wear ho̰t mă̰r mein Krattă̰ mit Floă̰sch gstohlă̰?
-WS20	Ă̰r(r) <(er)> ho̰t so tha̰u <(da̰u)>, wie wenn sĕn zum Dreschă̰ bstellt hättă̰t, se hents abă̰r selba̰r daṵ̆.
+WS20	Ă̰r(r) <(er)> ho̰t so tha̰u <(da̰u)>, wie wenn sĕn zum Dreschă̰ bstellt hättă̰t, se hents abă̰r selba̰r daṵ̌.
 WS21	Weam hot’r dui nui Gschīcht verzählt?
 WS22	Mă̰r muă̰ß laut schreiă̰, sŭst [versto̰ht’r] oam [et].
 WS23	Mă̰r send müă̰d ond hent Dūrst.

--- a/38044_Hünerberg.csv
+++ b/38044_Hünerberg.csv
@@ -21,7 +21,7 @@ WS10	I wills au nem̄e wieder doe.
 WS11	I schlag de glei mit am Kochlöffl omd Aura, du Aff.
 WS12	Wo gost na, sollet mer mit dr gau.
 WS13	S’ send schleachde Zeida.
-WS14	Mei liabs Ken̅, bleib onda stau, dia ba͜ise Gas beise de daut.
+WS14	Mei liabs Ken̄, bleib onda stau, dia ba͜ise Gas beise de daut.
 WS15	Du hast heut am meisda glearnt ond bist artich gwea, du derscht bälder noch Haus gau als d’ Andere.
 WS16	Du bist no net grauß gnuag, om a Flasch Wei ausztrenket, du muaßt airscht no ebbes wagsa ond gräußer weara.
 WS17	Gang, sei so guat ond sags deiner Schweschdr, se soll d’ Kloader für euer Muader ferdich naije ond mit der Bürscht sauber macha. 

--- a/38044_Hünerberg.csv
+++ b/38044_Hünerberg.csv
@@ -21,7 +21,7 @@ WS10	I wills au nem̄e wieder doe.
 WS11	I schlag de glei mit am Kochlöffl omd Aura, du Aff.
 WS12	Wo gost na, sollet mer mit dr gau.
 WS13	S’ send schleachde Zeida.
-WS14	Mei liabs Ken̄, bleib onda stau, dia ba͜ise Gas beise de daut.
+WS14	Mei liabs Ken̄, bleib onda stau, dia ba͡ise Gas beise de daut.
 WS15	Du hast heut am meisda glearnt ond bist artich gwea, du derscht bälder noch Haus gau als d’ Andere.
 WS16	Du bist no net grauß gnuag, om a Flasch Wei ausztrenket, du muaßt airscht no ebbes wagsa ond gräußer weara.
 WS17	Gang, sei so guat ond sags deiner Schweschdr, se soll d’ Kloader für euer Muader ferdich naije ond mit der Bürscht sauber macha. 

--- a/38169_Dennach.csv
+++ b/38169_Dennach.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Em Wender flia̰ga̰t dia̰ trugga̰ne Bledder in da̰r Luft rom.
 WS02	S’ hört glei uff z’schneicha̰, no̰ words Wädder béssa̰r.
 WS03	Duar Kohla en Ofa, daß d’ Milch ball a z’kocha fangt.
-WS04	Dǎ̰r gua̰d alt Mann ischt mit a̰m Roß durchs Eis brŏcha̰ ŏn ens kalt Wassa̰r g’falla̰.
+WS04	Dă̰r gua̰d alt Mann ischt mit a̰m Roß durchs Eis brŏcha̰ ŏn ens kalt Wassa̰r g’falla̰.
 WS05	A̰r ischt vor via̰r odda̰r ségs Wocha̰ g’storwa̰.
 WS06	S feuar ischt schtark gwä, no sĕn dia Kuacha ŏna ganz schwarz brénnt.
 WS07	A̰r ißt d’ Aia̰r alla̰weil ohne Salz ŏn Pfèffa̰r.

--- a/38169_Dennach.csv
+++ b/38169_Dennach.csv
@@ -11,10 +11,10 @@ Anmerkungen: ''
 WS01	Em Wender flia̰ga̰t dia̰ trugga̰ne Bledder in da̰r Luft rom.
 WS02	S’ hört glei uff z’schneicha̰, no̰ words Wädder béssa̰r.
 WS03	Duar Kohla en Ofa, daß d’ Milch ball a z’kocha fangt.
-WS04	Dǎ̰r gua̰d alt Mann ischt mit a̰m Roß durchs Eis brǒcha̰ ǒn ens kalt Wassa̰r g’falla̰.
+WS04	Dǎ̰r gua̰d alt Mann ischt mit a̰m Roß durchs Eis brŏcha̰ ŏn ens kalt Wassa̰r g’falla̰.
 WS05	A̰r ischt vor via̰r odda̰r ségs Wocha̰ g’storwa̰.
 WS06	S feuar ischt schtark gwä, no sĕn dia Kuacha ŏna ganz schwarz brénnt.
-WS07	A̰r ißt d’ Aia̰r alla̰weil ohne Salz ǒn Pfèffa̰r.
+WS07	A̰r ißt d’ Aia̰r alla̰weil ohne Salz ŏn Pfèffa̰r.
 WS08	D’ Füãß de mãr waih, i glaub, i häb se durchg’loffã.
 WS09	I benn bei da̰r Frau gwä ŏn häbbs a̰ra̰ gsaid, ŏn se hat gsait, se wells au ihra̰m Maidle saga̰.
 WS10	I wills au nemme dō.
@@ -45,6 +45,6 @@ WS34	Des Wōrt isch a̰m von Hèrza̰ komma̰.
 WS35	Dē̄s isch rècht von enă̰.
 WS36	Was sitza̰t do̰ fü̆r Vega̰la̰ owă̰ uff dem Mäua̰rle?
 WS37	Dia̰ Baura̰ hen fenf Ochsa̰ ŏn noḛ Küha̰ ŏn zwölf Schäfla̰ vors Dorf bro̰cht, dia̰ wéllt se verkaufa̰.
-WS38	Dia Leut sen hoet alle uff am Fäll daußa ǒn maihat. 
+WS38	Dia Leut sen hoet alle uff am Fäll daußa ŏn maihat. 
 WS39	Gang no, dar brau Hon duad dar negs.
 WS40	I ben mit de Leut do henna̰ üwa̰r d Wiesa̰ ens Korn g’fahra̰.

--- a/38169_Dennach.csv
+++ b/38169_Dennach.csv
@@ -21,7 +21,7 @@ WS10	I wills au nemme dō.
 WS11	I schlag de glei mit am Kochlöff’l ŏm d’ Ohra du Aff!
 WS12	Wo gehst na, solla mar mit dar géh?
 WS13	Sĕn schlèchde Zeida̰!
-WS14	Moḛ lia̰bs Kĕn, bleib do̰ onna̰ ste̒h, dia̰ böse Ges beißa̰ de dōd.
+WS14	Moḛ lia̰bs Kĕn, bleib do̰ onna̰ stéh, dia̰ böse Ges beißa̰ de dōd.
 WS15	Du hast hoḛt a̰m méschda̰ glèrnt onn bischt ārtich gwǟ, du därfscht bella̰r hoḛm als de anna̰re.
 WS16	Du bischt no nét groß gnua̰g, om a̰ Flăsch Woḛ ausz’trénka̰, du mua̰scht zérscht no èbba̰s wachsa̰ ŏn größer wèrra̰.
 WS17	Gang, sei so gua̰d ŏn sag doḛna̰r Schwésta̰r, se soll dia̰ Klaida̰r für eua̰r Mua̰da̰r fértich naiha̰ ŏn ausbǖrschta̰.
@@ -42,7 +42,7 @@ WS31	I verstăn ich nĕt, da̰r müa̰ßt a̰ bißle lauta̰r schwätza̰.
 WS32	Hen dar koe Stickle weißa Saife für me uff moem Disch gfona?
 WS33	Soḛ Brua̰da̰r will a̰m zwai schöne neue Häusa̰r en eua̰ră̰n Gārda̰ baua̰.
 WS34	Des Wōrt isch a̰m von Hèrza̰ komma̰.
-WS35	Dē̄s isch rècht von enă̰.
+WS35	Dḗs isch rècht von enă̰.
 WS36	Was sitza̰t do̰ fü̆r Vega̰la̰ owă̰ uff dem Mäua̰rle?
 WS37	Dia̰ Baura̰ hen fenf Ochsa̰ ŏn noḛ Küha̰ ŏn zwölf Schäfla̰ vors Dorf bro̰cht, dia̰ wéllt se verkaufa̰.
 WS38	Dia Leut sen hoet alle uff am Fäll daußa ŏn maihat. 

--- a/38215_Stuttgart.csv
+++ b/38215_Stuttgart.csv
@@ -16,7 +16,7 @@ WS05	‘r ischt vo̰a̰r a̰ Wocha̰ via̰r oder ſex g’ſchdorba̰.
 WS06	‘s Feier ischt z’ſchtark gwä̱ d’Kůcha̰ ſend jo onda̰ ganz ſchwarz bran̄d.
 WS07	‘r ißt d’O̰ier emmer ohne Salz ond Pfeffḛr.
 WS08	D’Fiaß dhea̰nd mḛr weh ih’ glaůb’, ih’ han̄ ſe důrchglaffa̰.
-WS09	Ih’ bé̱’ bei dea̰ra̰ Fraů gwä̱ ond háu’s ḛr ḛ g’ſagt no̰ hot ſe g’ſagt, ſe wells aṵ̊ ihrḛr Do̱chdḛr ſaga̰.
+WS09	Ih’ bé̱’ bei dea̰ra̰ Fraů gwä̱ ond háu’s ḛr ḛ g’ſagt no̰ hot ſe g’ſagt, ſe wells aṵ̆ ihrḛr Do̱chdḛr ſaga̰.
 WS10	I̱’h wills némmé dho̱.
 WS11	 I̱’h schlag’ de glei mit ḛm Kührlöffel an d’Ohra̰, dů Aff’!
 WS12	Wo̰ go̰̱ſchd dů na̰, ſollḛt mḛr mit d’r ganga̰.
@@ -30,14 +30,14 @@ WS19	Wéar ho̰t mĕr mein Korb mit Flo̰éſch g’ſchdula̰.
 WS20	‘r ho̰t ſo dho̱, als hättḛt ſe’n zum drèſcha̰ b’ſchdélld, ſé hénd’s aber ſèlber dho̱.
 WS21	Wém ho̰t’r dé neu G’ſchicht’ verze’hlt?
 WS22	Ma̰ můa̰ß laůd ſchreia̰, ſouſchd verſchdohd’r’s net.
-WS23	M’r ſeud mia̰d ond hénd dṵ̊rſcht.
+WS23	M’r ſeud mia̰d ond hénd dṵ̆rſcht.
 WS24	Wo (als) m’r geſchderd z’O̰bḛd z’rickkum̄a̰ ſend, no̰ ſend de Andḛre ſcho̱ em Bett gläga̰ ond hend ſe ſcho gſchlofa.
 WS25	D’r ſchnee iſcht ſeḭd Na̱cht bei ons liega̰ blieba̰, aber ſeḭda̰ Morga̰ iſcht’r g’ſchmolza.
 WS26	Hendḛr onſrem Haus ſchtandḛt drei ſchene Apfelbḛmla̰ mit rode Apfḛla̰.
 WS27	Kenḛt ia̰hr net no en Aůga̰blick ůf’s warta̰ no̰ gangḛt mir mit é̮ch.
 WS28	‘r därfet ét ſotté Kendera̰ia̰ treiba̰.
 WS29	Onſḛre Berg’ ſénd ét arg hoch, dé eire ſénd viel hé̱chḛr.
-WS30	Wia̰v’l Pfond Wṵ̊rſcht ond wia̰v’l Brod wélla̰t’r ha̱n?
+WS30	Wia̰v’l Pfond Wṵ̆rſcht ond wia̰v’l Brod wélla̰t’r ha̱n?
 WS31	I̱’h verſchdand eich net, ‘r mia̰ßt a̰ bißle laůdḛr ſchwätzḛ.
 WS32	Heud ia̰hr kon̰ ſchdi̮gglé weißa̰ ſo̰efa̰ fir mi’ ůff mei’m Diſch g’fonda̰
 WS33	ſḛi Brua̰dḛr will ſé zwo̰e ſché̱né neie Heiſer en eirem Ga̮rda̰ baůa̰.

--- a/38215_Stuttgart.csv
+++ b/38215_Stuttgart.csv
@@ -16,22 +16,22 @@ WS05	‘r ischt vo̰a̰r a̰ Wocha̰ via̰r oder ſex g’ſchdorba̰.
 WS06	‘s Feier ischt z’ſchtark gwä̱ d’Kůcha̰ ſend jo onda̰ ganz ſchwarz bran̄d.
 WS07	‘r ißt d’O̰ier emmer ohne Salz ond Pfeffḛr.
 WS08	D’Fiaß dhea̰nd mḛr weh ih’ glaůb’, ih’ han̄ ſe důrchglaffa̰.
-WS09	Ih’ bé̱’ bei dea̰ra̰ Fraů gwä̱ ond háu’s ḛr ḛ g’ſagt no̰ hot ſe g’ſagt, ſe wells aṵ̌ ihrḛr Do̱chdḛr ſaga̰.
-WS10	I̱’h wills némmé dho̱.
+WS09	Ih’ bé̱’ bei dea̰ra̰ Fraů gwä̱ ond háu’s ḛr ḛ g’ſagt no̰ hot ſe g’ſagt, ſe wells aṵ̌ ihrḛr Do̠chdḛr ſaga̰.
+WS10	I̱’h wills némmé dho̠.
 WS11	 I̱’h schlag’ de glei mit ḛm Kührlöffel an d’Ohra̰, dů Aff’!
-WS12	Wo̰ go̰̱ſchd dů na̰, ſollḛt mḛr mit d’r ganga̰.
+WS12	Wo̰ go̰̠ſchd dů na̰, ſollḛt mḛr mit d’r ganga̰.
 WS13	S’ſénd ſchlèchte Zeita̰!
-WS14	Lia̰bs Kend, bleib’ no do̰ onda̰ ſchteha̰, dia̰ bé̱ſé Ge̱hs beißa̰ dé do̱d.
+WS14	Lia̰bs Kend, bleib’ no do̰ onda̰ ſchteha̰, dia̰ bé̱ſé Ge̱hs beißa̰ dé do̠d.
 WS15	Weil dů hḛit a̰m maiſchdḛ g’lèrnt ho̰ſcht, ond a̱rdech (brav) gwä bischt, därſcht bälder ho̰im geha̰ als de Andḛrn.
 WS16	Dé bisſt nonet groß gnůa̰g, um a̰ Flaſch’ Wḛi’ aůsz’trenka̰, dé můa̰ſcht erſcht no ebbes wagſa̰ und greßḛr wèrda̰.
 WS17	Ga̰ng, ſeiſo gůa̰t und ſag’ dḛira̰ Schwéſchḛr ſe ſoll d’Klo̰ider fir eier Můa̰der ferdech(g) näha̰ ond saůber ausbīrſchta̰.
 WS18	Hätt’ſcht en kend, no̰ wärs andḛrſcht koma̰ ond’s dhäd beſſḛr om èn ſchtéha̰.
 WS19	Wéar ho̰t mĕr mein Korb mit Flo̰éſch g’ſchdula̰.
-WS20	‘r ho̰t ſo dho̱, als hättḛt ſe’n zum drèſcha̰ b’ſchdélld, ſé hénd’s aber ſèlber dho̱.
+WS20	‘r ho̰t ſo dho̠, als hättḛt ſe’n zum drèſcha̰ b’ſchdélld, ſé hénd’s aber ſèlber dho̠.
 WS21	Wém ho̰t’r dé neu G’ſchicht’ verze’hlt?
 WS22	Ma̰ můa̰ß laůd ſchreia̰, ſouſchd verſchdohd’r’s net.
 WS23	M’r ſeud mia̰d ond hénd dṵ̌rſcht.
-WS24	Wo (als) m’r geſchderd z’O̰bḛd z’rickkum̄a̰ ſend, no̰ ſend de Andḛre ſcho̱ em Bett gläga̰ ond hend ſe ſcho gſchlofa.
+WS24	Wo (als) m’r geſchderd z’O̰bḛd z’rickkum̄a̰ ſend, no̰ ſend de Andḛre ſcho̠ em Bett gläga̰ ond hend ſe ſcho gſchlofa.
 WS25	D’r ſchnee iſcht ſeḭd Na̱cht bei ons liega̰ blieba̰, aber ſeḭda̰ Morga̰ iſcht’r g’ſchmolza.
 WS26	Hendḛr onſrem Haus ſchtandḛt drei ſchene Apfelbḛmla̰ mit rode Apfḛla̰.
 WS27	Kenḛt ia̰hr net no en Aůga̰blick ůf’s warta̰ no̰ gangḛt mir mit é̮ch.
@@ -41,10 +41,10 @@ WS30	Wia̰v’l Pfond Wṵ̌rſcht ond wia̰v’l Brod wélla̰t’r ha̱n?
 WS31	I̱’h verſchdand eich net, ‘r mia̰ßt a̰ bißle laůdḛr ſchwätzḛ.
 WS32	Heud ia̰hr kon̰ ſchdi̮gglé weißa̰ ſo̰efa̰ fir mi’ ůff mei’m Diſch g’fonda̰
 WS33	ſḛi Brua̰dḛr will ſé zwo̰e ſché̱né neie Heiſer en eirem Ga̮rda̰ baůa̰.
-WS34	Dees Wort iſcht’m vo̱ Hérza̰ kom̄a̰.
+WS34	Dees Wort iſcht’m vo̠ Hérza̰ kom̄a̰.
 WS35	Dees iſcht récht von’n gwä̱.
 WS36	Was ſitzet do̰ fir Ve̱gḛla̰ ůff dea̰m Meierle droba̰?
 WS37	Dia̰ Baůra̰ hend fenf Ochſa, ond nḛi Kia̰h ond zwelf Schäfla̰ or’s Dorf bro̰cht, dia̰ hend ſé verkaůfa̰ wélla̰.
 WS38	D’Leit ſénd heḭt ällé ůff’m Fèld drŭſſa̰ ond mähḛt.
-WS39	Gang no̱, dea̰r braṵ Hund dhůa̰d d’r néx.
+WS39	Gang no̠, dea̰r braṵ Hund dhůa̰d d’r néx.
 WS40	I’h be̱’ mit de Leit’ do̰ héndḛ ibḛr d’Wieſa̰ éns Kŏrn g’fa̱hra̰.

--- a/38215_Stuttgart.csv
+++ b/38215_Stuttgart.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	Iḿ Wéndḛ́r flia̰gḛd dé druggéné bléddḛr én d’r Lů̮ft rom.
 WS02	‘s heert glei aŭf z’schneiad, no̰ wird ‘s Wèddḛr wiedḛr beſſḛr.
-WS03	Dhua̰ Kohla en de n͡ O̱fa̰, daß d’Milch bald a̰fa̰ngd z’kocha̰.
+WS03	Dhua̰ Kohla en de n͡ O̠fa̰, daß d’Milch bald a̰fa̰ngd z’kocha̰.
 WS04	D’r gůa̰d ald’ Ma̰’ ischt mit ḛm Gaůl ens Eis ḛibrocha̰ ond ens kalt Wassḛr g’falla̰.
 WS05	‘r ischt vo̰a̰r a̰ Wocha̰ via̰r oder ſex g’ſchdorba̰.
 WS06	‘s Feier ischt z’ſchtark gwä̱ d’Kůcha̰ ſend jo onda̰ ganz ſchwarz bran̄d.
@@ -21,7 +21,7 @@ WS10	I̱’h wills némmé dho̠.
 WS11	 I̱’h schlag’ de glei mit ḛm Kührlöffel an d’Ohra̰, dů Aff’!
 WS12	Wo̰ go̰̠ſchd dů na̰, ſollḛt mḛr mit d’r ganga̰.
 WS13	S’ſénd ſchlèchte Zeita̰!
-WS14	Lia̰bs Kend, bleib’ no do̰ onda̰ ſchteha̰, dia̰ bé̱ſé Ge̱hs beißa̰ dé do̠d.
+WS14	Lia̰bs Kend, bleib’ no do̰ onda̰ ſchteha̰, dia̰ bé̱ſé Ge̠hs beißa̰ dé do̠d.
 WS15	Weil dů hḛit a̰m maiſchdḛ g’lèrnt ho̰ſcht, ond a̱rdech (brav) gwä bischt, därſcht bälder ho̰im geha̰ als de Andḛrn.
 WS16	Dé bisſt nonet groß gnůa̰g, um a̰ Flaſch’ Wḛi’ aůsz’trenka̰, dé můa̰ſcht erſcht no ebbes wagſa̰ und greßḛr wèrda̰.
 WS17	Ga̰ng, ſeiſo gůa̰t und ſag’ dḛira̰ Schwéſchḛr ſe ſoll d’Klo̰ider fir eier Můa̰der ferdech(g) näha̰ ond saůber ausbīrſchta̰.
@@ -43,8 +43,8 @@ WS32	Heud ia̰hr kon̰ ſchdi̬gglé weißa̰ ſo̰efa̰ fir mi’ ůff mei’m 
 WS33	ſḛi Brua̰dḛr will ſé zwo̰e ſché̱né neie Heiſer en eirem Ga̮rda̰ baůa̰.
 WS34	Dees Wort iſcht’m vo̠ Hérza̰ kom̄a̰.
 WS35	Dees iſcht récht von’n gwä̱.
-WS36	Was ſitzet do̰ fir Ve̱gḛla̰ ůff dea̰m Meierle droba̰?
+WS36	Was ſitzet do̰ fir Ve̠gḛla̰ ůff dea̰m Meierle droba̰?
 WS37	Dia̰ Baůra̰ hend fenf Ochſa, ond nḛi Kia̰h ond zwelf Schäfla̰ or’s Dorf bro̰cht, dia̰ hend ſé verkaůfa̰ wélla̰.
 WS38	D’Leit ſénd heḭt ällé ůff’m Fèld drŭſſa̰ ond mähḛt.
 WS39	Gang no̠, dea̰r braṵ Hund dhůa̰d d’r néx.
-WS40	I’h be̱’ mit de Leit’ do̰ héndḛ ibḛr d’Wieſa̰ éns Kŏrn g’fa̱hra̰.
+WS40	I’h be̠’ mit de Leit’ do̰ héndḛ ibḛr d’Wieſa̰ éns Kŏrn g’fa̱hra̰.

--- a/38215_Stuttgart.csv
+++ b/38215_Stuttgart.csv
@@ -10,7 +10,7 @@ Anmerkungen: ''
 ...
 WS01	Iḿ Wéndḛ́r flia̰gḛd dé druggéné bléddḛr én d’r Lů̮ft rom.
 WS02	‘s heert glei aŭf z’schneiad, no̰ wird ‘s Wèddḛr wiedḛr beſſḛr.
-WS03	Dhua̰ Kohla en de n͜ O̱fa̰, daß d’Milch bald a̰fa̰ngd z’kocha̰.
+WS03	Dhua̰ Kohla en de n͡ O̱fa̰, daß d’Milch bald a̰fa̰ngd z’kocha̰.
 WS04	D’r gůa̰d ald’ Ma̰’ ischt mit ḛm Gaůl ens Eis ḛibrocha̰ ond ens kalt Wassḛr g’falla̰.
 WS05	‘r ischt vo̰a̰r a̰ Wocha̰ via̰r oder ſex g’ſchdorba̰.
 WS06	‘s Feier ischt z’ſchtark gwä̱ d’Kůcha̰ ſend jo onda̰ ganz ſchwarz bran̄d.
@@ -39,7 +39,7 @@ WS28	‘r därfet ét ſotté Kendera̰ia̰ treiba̰.
 WS29	Onſḛre Berg’ ſénd ét arg hoch, dé eire ſénd viel hé̱chḛr.
 WS30	Wia̰v’l Pfond Wṵ̌rſcht ond wia̰v’l Brod wélla̰t’r ha̱n?
 WS31	I̱’h verſchdand eich net, ‘r mia̰ßt a̰ bißle laůdḛr ſchwätzḛ.
-WS32	Heud ia̰hr kon̰ ſchdi̮gglé weißa̰ ſo̰efa̰ fir mi’ ůff mei’m Diſch g’fonda̰
+WS32	Heud ia̰hr kon̰ ſchdi̬gglé weißa̰ ſo̰efa̰ fir mi’ ůff mei’m Diſch g’fonda̰
 WS33	ſḛi Brua̰dḛr will ſé zwo̰e ſché̱né neie Heiſer en eirem Ga̮rda̰ baůa̰.
 WS34	Dees Wort iſcht’m vo̠ Hérza̰ kom̄a̰.
 WS35	Dees iſcht récht von’n gwä̱.

--- a/38215_Stuttgart.csv
+++ b/38215_Stuttgart.csv
@@ -16,7 +16,7 @@ WS05	‘r ischt vo̰a̰r a̰ Wocha̰ via̰r oder ſex g’ſchdorba̰.
 WS06	‘s Feier ischt z’ſchtark gwä̱ d’Kůcha̰ ſend jo onda̰ ganz ſchwarz bran̄d.
 WS07	‘r ißt d’O̰ier emmer ohne Salz ond Pfeffḛr.
 WS08	D’Fiaß dhea̰nd mḛr weh ih’ glaůb’, ih’ han̄ ſe důrchglaffa̰.
-WS09	Ih’ bé̱’ bei dea̰ra̰ Fraů gwä̱ ond háu’s ḛr ḛ g’ſagt no̰ hot ſe g’ſagt, ſe wells aṵ̆ ihrḛr Do̱chdḛr ſaga̰.
+WS09	Ih’ bé̱’ bei dea̰ra̰ Fraů gwä̱ ond háu’s ḛr ḛ g’ſagt no̰ hot ſe g’ſagt, ſe wells aṵ̌ ihrḛr Do̱chdḛr ſaga̰.
 WS10	I̱’h wills némmé dho̱.
 WS11	 I̱’h schlag’ de glei mit ḛm Kührlöffel an d’Ohra̰, dů Aff’!
 WS12	Wo̰ go̰̱ſchd dů na̰, ſollḛt mḛr mit d’r ganga̰.
@@ -30,14 +30,14 @@ WS19	Wéar ho̰t mĕr mein Korb mit Flo̰éſch g’ſchdula̰.
 WS20	‘r ho̰t ſo dho̱, als hättḛt ſe’n zum drèſcha̰ b’ſchdélld, ſé hénd’s aber ſèlber dho̱.
 WS21	Wém ho̰t’r dé neu G’ſchicht’ verze’hlt?
 WS22	Ma̰ můa̰ß laůd ſchreia̰, ſouſchd verſchdohd’r’s net.
-WS23	M’r ſeud mia̰d ond hénd dṵ̆rſcht.
+WS23	M’r ſeud mia̰d ond hénd dṵ̌rſcht.
 WS24	Wo (als) m’r geſchderd z’O̰bḛd z’rickkum̄a̰ ſend, no̰ ſend de Andḛre ſcho̱ em Bett gläga̰ ond hend ſe ſcho gſchlofa.
 WS25	D’r ſchnee iſcht ſeḭd Na̱cht bei ons liega̰ blieba̰, aber ſeḭda̰ Morga̰ iſcht’r g’ſchmolza.
 WS26	Hendḛr onſrem Haus ſchtandḛt drei ſchene Apfelbḛmla̰ mit rode Apfḛla̰.
 WS27	Kenḛt ia̰hr net no en Aůga̰blick ůf’s warta̰ no̰ gangḛt mir mit é̮ch.
 WS28	‘r därfet ét ſotté Kendera̰ia̰ treiba̰.
 WS29	Onſḛre Berg’ ſénd ét arg hoch, dé eire ſénd viel hé̱chḛr.
-WS30	Wia̰v’l Pfond Wṵ̆rſcht ond wia̰v’l Brod wélla̰t’r ha̱n?
+WS30	Wia̰v’l Pfond Wṵ̌rſcht ond wia̰v’l Brod wélla̰t’r ha̱n?
 WS31	I̱’h verſchdand eich net, ‘r mia̰ßt a̰ bißle laůdḛr ſchwätzḛ.
 WS32	Heud ia̰hr kon̰ ſchdi̮gglé weißa̰ ſo̰efa̰ fir mi’ ůff mei’m Diſch g’fonda̰
 WS33	ſḛi Brua̰dḛr will ſé zwo̰e ſché̱né neie Heiſer en eirem Ga̮rda̰ baůa̰.

--- a/38215_Stuttgart.csv
+++ b/38215_Stuttgart.csv
@@ -13,16 +13,16 @@ WS02	‘s heert glei aŭf z’schneiad, no̰ wird ‘s Wèddḛr wiedḛr beſſ
 WS03	Dhua̰ Kohla en de n͡ O̠fa̰, daß d’Milch bald a̰fa̰ngd z’kocha̰.
 WS04	D’r gůa̰d ald’ Ma̰’ ischt mit ḛm Gaůl ens Eis ḛibrocha̰ ond ens kalt Wassḛr g’falla̰.
 WS05	‘r ischt vo̰a̰r a̰ Wocha̰ via̰r oder ſex g’ſchdorba̰.
-WS06	‘s Feier ischt z’ſchtark gwä̱ d’Kůcha̰ ſend jo onda̰ ganz ſchwarz bran̄d.
+WS06	‘s Feier ischt z’ſchtark gwä̠ d’Kůcha̰ ſend jo onda̰ ganz ſchwarz bran̄d.
 WS07	‘r ißt d’O̰ier emmer ohne Salz ond Pfeffḛr.
 WS08	D’Fiaß dhea̰nd mḛr weh ih’ glaůb’, ih’ han̄ ſe důrchglaffa̰.
-WS09	Ih’ bé̱’ bei dea̰ra̰ Fraů gwä̱ ond háu’s ḛr ḛ g’ſagt no̰ hot ſe g’ſagt, ſe wells aṵ̌ ihrḛr Do̠chdḛr ſaga̰.
+WS09	Ih’ bé̱’ bei dea̰ra̰ Fraů gwä̠ ond háu’s ḛr ḛ g’ſagt no̰ hot ſe g’ſagt, ſe wells aṵ̌ ihrḛr Do̠chdḛr ſaga̰.
 WS10	I̱’h wills némmé dho̠.
 WS11	 I̱’h schlag’ de glei mit ḛm Kührlöffel an d’Ohra̰, dů Aff’!
 WS12	Wo̰ go̰̠ſchd dů na̰, ſollḛt mḛr mit d’r ganga̰.
 WS13	S’ſénd ſchlèchte Zeita̰!
 WS14	Lia̰bs Kend, bleib’ no do̰ onda̰ ſchteha̰, dia̰ bé̱ſé Ge̠hs beißa̰ dé do̠d.
-WS15	Weil dů hḛit a̰m maiſchdḛ g’lèrnt ho̰ſcht, ond a̱rdech (brav) gwä bischt, därſcht bälder ho̰im geha̰ als de Andḛrn.
+WS15	Weil dů hḛit a̰m maiſchdḛ g’lèrnt ho̰ſcht, ond a̠rdech (brav) gwä bischt, därſcht bälder ho̰im geha̰ als de Andḛrn.
 WS16	Dé bisſt nonet groß gnůa̰g, um a̰ Flaſch’ Wḛi’ aůsz’trenka̰, dé můa̰ſcht erſcht no ebbes wagſa̰ und greßḛr wèrda̰.
 WS17	Ga̰ng, ſeiſo gůa̰t und ſag’ dḛira̰ Schwéſchḛr ſe ſoll d’Klo̰ider fir eier Můa̰der ferdech(g) näha̰ ond saůber ausbīrſchta̰.
 WS18	Hätt’ſcht en kend, no̰ wärs andḛrſcht koma̰ ond’s dhäd beſſḛr om èn ſchtéha̰.
@@ -32,19 +32,19 @@ WS21	Wém ho̰t’r dé neu G’ſchicht’ verze’hlt?
 WS22	Ma̰ můa̰ß laůd ſchreia̰, ſouſchd verſchdohd’r’s net.
 WS23	M’r ſeud mia̰d ond hénd dṵ̌rſcht.
 WS24	Wo (als) m’r geſchderd z’O̰bḛd z’rickkum̄a̰ ſend, no̰ ſend de Andḛre ſcho̠ em Bett gläga̰ ond hend ſe ſcho gſchlofa.
-WS25	D’r ſchnee iſcht ſeḭd Na̱cht bei ons liega̰ blieba̰, aber ſeḭda̰ Morga̰ iſcht’r g’ſchmolza.
+WS25	D’r ſchnee iſcht ſeḭd Na̠cht bei ons liega̰ blieba̰, aber ſeḭda̰ Morga̰ iſcht’r g’ſchmolza.
 WS26	Hendḛr onſrem Haus ſchtandḛt drei ſchene Apfelbḛmla̰ mit rode Apfḛla̰.
 WS27	Kenḛt ia̰hr net no en Aůga̰blick ůf’s warta̰ no̰ gangḛt mir mit é̮ch.
 WS28	‘r därfet ét ſotté Kendera̰ia̰ treiba̰.
 WS29	Onſḛre Berg’ ſénd ét arg hoch, dé eire ſénd viel hé̱chḛr.
-WS30	Wia̰v’l Pfond Wṵ̌rſcht ond wia̰v’l Brod wélla̰t’r ha̱n?
+WS30	Wia̰v’l Pfond Wṵ̌rſcht ond wia̰v’l Brod wélla̰t’r ha̠n?
 WS31	I̱’h verſchdand eich net, ‘r mia̰ßt a̰ bißle laůdḛr ſchwätzḛ.
 WS32	Heud ia̰hr kon̰ ſchdi̬gglé weißa̰ ſo̰efa̰ fir mi’ ůff mei’m Diſch g’fonda̰
-WS33	ſḛi Brua̰dḛr will ſé zwo̰e ſché̱né neie Heiſer en eirem Ga̮rda̰ baůa̰.
+WS33	ſḛi Brua̰dḛr will ſé zwo̰e ſché̱né neie Heiſer en eirem Ga̬rda̰ baůa̰.
 WS34	Dees Wort iſcht’m vo̠ Hérza̰ kom̄a̰.
-WS35	Dees iſcht récht von’n gwä̱.
+WS35	Dees iſcht récht von’n gwä̠.
 WS36	Was ſitzet do̰ fir Ve̠gḛla̰ ůff dea̰m Meierle droba̰?
 WS37	Dia̰ Baůra̰ hend fenf Ochſa, ond nḛi Kia̰h ond zwelf Schäfla̰ or’s Dorf bro̰cht, dia̰ hend ſé verkaůfa̰ wélla̰.
 WS38	D’Leit ſénd heḭt ällé ůff’m Fèld drŭſſa̰ ond mähḛt.
 WS39	Gang no̠, dea̰r braṵ Hund dhůa̰d d’r néx.
-WS40	I’h be̠’ mit de Leit’ do̰ héndḛ ibḛr d’Wieſa̰ éns Kŏrn g’fa̱hra̰.
+WS40	I’h be̠’ mit de Leit’ do̰ héndḛ ibḛr d’Wieſa̰ éns Kŏrn g’fa̠hra̰.

--- a/38482_Kleinvillars.csv
+++ b/38482_Kleinvillars.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Em Wender fliaga dia druggana Bläddr en dar Lufd rom.
 WS02	’s hé̄rd glei uff z’schné̄a, no wèrd ’s Wäddr widder béssar.
 WS03	Dua Kohla en dar=Ofa, daß d’ Millich ball ahfangt z’kocha.
-WS04	Dèr guat ald’ Mann isch middam Gaul durch’s Eis ’brocha ǒnd én’s kald Waßr g’falla.
+WS04	Dèr guat ald’ Mann isch middam Gaul durch’s Eis ’brocha ŏnd én’s kald Waßr g’falla.
 WS05	Èr isch vōr viar oddr secks Wocha g’schdorwa.
 WS06	’s Feier isch tschtarig gwè, dia Kuacha sinn’ jo unna ganz schwarz verbren̄d.
 WS07	Er èßt d’ Eiar allford ohne Salz on̄ Pfeffr.

--- a/39746_Sielenbach.csv
+++ b/39746_Sielenbach.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	A̰n Winda͡n̰g flia͡n̰̮g de druckigè̮n Blé̠da in da Luft umananda.
 WS02	A̰͡ns he͡art gei au ’zschneim, nacha we͜ards Wĕda͡[n̰] wieda bessa͡[n̰].
 WS03	Du͡a̰ Köln nei a͡n Ofa͡n̰, daß <(a tief gespr.)> d’Mili bai z’siad’n an͡gfangt.
-WS04	Da gu͜at Ma͡n̰g is mit’n Ro͜ß durchs Eis brocha und a’s koit Wassa nei gfoin.
+WS04	Da gu͡at Ma͡n̰g is mit’n Ro͜ß durchs Eis brocha und a’s koit Wassa nei gfoin.
 WS05	Ear is vo͡ar vi͡ar oda sex Wocha͡n̰ gstarbn.
 WS06	S Fui̮r is zgroas, de Kuacha san ja unt’ ganz schwo͡arz brennt.
 WS07	Ear ißt d’ O̠a̠͡r älwül aṵi Saitz und Pfäffa[n̰].

--- a/39746_Sielenbach.csv
+++ b/39746_Sielenbach.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	A̰n Winda͡n̰g flia͡n̰̮g de druckigè̮n Blé̠da in da Luft umananda.
 WS02	A̰͡ns he͡art gei au ’zschneim, nacha we͜ards Wĕda͡[n̰] wieda bessa͡[n̰].
 WS03	Du͡a̰ Köln nei a͡n Ofa͡n̰, daß <(a tief gespr.)> d’Mili bai z’siad’n an͡gfangt.
-WS04	Da gu͡at Ma͡n̰g is mit’n Ro͜ß durchs Eis brocha und a’s koit Wassa nei gfoin.
+WS04	Da gu͡at Ma͡n̰g is mit’n Ro͡ß durchs Eis brocha und a’s koit Wassa nei gfoin.
 WS05	Ear is vo͡ar vi͡ar oda sex Wocha͡n̰ gstarbn.
 WS06	S Fui̮r is zgroas, de Kuacha san ja unt’ ganz schwo͡arz brennt.
 WS07	Ear ißt d’ O̠a̠͡r älwül aṵi Saitz und Pfäffa[n̰].

--- a/39746_Sielenbach.csv
+++ b/39746_Sielenbach.csv
@@ -8,8 +8,8 @@ Transliterationsprojekt: REDE
 Transliterent: Victoria Schaub
 Anmerkungen: ''
 ...
-WS01	A̰n Winda͡n̰g flia͡n̰̮g de druckigè̮n Blé̠da in da Luft umananda.
-WS02	A̰͡ns he͡art gei au ’zschneim, nacha we͜ards Wĕda͡[n̰] wieda bessa͡[n̰].
+WS01	A̰n Winda͡n̰g flia͡n̰̮g de druckigè̮n Blé̱da in da Luft umananda.
+WS02	A̰͡ns he͡art gei au ’zschneim, nacha we͡ards Wĕda͡[n̰] wieda bessa͡[n̰].
 WS03	Du͡a̰ Köln nei a͡n Ofa͡n̰, daß <(a tief gespr.)> d’Mili bai z’siad’n an͡gfangt.
 WS04	Da gu͡at Ma͡n̰g is mit’n Ro͡ß durchs Eis brocha und a’s koit Wassa nei gfoin.
 WS05	Ear is vo͡ar vi͡ar oda sex Wocha͡n̰ gstarbn.
@@ -21,8 +21,8 @@ WS10	I w’ll’s o et wida doa͡n̰!
 WS11	I schlog dé gei mit’n Kochleffa͡n̰g um d’Oarn rum, du Aff!
 WS12	Wo géasch du hi(n̬), só̮ll ma͡n̰ mida͡n̰ gea͡n̰g.
 WS13	S sein schlächde Zeit’n!
-WS14	Mai li͡abs Kind’, blei do dunt steh͜a̰n, de beas’n Gäns beißnde z’doad.
-WS15	Du hosch heḭnt s’measchde glernt und bisch brav gwen, du däsch frü͡ah͜na hoam gean̰ ais <(ois)> de o͡an.
+WS14	Mai li͡abs Kind’, blei do dunt steh͡a̰n, de beas’n Gäns beißnde z’doad.
+WS15	Du hosch heḭnt s’measchde glernt und bisch brav gwen, du däsch frü͡ah͡na hoam gean̰ ais <(ois)> de o͡an.
 WS16	Du bisch no et groaß gnua, dasch a͡n̰ Flasch’n Wein̰ ausdringsch, du muasch z’scheascht no bessa wax’n u. grea[?]ßa wean.
 WS17	Gea bi so guat u. sog deina Schweschda, sie s(ö̮)ll s’Gwand für ḛ͡ncha Muada fördi nahn u. mit da Bürsch’n sauwa machn.
 WS18	Hédsch’n du kent! nacha war’s <(a zwischen [ä] und a)> anaschd kema͡n̰ u. es d<(>ä</a)>t be/äss[a͡n̰] um an stea͡n̰gh.

--- a/39746_Sielenbach.csv
+++ b/39746_Sielenbach.csv
@@ -21,8 +21,8 @@ WS10	I w’ll’s o et wida doa͡n̰!
 WS11	I schlog dé gei mit’n Kochleffa͡n̰g um d’Oarn rum, du Aff!
 WS12	Wo géasch du hi(n̬), só̮ll ma͡n̰ mida͡n̰ gea͡n̰g.
 WS13	S sein schlächde Zeit’n!
-WS14	Mai li͡abs Kind’, blei do dunt steh͡a̰n, de beas’n Gäns beißnde z’doad.
-WS15	Du hosch heḭnt s’measchde glernt und bisch brav gwen, du däsch frü͡ah͡na hoam gean̰ ais <(ois)> de o͡an.
+WS14	Mai li͡abs Kind’, blei do dunt steh͜a̰n, de beas’n Gäns beißnde z’doad.
+WS15	Du hosch heḭnt s’measchde glernt und bisch brav gwen, du däsch frü͡ah͜na hoam gean̰ ais <(ois)> de o͡an.
 WS16	Du bisch no et groaß gnua, dasch a͡n̰ Flasch’n Wein̰ ausdringsch, du muasch z’scheascht no bessa wax’n u. grea[?]ßa wean.
 WS17	Gea bi so guat u. sog deina Schweschda, sie s(ö̮)ll s’Gwand für ḛ͡ncha Muada fördi nahn u. mit da Bürsch’n sauwa machn.
 WS18	Hédsch’n du kent! nacha war’s <(a zwischen [ä] und a)> anaschd kema͡n̰ u. es d<(>ä</a)>t be/äss[a͡n̰] um an stea͡n̰gh.

--- a/39746_Sielenbach.csv
+++ b/39746_Sielenbach.csv
@@ -13,13 +13,13 @@ WS02	A̰͡ns he͡art gei au ’zschneim, nacha we͜ards Wĕda͡[n̰] wieda bessa
 WS03	Du͡a̰ Köln nei a͡n Ofa͡n̰, daß <(a tief gespr.)> d’Mili bai z’siad’n an͡gfangt.
 WS04	Da gu͡at Ma͡n̰g is mit’n Ro͡ß durchs Eis brocha und a’s koit Wassa nei gfoin.
 WS05	Ear is vo͡ar vi͡ar oda sex Wocha͡n̰ gstarbn.
-WS06	S Fui̮r is zgroas, de Kuacha san ja unt’ ganz schwo͡arz brennt.
+WS06	S Fui̬r is zgroas, de Kuacha san ja unt’ ganz schwo͡arz brennt.
 WS07	Ear ißt d’ O̠a̠͡r älwül aṵi Saitz und Pfäffa[n̰].
 WS08	D’Füaß dean̰a ma weah, i glo(b’) i hans durchganga̰n.
 WS09	I bi bei da Frau gwen und hos eam gsag’, und sie sak’, sie w’ll’s o seina Dochta sogn.
 WS10	I w’ll’s o et wida doa͡n̰!
 WS11	I schlog dé gei mit’n Kochleffa͡n̰g um d’Oarn rum, du Aff!
-WS12	Wo géasch du hi(n̮), só̮ll ma͡n̰ mida͡n̰ gea͡n̰g.
+WS12	Wo géasch du hi(n̬), só̮ll ma͡n̰ mida͡n̰ gea͡n̰g.
 WS13	S sein schlächde Zeit’n!
 WS14	Mai li͡abs Kind’, blei do dunt steh͡a̰n, de beas’n Gäns beißnde z’doad.
 WS15	Du hosch heḭnt s’measchde glernt und bisch brav gwen, du däsch frü͡ah͡na hoam gean̰ ais <(ois)> de o͡an.

--- a/40646_Unterlauchringen.csv
+++ b/40646_Unterlauchringen.csv
@@ -29,7 +29,7 @@ WS18	Wenna kénnt hètscht no wärs anderscht cho und ’s dä̠d bèsser um en 
 WS19	Wer hät mir mi̠n Chorb mit Flaisch gschdollḛ.
 WS20	Er hät so duah wia wenn ’sen zum Dröscha bschdellt heddḛt, sie héns aber selber duah.
 WS21	Wém hät er di neu Gschicht vḛ̆z[è]llt?
-WS22	Ma mua lu̮t brü̠ala suschd verschdoht er is it.
+WS22	Ma mua lu̬t brü̠ala suschd verschdoht er is it.
 WS23	Mḛ sind müad un hénd Durscht.
 WS24	Wo m’r g[è]schdert z’ Obḛd hei cho sind, sind die andḛrḛ scho im Bètt glägḛ und händ fèscht gschlōffa.
 WS25	Dḛ Schn[éé] ischt hinicht [binis] liegḛ bliebḛ; aber hüta̰ Morgḛ ischer vḛrgange.

--- a/40646_Unterlauchringen.csv
+++ b/40646_Unterlauchringen.csv
@@ -16,7 +16,7 @@ WS05	Er isch vor viar oder segs Wucha gschdorbḛ.
 WS06	’S Fü̠r isch z’ schdarch gsi; d’ Dünnḛ sind jo undḛ ganz schwarz br[e]ut.
 WS07	Er isst d’ Eier alliwiel uhni Salz un Pfeffer.
 WS08	D’ Füḛß düamer wèh; i glaub i hā[s] durgloffḛ
-WS09	I bi̠ bi̮ dḛ Frau gsi und hāneres gsait und sie hät gsait sie wèlls au ihrḛ Döchter sägḛ.
+WS09	I bi̠ bi̬ dḛ Frau gsi und hāneres gsait und sie hät gsait sie wèlls au ihrḛ Döchter sägḛ.
 WS10	I wills au nümmḛ duah.
 WS11	I schla di grad mit=din Chochlöffel um d’ Ohrḛ, du Aff.
 WS12	Wo gōscht hi̠; söddamḛr mit dr gōh?

--- a/40930_Ravensburg.csv
+++ b/40930_Ravensburg.csv
@@ -34,10 +34,10 @@ WS23	Wir sind müa̰d u. hont Durscht.
 WS24	Wo mr gerscht Obet zrück kom̄a̰ sind, sind dia̰ a̰ndere schoa̰ im Bett g’lega̰ u. h[u]nt f[e]st g’schlofa̰.
 WS25	D’r Schnee isch heut Na̠cht bei uns liga̰ bliba̰, aber heit a̰ Morga̰ ischt’r g’schmolza̰.
 WS26	Hinter unserm Hu̠s schtond drei schöne Epfelbä̰m̄len mit rotha̯ Epfelen.
-WS27	Ken̄et’r et no a̰ bitze̺le uf [o̰]ns warta̰, dan̄ go̠ me̺r mite͜n [e̠].
+WS27	Ken̄et’r et no a̰ bitze̺le uf [o̰]ns warta̰, dan̄ go̠ me̺r mite͡n [e̠].
 WS28	Ihr dürfet ko̰ine so Kindereia triba̰.
 WS29	Unsere Berg sind net b’sonders hoch, dia̰ euere sind viel höher.
-WS30	Wia̰ vell Pfond Wurscht u. wia̰ vell Brot we͜n dr ho̠?
+WS30	Wia̰ vell Pfond Wurscht u. wia̰ vell Brot we͡n dr ho̠?
 WS31	I verstand eu itta̰, ir mo̰int a bitzela luter schwäza.
 WS32	Hont’r koi Schtückle wißa̰ So̰ifa̰ für mi u̬f mein Disch g’funda̰.
 WS33	Sḛi Bruder will se zwei schone, neue Hüßer in euerem Garta̰ baua̰.

--- a/40930_Ravensburg.csv
+++ b/40930_Ravensburg.csv
@@ -39,7 +39,7 @@ WS28	Ihr dürfet ko̰ine so Kindereia triba̰.
 WS29	Unsere Berg sind net b’sonders hoch, dia̰ euere sind viel höher.
 WS30	Wia̰ vell Pfond Wurscht u. wia̰ vell Brot we͜n dr ho̠?
 WS31	I verstand eu itta̰, ir mo̰int a bitzela luter schwäza.
-WS32	Hont’r koi Schtückle wißa̰ So̰ifa̰ für mi u̺f mein Disch g’funda̰.
+WS32	Hont’r koi Schtückle wißa̰ So̰ifa̰ für mi u̬f mein Disch g’funda̰.
 WS33	Sḛi Bruder will se zwei schone, neue Hüßer in euerem Garta̰ baua̰.
 WS34	Dös Wort ischtm vom Herza̯ kom̄a̰.
 WS35	Dös ischt recht g’sei von ihna̰.

--- a/40930_Ravensburg.csv
+++ b/40930_Ravensburg.csv
@@ -18,7 +18,7 @@ WS07	Er ißt d’Oir alla̰wi̠l ohne Sa̠lz u. Pfeffer.
 WS08	D’Füa̰ß do̰mir reat wea̰h, i glaub i hons durchgloffa̰.
 WS09	I bin bei dr Frau g’sei u. ho̰ners g’sait, sia̰ hot g’sait, sia̰ wölls au i͜rer Döcht’r saga̰.
 WS10	I wills au nim̄a̰ dua̰.
-WS11	I schlag di̺ go̺ gli̠ mit’m Kohlöffḛl an d’Ohra̰, du Aff.
+WS11	I schlag di̺ go̬ gli̠ mit’m Kohlöffḛl an d’Ohra̰, du Aff.
 WS12	Wo gohscht na̰, sollḛ me̺r mit’r go̠h.
 WS13	Es sind schleche Zi̠ta̰.
 WS14	Lia̰bs Kind, blib hunta̰ sto̠h, dia̰ böse Gäns bi̠se̺te sonst dod.

--- a/40930_Ravensburg.csv
+++ b/40930_Ravensburg.csv
@@ -16,7 +16,7 @@ WS05	Er ischt vor vier oder sechs Wocha̰ gschtorba̰.
 WS06	S’ Feuer ischt z’stark g’sèi, Kucha̰ sind unta̰ ganz verbren̄t.
 WS07	Er ißt d’Oir alla̰wi̠l ohne Sa̠lz u. Pfeffer.
 WS08	D’Füa̰ß do̰mir reat wea̰h, i glaub i hons durchgloffa̰.
-WS09	I bin bei dr Frau g’sei u. ho̰ners g’sait, sia̰ hot g’sait, sia̰ wölls au i͜rer Döcht’r saga̰.
+WS09	I bin bei dr Frau g’sei u. ho̰ners g’sait, sia̰ hot g’sait, sia̰ wölls au i͡rer Döcht’r saga̰.
 WS10	I wills au nim̄a̰ dua̰.
 WS11	I schlag di̺ go̬ gli̠ mit’m Kohlöffḛl an d’Ohra̰, du Aff.
 WS12	Wo gohscht na̰, sollḛ me̺r mit’r go̠h.

--- a/41214_Aspach-Le-Bas.csv
+++ b/41214_Aspach-Le-Bas.csv
@@ -11,10 +11,10 @@ Anmerkungen: ''
 WS01	Im Wint’r fliaga diă truckena Blätt’r in dr Luft ărum.
 WS02	As hèrt gli uff zu schnḗja, drno wird’s Watt’r bèss’r.
 WS03	Düa Kohla in dr Ofa, as d’ Milch boll afangt z’kocha.
-WS04	dr gǖǎtǎ altǎ Mann isch mit dm Roß durch’s Iß g’brocha un in’s kaltǎ Wass’r g’fallǎ.
-WS05	Ar isch vor viǎr od’r sechs Wuchǎ g’storwa.
+WS04	dr gǖătă altă Mann isch mit dm Roß durch’s Iß g’brocha un in’s kaltă Wass’r g’fallă.
+WS05	Ar isch vor viăr od’r sechs Wuchă g’storwa.
 WS06	s’ Fier isch z’stark g’sie, d’ Küăcha sin jo unta ganz schwarz verbrennt.
-WS07	Ar ißt d’ Eiǎr imm’r ohnǎ Salz un Pfaff’r.
+WS07	Ar ißt d’ Eiăr imm’r ohnă Salz un Pfaff’r.
 WS08	D’ Fíaß düá m’r weh, ich gláib, ich ha sá durgloffá.
 WS09	Ich bi bĭ d’r Frāi g’sie un ha ’s ’ră g’sāit, un sie hatt g’sāit, sie hètt ’s ōi ihrăr Tocht’r sagă wèlla.
 WS10	Ich will’s ōi nimmă widd’r düa!

--- a/41296_Oberentzen.csv
+++ b/41296_Oberentzen.csv
@@ -20,7 +20,7 @@ WS09	Ich bé bidr Froi gsé un hasera gsait, sie wills oi ihrèr Tochtèr saga.
 WS10	Ich wills oi nim thüa.
 WS11	Ich schlag dich glich mit dem Kochleffl um d’ Ohra, dü Aff!
 WS12	Wo gesch dü hé, solla mir médr geh?
-WS13	A̮s sin schla̠chti̬ Zitta̬!
+WS13	A̬s sin schla̠chti̬ Zitta̬!
 WS14	Mi lia̬bs Kind, blib do unta̬ steh, dia̬ bési̬ Gans bißa̬ dich tod.
 WS15	Dü hésch héta am mérstel glért und bésch artig gsé, dü dèrfsch frièhr heim geh aß d’ Andri.
 WS16	Dü bésch no nét groß gnüa̬, um a Flasch Wi üsstrinka̬, dü müa̬sch èrst noch ébis wagsa̬ un größer wara̬.

--- a/41296_Oberentzen.csv
+++ b/41296_Oberentzen.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: SyHD
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Im Winder fliaga͜ trogene Blätter in dr Luft uma.
+WS01	Im Winder fliaga͡ trogene Blätter in dr Luft uma.
 WS02	A̬s hért glich uf dschnéia̬, drno wurds Watter wider besser.
 WS03	Thüa Kohla in dr Ofa, daß d’ Milch bol zkocha afangt.
 WS04	Dr güa̬t alt Mann isch mit dem Pfard durs Is brocha̬, un ins kalta̬ Wasser gfalla̬.
@@ -20,8 +20,8 @@ WS09	Ich bé bidr Froi gsé un hasera gsait, sie wills oi ihrèr Tochtèr saga.
 WS10	Ich wills oi nim thüa.
 WS11	Ich schlag dich glich mit dem Kochleffl um d’ Ohra, dü Aff!
 WS12	Wo gesch dü hé, solla mir médr geh?
-WS13	A̮s sin schla̠chti̬ Zitta̮!
-WS14	Mi lia̮bs Kind, blib do unta̮ steh, dia̮ bési̬ Gans bißa̮ dich tod.
+WS13	A̮s sin schla̠chti̬ Zitta̬!
+WS14	Mi lia̬bs Kind, blib do unta̬ steh, dia̬ bési̬ Gans bißa̬ dich tod.
 WS15	Dü hésch héta am mérstel glért und bésch artig gsé, dü dèrfsch frièhr heim geh aß d’ Andri.
 WS16	Dü bésch no nét groß gnüa̬, um a Flasch Wi üsstrinka̬, dü müa̬sch èrst noch ébis wagsa̬ un größer wara̬.
 WS17	Gang, bésch so güa̺t un sag dinèr Schwèschtèr, sie soll d Kleider fér eiri Müa̺tter fèrtig nahia̺, un mit der Burst süfèr macha̺. 
@@ -29,22 +29,22 @@ WS18	Hatsch dü ihna̺ kènnt! drno wars andèrscht kumma̺ un as dad bèssèr u
 WS19	Wer hét mér mina Korb un mi Fleisch gstohla?
 WS20	Ar macht a so, aß hattana si ihna zum Drescha bstellt, Sie hans awer salbscht gmacht.
 WS21	In wèna hètr dia néi Gschicht verzéhlt?
-WS22	Ma müa̮ß lüt schreia̮, sunscht versteht a̱r uns nit.
+WS22	Ma müa̬ß lüt schreia̬, sunscht versteht a̠r uns nit.
 WS23	Mir sin miad un hann durst.
 WS24	Wumr gestert haim kumma sin, sin alli scho im Bett glaga, un han fescht gschlofa.
 WS25	Dr Schnee esch dia Nacht bi uns liga blewa, awer hetta Morga eschr g’schmolza.
 WS26	Hinder unserm Hüß stehn drei scheni Äpfelbaim mit rota Äpfala.
-WS27	Kenna̮ ihr nit noch a Oiga̮blick uf uns warta̮, drno geh mir mét éich.
+WS27	Kenna̬ ihr nit noch a Oiga̬blick uf uns warta̬, drno geh mir mét éich.
 WS28	Ihr dèrfa nit sonagi Kindareia triwa.
 WS29	Unsri Barg sin nit so hoch, éiri sin viel héchèr.
 WS30	Wia̺viel Pfund Wurst un wia̺viel wann ihr ha?
 WS31	Ich verstand éich nit, ihr mian a bétzi lüter réda.
 WS32	Han ihr ké Steck wißi Saif fer mich uf mim Tisch gfunda?
-WS33	Si Brüa̮der will zwei schéni néi Hiser fir ihna̮ in eirem Garta̮ boia̮. 
-WS34	Das Wort isch ihm vu Harza̮ kumma̮.
-WS35	Das isch racht gsi vu ihna̮.
+WS33	Si Brüa̬der will zwei schéni néi Hiser fir ihna̬ in eirem Garta̬ boia̬. 
+WS34	Das Wort isch ihm vu Harza̬ kumma̬.
+WS35	Das isch racht gsi vu ihna̬.
 WS36	Was sétza̺ do fér Végala̺ owa̺ uf dam Mirla̺?
-WS37	Dia̮ Büra̮ han fémf Ogsa̮ un ni̠en Kia̮ un zwelf Schefla̮ vors Dorf brocht, dia woda̮ sie vèrkoifa̮.
+WS37	Dia̬ Büra̬ han fémf Ogsa̬ un ni̠en Kia̬ un zwelf Schefla̬ vors Dorf brocht, dia woda̬ sie vèrkoifa̬.
 WS38	D’ Lit sin héta alli dusa uf èm Fald un maiha.
 WS39	Gang nur, dr brün Hund macht dér nigs.
-WS40	Ich bin mit da Lit do hénta̮ übr dia̮ Matt ins Korn gfahra̯.
+WS40	Ich bin mit da Lit do hénta̬ übr dia̬ Matt ins Korn gfahra̯.

--- a/41296_Oberentzen.csv
+++ b/41296_Oberentzen.csv
@@ -20,8 +20,8 @@ WS09	Ich bé bidr Froi gsé un hasera gsait, sie wills oi ihrèr Tochtèr saga.
 WS10	Ich wills oi nim thüa.
 WS11	Ich schlag dich glich mit dem Kochleffl um d’ Ohra, dü Aff!
 WS12	Wo gesch dü hé, solla mir médr geh?
-WS13	A̮s sin schla̠chti̮ Zitta̮!
-WS14	Mi lia̮bs Kind, blib do unta̮ steh, dia̮ bési̮ Gans bißa̮ dich tod.
+WS13	A̮s sin schla̠chti̬ Zitta̮!
+WS14	Mi lia̮bs Kind, blib do unta̮ steh, dia̮ bési̬ Gans bißa̮ dich tod.
 WS15	Dü hésch héta am mérstel glért und bésch artig gsé, dü dèrfsch frièhr heim geh aß d’ Andri.
 WS16	Dü bésch no nét groß gnüa̬, um a Flasch Wi üsstrinka̬, dü müa̬sch èrst noch ébis wagsa̬ un größer wara̬.
 WS17	Gang, bésch so güa̺t un sag dinèr Schwèschtèr, sie soll d Kleider fér eiri Müa̺tter fèrtig nahia̺, un mit der Burst süfèr macha̺. 

--- a/41309_Feldkirch.csv
+++ b/41309_Feldkirch.csv
@@ -12,7 +12,7 @@ WS01	Im Winter fliä̆ge diĕ truckene Blätter in d’r Luft rum.
 WS02	’s hört gli uf z schneie drno wurd s Wetter widder besser.
 WS03	Dua chole in de Ofe, daß d Milch ball anfangt z choche.
 WS04	Dr guet alt Mann isch mit dm Roß dur s Is broche un ins chalt Wasser keit.
-WS05	Èr isch vǒr viër odder sex Woche gschtorbe.
+WS05	Èr isch vŏr viër odder sex Woche gschtorbe.
 WS06	S Für isch z schtarch gsi d Chueche sin̄ jo unte ganz schwarz brännt.
 WS07	Èr ißt d’ Eier alliwiel uhni Salz un Pfäffer.
 WS08	D’ Füeß düén mer selli weh i glaub i há ’s durgloffe.

--- a/41351_Urbès.csv
+++ b/41351_Urbès.csv
@@ -47,4 +47,4 @@ WS36	Was fi̠r Vegele sitze do owene uffem Mirele.
 WS37	D’ Būre hann fi̠mf Ochse un nī Kie un zwelf Schefle vorem Dorf gebrōch, se hann se welle verka̠ife.
 WS38	D’ Lit sin hit alle duse uffem Fald un māje.
 WS39	Gang nur, dr brune Hund macht dr nit.
-WS40	I bi̠n mit d’ Lit do hinte iwer d’ Ma̱tt im Korn gfa̱hre.
+WS40	I bi̠n mit d’ Lit do hinte iwer d’ Ma̠tt im Korn gfa̠hre.

--- a/41351_Urbès.csv
+++ b/41351_Urbès.csv
@@ -21,7 +21,7 @@ WS10	I wills o nimmemeh thue.
 WS11	I schlack dr gli mitem Kochleffel um d’ Ohre, du Aff.
 WS12	Wu gehsch anne; sellemer mitr kumme.
 WS13	Si̠ schlachte Zitte.
-WS14	Mi lieb Ki̱nd blĭb do unte steh, de bese Gans bisse di tot.
+WS14	Mi lieb Ki̠nd blĭb do unte steh, de bese Gans bisse di tot.
 WS15	De hasch hitt am merschstel glehrt un bisch ordlig gsi, de derfsch ehndr heim as andr.
 WS16	De bisch no nit groß gnue, fir e Botal Wi ustrinke, de musch zersch no ne bizzel wackse un greßer ware.
 WS17	Gang, bisch so guet un sag i di Schweschtr, se setts Plundr fir ehre Mueter fertig naje un mitem Burscht sufer mache.
@@ -29,7 +29,7 @@ WS18	Hettsch dü ne gekennt derno wars andersch kumme un s’ gat besser mitem s
 WS19	Wer hatt i mir mi Korb mit Flaisch g’stohle?
 WS20	Ar hātt gmacht, as wi wesene fir Dresche bstellt hette, se hanns awer salwer gmacht.
 WS21	I wem hat er d neje Gschicht verzehlt?
-WS22	Ma mueß lutt schreje, susch verschteht er i ni̱t.
+WS22	Ma mueß lutt schreje, susch verschteht er i ni̠t.
 WS23	Mr si mied un han durscht.
 WS24	Wu mr nach zruck kumme sin si d’ andr scho im Bett glage un sin fest am Schlofe g’si.
 WS25	Die Nach isch dr Schnee bi uns bliwe lige, awer da Morge ischer g’schmulze.
@@ -43,8 +43,8 @@ WS32	Hann-er gä Stickl wiße Saife fir mir uff mi Tisch gfunde?
 WS33	Si Bruedr willem zwei schene neje Hiser i̠ ihre Ga̠rta boje.
 WS34	Das Wort i̠schem vum Harz kumme.
 WS35	Das i̠sch rāch gsi̠ vonere.
-WS36	Was fi̱r Vegele sitze do owene uffem Mirele.
+WS36	Was fi̠r Vegele sitze do owene uffem Mirele.
 WS37	D’ Būre hann fi̠mf Ochse un nī Kie un zwelf Schefle vorem Dorf gebrōch, se hann se welle verka̠ife.
 WS38	D’ Lit sin hit alle duse uffem Fald un māje.
 WS39	Gang nur, dr brune Hund macht dr nit.
-WS40	I bi̱n mit d’ Lit do hinte iwer d’ Ma̱tt im Korn gfa̱hre.
+WS40	I bi̠n mit d’ Lit do hinte iwer d’ Ma̱tt im Korn gfa̱hre.

--- a/41365_Rimbach-Près-Guebwiller.csv
+++ b/41365_Rimbach-Près-Guebwiller.csv
@@ -11,10 +11,10 @@ Anmerkungen: ''
 WS01	Im Windér fliaga d’rockenè Blǟdér in d’r Luft ŭmma.
 WS02	Ās hört glī uf schneia, d’rnŏ wurd’s Wädér wèder bèssér.
 WS03	Dua Kola in d’r Ofa, daß d’ Melch bol afangt a kocha.
-WS04	D’r güāt ald Mann ésch mit’m Pfārd durch’s Is brŏchǎ un in’s skalta Wāsser g’fǎlla
+WS04	D’r güāt ald Mann ésch mit’m Pfārd durch’s Is brŏchă un in’s skalta Wāsser g’fălla
 WS05	Ār īsch vor ĕbéna viar oder sèchs Wucha g’stōrba.
 WS06	Ds’ Fier war z’stārk, d’ Küacha sĕn jo unda ganz schwarz brènnt.
-WS07	Ār èßt d’ Eier immér ŏhna Salz un Pfǎff’r.
+WS07	Ār èßt d’ Eier immér ŏhna Salz un Pfăff’r.
 WS08	D’ Fiáß dia m’r wéh, i gláüb i ha si durag’lofa.
 WS09	I bé bé d’r Frau g’sḕ un has’ara g’said, un sie hèt g’said, sé will’s au ihrèr Dochter sāgă.
 WS10	I wèll’s au nimma mèh d’hüa.

--- a/41365_Rimbach-Près-Guebwiller.csv
+++ b/41365_Rimbach-Près-Guebwiller.csv
@@ -12,7 +12,7 @@ WS01	Im Windér fliaga d’rockenè Blǟdér in d’r Luft ŭmma.
 WS02	Ās hört glī uf schneia, d’rnŏ wurd’s Wädér wèder bèssér.
 WS03	Dua Kola in d’r Ofa, daß d’ Melch bol afangt a kocha.
 WS04	D’r güāt ald Mann ésch mit’m Pfārd durch’s Is brŏchǎ un in’s skalta Wāsser g’fǎlla
-WS05	Ār īsch vor ěbéna viar oder sèchs Wucha g’stōrba.
+WS05	Ār īsch vor ĕbéna viar oder sèchs Wucha g’stōrba.
 WS06	Ds’ Fier war z’stārk, d’ Küacha sĕn jo unda ganz schwarz brènnt.
 WS07	Ār èßt d’ Eier immér ŏhna Salz un Pfǎff’r.
 WS08	D’ Fiáß dia m’r wéh, i gláüb i ha si durag’lofa.
@@ -35,7 +35,7 @@ WS24	Wo m’r gescht’r z’ Oba z’ruck kumma, do sen d’ andri scho em Bett
 WS25	D’r Schnee esch dia Nacht bi uns bliba lega, ab’r heta Morgan esch’r g’schmulza.
 WS26	Hentr uns’rm Hüs stehn drei scheni Äpfelbaim met roda Äpfale.
 WS27	Kĕ́nna ḕhr nèt a Augablecklḕ uf uns wardă, d’rno gèm’r mèt ēich.
-WS28	Ḕhr dérfa net a sōnigè Ke̊ndarēia trībă.
+WS28	Ḕhr dérfa net a sōnigè Kėndarēia trībă.
 WS29	Unséri Bérga sèn nèt so hoch, d’ ēirigi sèn viel höchér.
 WS30	Wīaviel Pfund Wurscht un wīaviel Brod wău ḕhr hā?
 WS31	Ĕ̀ch verstand ēiach nét, èhr mīan a bètzĭ lüdèr spracha.

--- a/41365_Rimbach-Près-Guebwiller.csv
+++ b/41365_Rimbach-Près-Guebwiller.csv
@@ -11,10 +11,10 @@ Anmerkungen: ''
 WS01	Im Windér fliaga d’rockenè Blǟdér in d’r Luft ŭmma.
 WS02	Ās hört glī uf schneia, d’rnŏ wurd’s Wädér wèder bèssér.
 WS03	Dua Kola in d’r Ofa, daß d’ Melch bol afangt a kocha.
-WS04	D’r güāt ald Mann ésch mit’m Pfārd durch’s Is brǒchǎ un in’s skalta Wāsser g’fǎlla
+WS04	D’r güāt ald Mann ésch mit’m Pfārd durch’s Is brŏchǎ un in’s skalta Wāsser g’fǎlla
 WS05	Ār īsch vor ěbéna viar oder sèchs Wucha g’stōrba.
 WS06	Ds’ Fier war z’stārk, d’ Küacha sĕn jo unda ganz schwarz brènnt.
-WS07	Ār èßt d’ Eier immér ǒhna Salz un Pfǎff’r.
+WS07	Ār èßt d’ Eier immér ŏhna Salz un Pfǎff’r.
 WS08	D’ Fiáß dia m’r wéh, i gláüb i ha si durag’lofa.
 WS09	I bé bé d’r Frau g’sḕ un has’ara g’said, un sie hèt g’said, sé will’s au ihrèr Dochter sāgă.
 WS10	I wèll’s au nimma mèh d’hüa.

--- a/41460_Rixheim.csv
+++ b/41460_Rixheim.csv
@@ -47,4 +47,4 @@ WS36	Was sètza do fèr Vègela owe uf em Mirla?
 WS37	Dia Büra hann fèmf Ochse un ni̠n Kiah un zwälf Schèfla vor’s Dorf brocht ka, sè hann-se wälle verkauifa.
 WS38	D’ Lit sèn hèt alle duss uf-em Fald un mahia.
 WS39	Gang nur, da brün Hund macht dr nit.
-WS40	Ech bè mèt da̲ne Lit do hènte èwer d’ Matte èns Korn gfahre.
+WS40	Ech bè mèt da̠ne Lit do hènte èwer d’ Matte èns Korn gfahre.

--- a/41566_Ranspach-Le-Bas.csv
+++ b/41566_Ranspach-Le-Bas.csv
@@ -12,7 +12,7 @@ WS01	Im Winder flīaga dirre Blätter in d’r Luft umma.
 WS02	As hert gli üf z’schneya, d’rno wird s’ Watter wieder besser.
 WS03	Thüa Chola in d’r Ofa, aß d’ Milch boll afoht z chocha.
 WS04	Dr güate alte Ma isch mit dm Roß dur’s Isch brocha un in’s chalte Wasser (g) kēyt.
-WS05	Er isch vor viǎr etter sachs Wucha gschtorba.
+WS05	Er isch vor viăr etter sachs Wucha gschtorba.
 WS06	S’ Fïhr isch tschtarch gsi d’ Chucha sinn ja unga ganz schwarz brännt.
 WS07	Ar ißt d’ Eier allewil ohna Salz un Pfaffr.
 WS08	D’ Fiaß thían mr racht weh, i glaub, i ha se durglufa. 

--- a/41598_Lörrach.csv
+++ b/41598_Lörrach.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Im Winter fliège diè trochĕnĕ Bledder in d’r Luft umme.
 WS02	S’ hört glī ūf z’schneie, d’rno wird’s Wädder wieder besser.
 WS03	Duä Chole in d’r Ofe, daß d’ Milch bald bald afangt z’chocha.
-WS04	D’r guèt alt Mā isch mit dȇm Roß dur’s Is brochȇ und in’s chalt Wasser keit/gfalle.
+WS04	D’r guèt alt Mā isch mit dêm Roß dur’s Is brochê und in’s chalt Wasser keit/gfalle.
 WS05	’R isch vor v̇ier oder sex Wuchà ġschtorba.
 WS06	S’ Für hed z’schtark bren̄t, d’ Chuchä sin unda jo ganz schwarz abrennt.
 WS07	’R ißt d’ Eier allewīl ohni Salz und Pfäffer.
@@ -35,7 +35,7 @@ WS24	Wo mer geschterd Z’ obe zruck cho si, si die andere scho im Bett glega un
 WS25	Der Schnee isch hinnecht bi eus liege bliebe aber hüte morge ischer vergange.
 WS26	Hinter unsem Hus schtöhn drei schöni Öpfelbäumli mit rote Öpfeli.
 WS27	Choneter nüt no ne Augenblickli uf is wardè, derno gömer mit èch.
-WS28	D’r dörfed nüt so Chindereien trībȇ.
+WS28	D’r dörfed nüt so Chindereien trībê.
 WS29	Eusere Bèrg si nüt arg hoch, eueri sī viel höher.
 WS30	Wièvel Pfund Würst und wièvel Brod waider ha?
 WS31	Ī verstand ich nüt, d’r müēnd e bizele luter schwätze.

--- a/41615_Schopfheim.csv
+++ b/41615_Schopfheim.csv
@@ -23,28 +23,28 @@ WS12	Wo gohsch hi, sollĕ <(müen)> mĕr mit dr (goh)?
 WS13	’S sin schlechti Zitĕ!
 WS14	(Mi) lièb Chind, blīb do untĕ stōh; diè böse Gäns bissĕ d[i] tot.
 WS15	Du <(De)> hésch hüt am meistĕ glēhrt u. bisch brav <(artig)> gsi, <(dĕ)> darfsch [ehnder] heim as die andĕrĕ.
-WS16	Du bisch no nit groß gnu͜èg zumĕrĕ Fläschĕ Wi usz’trinkĕ; du mu͜èsch z’erscht no [ö]bbis wachsĕ.
-WS17	Gang, bisch so gu͜èt u. sag di[rr]er Schwéster, sie soll d’ Chleider für euji Muetter näihe u. ūsbürschte.
+WS16	Du bisch no nit groß gnu͡èg zumĕrĕ Fläschĕ Wi usz’trinkĕ; du mu͡èsch z’erscht no [ö]bbis wachsĕ.
+WS17	Gang, bisch so gu͡èt u. sag di[rr]er Schwéster, sie soll d’ Chleider für euji Muetter näihe u. ūsbürschte.
 WS18	Wen̄ dr’nen gchen̄t hättsch, wär’s anderscht cho, u. ’s thät <(stüènd)> besser um͜en <(stoh)>.
 WS19	Wer hat mer mi Chorb mit (em) Fleisch gstohle? <(gno?)>
-WS20	Er het (so) tho as wen̄ <(hätte)> sie en <(ihn)> zu͜èm Dresche bstellt <(hätte)>, sie hen̄’s selber thō.
+WS20	Er het (so) tho as wen̄ <(hätte)> sie en <(ihn)> zu͡èm Dresche bstellt <(hätte)>, sie hen̄’s selber thō.
 WS21	Wèm hat er die neui G’schicht verzählt <(verze’llt)> ?
-WS22	Mĕ mu͜è lutt schreie <(brü͜èlle)> s[u]st verstōht er is nit.
-WS23	Wĕr sin mü͜èd und hĕn Durst.
+WS22	Mĕ mu͡è lutt schreie <(brü͡èlle)> s[u]st verstōht er is nit.
+WS23	Wĕr sin mü͡èd und hĕn Durst.
 WS24	Wo mer gestert z’Obe zrückcho sin, sin di͜è andĕrĕ scho im Bett glè̄gĕ und {Anm. VS: Der Rest ist unleserlich rot und schwarz übereinander geschrieben}
-WS25	Der Schnee isch h[uenècht] bi uns <(uis)> liege bli(e)be, aber hüt frü͜e isch er gschmul[ze].
+WS25	Der Schnee isch h[uenècht] bi uns <(uis)> liege bli(e)be, aber hüt frü͡e isch er gschmul[ze].
 WS26	Hinter unse(r)m Hus stöhn drei schöni Öpfelbäumli mit roten Öpfeli.
-WS27	Chönnet ĕr nit no en Augeblickli <(bizzeli)> uf is warte, mĕr göhn drno mit͜ ich.
+WS27	Chönnet ĕr nit no en Augeblickli <(bizzeli)> uf is warte, mĕr göhn drno mit͡ ich.
 WS28	Ihr dörfet keine so Chindereie trībe. <kénĕ so [???????]>
 WS29	Unsi Berg sin nit so arg hoch, euri <(eui)> sin viel höcher.
 WS30	Wi͜è viel Pfund Wurst u. wi͜è viel Brot wèn̄t er (ha)?
 WS31	I verstand ich nit, ihr mi͜ènt e bizzeli <(ne wengeli)> lut(t)er schwätzĕ.
-WS32	Hèn̄t͜ er nĭt ĕ Stückli wĭßĭ Seipfi für mĭ uf mim Tisch gfundĕ?
-WS33	Si Bru͜èder will si(ch) zwei schönĭ neuĭ Hüser in eue(r)m Garte bauĕ.
+WS32	Hèn̄t͡ er nĭt ĕ Stückli wĭßĭ Seipfi für mĭ uf mim Tisch gfundĕ?
+WS33	Si Bru͡èder will si(ch) zwei schönĭ neuĭ Hüser in eue(r)m Garte bauĕ.
 WS34	Das <(’S)> Wort isch em vo Herzen cho!
 WS35	Das isch rècht von͜ ĕnĕ.
 WS36	Was sitze do für Vögeli oben͜ uf dèm <(em)> Mǖrli?
-WS37	D’ Bure hèn̄ fünf Ochse <(x)> u. nün Chü͜èih und zwölf Schöfli vor’s Dorf brocht, u. hen̄ sie welle verchaufe <(di͜è hen̄ sie welle verchaufe)>.
+WS37	D’ Bure hèn̄ fünf Ochse <(x)> u. nün Chü͡èih und zwölf Schöfli vor’s Dorf brocht, u. hen̄ sie welle verchaufe <(di͜è hen̄ sie welle verchaufe)>.
 WS38	D’Lüt sin hüt alli du[ss]e uf͜em Feld und maihe. <Hüt sin xx>
-WS39	Gang num[???], d’r brūn Hund thu͜èt d’r nü̆t.
+WS39	Gang num[???], d’r brūn Hund thu͡èt d’r nü̆t.
 WS40	Ii bi mit dĕ Lütĕ dō hintĕ übĕr d’Mattĕ <(in d’ Frucht (ins Korn) gfahrn.)> goh Frucht holĕ.

--- a/41615_Schopfheim.csv
+++ b/41615_Schopfheim.csv
@@ -12,7 +12,7 @@ WS01	Im Winter fliège die trochene Blätter in dr Luft um̄e.
 WS02	’S hört gli uf z’ schneie, drno wird’s Wetter wieder besser.
 WS03	Thuè Chole in dn Ofe, aß d’ Milch bal afangt z’choche.
 WS04	Dè guet alt Ma isch mit‿ĕm Roß dur’s Is broche und ins chalt Wasser gfalle <(gheit)>.
-WS05	Er ist vor vi͜èr sechs <(x)> Woche gstorbe.
+WS05	Er ist vor vi͡èr sechs <(x)> Woche gstorbe.
 WS06	’S Füür ist zu stark gsi, d’ Chuèche (Weihe) sin jo unte ganz abrèn̄t <(ver?)>
 WS07	Er isst d’ Eier allewil ohne Salz und Pfeffer.
 WS08	D’Füèß thièn mĕr arg wèh, i glaub i ha si(e) durglaufe.
@@ -25,26 +25,26 @@ WS14	(Mi) lièb Chind, blīb do untĕ stōh; diè böse Gäns bissĕ d[i] tot.
 WS15	Du <(De)> hésch hüt am meistĕ glēhrt u. bisch brav <(artig)> gsi, <(dĕ)> darfsch [ehnder] heim as die andĕrĕ.
 WS16	Du bisch no nit groß gnu͡èg zumĕrĕ Fläschĕ Wi usz’trinkĕ; du mu͡èsch z’erscht no [ö]bbis wachsĕ.
 WS17	Gang, bisch so gu͡èt u. sag di[rr]er Schwéster, sie soll d’ Chleider für euji Muetter näihe u. ūsbürschte.
-WS18	Wen̄ dr’nen gchen̄t hättsch, wär’s anderscht cho, u. ’s thät <(stüènd)> besser um͜en <(stoh)>.
+WS18	Wen̄ dr’nen gchen̄t hättsch, wär’s anderscht cho, u. ’s thät <(stüènd)> besser um͡en <(stoh)>.
 WS19	Wer hat mer mi Chorb mit (em) Fleisch gstohle? <(gno?)>
 WS20	Er het (so) tho as wen̄ <(hätte)> sie en <(ihn)> zu͡èm Dresche bstellt <(hätte)>, sie hen̄’s selber thō.
 WS21	Wèm hat er die neui G’schicht verzählt <(verze’llt)> ?
 WS22	Mĕ mu͡è lutt schreie <(brü͡èlle)> s[u]st verstōht er is nit.
 WS23	Wĕr sin mü͡èd und hĕn Durst.
-WS24	Wo mer gestert z’Obe zrückcho sin, sin di͜è andĕrĕ scho im Bett glè̄gĕ und {Anm. VS: Der Rest ist unleserlich rot und schwarz übereinander geschrieben}
+WS24	Wo mer gestert z’Obe zrückcho sin, sin di͡è andĕrĕ scho im Bett glè̄gĕ und {Anm. VS: Der Rest ist unleserlich rot und schwarz übereinander geschrieben}
 WS25	Der Schnee isch h[uenècht] bi uns <(uis)> liege bli(e)be, aber hüt frü͡e isch er gschmul[ze].
 WS26	Hinter unse(r)m Hus stöhn drei schöni Öpfelbäumli mit roten Öpfeli.
 WS27	Chönnet ĕr nit no en Augeblickli <(bizzeli)> uf is warte, mĕr göhn drno mit͡ ich.
 WS28	Ihr dörfet keine so Chindereie trībe. <kénĕ so [???????]>
 WS29	Unsi Berg sin nit so arg hoch, euri <(eui)> sin viel höcher.
-WS30	Wi͜è viel Pfund Wurst u. wi͜è viel Brot wèn̄t er (ha)?
-WS31	I verstand ich nit, ihr mi͜ènt e bizzeli <(ne wengeli)> lut(t)er schwätzĕ.
+WS30	Wi͡è viel Pfund Wurst u. wi͡è viel Brot wèn̄t er (ha)?
+WS31	I verstand ich nit, ihr mi͡ènt e bizzeli <(ne wengeli)> lut(t)er schwätzĕ.
 WS32	Hèn̄t͡ er nĭt ĕ Stückli wĭßĭ Seipfi für mĭ uf mim Tisch gfundĕ?
 WS33	Si Bru͡èder will si(ch) zwei schönĭ neuĭ Hüser in eue(r)m Garte bauĕ.
 WS34	Das <(’S)> Wort isch em vo Herzen cho!
-WS35	Das isch rècht von͜ ĕnĕ.
-WS36	Was sitze do für Vögeli oben͜ uf dèm <(em)> Mǖrli?
-WS37	D’ Bure hèn̄ fünf Ochse <(x)> u. nün Chü͡èih und zwölf Schöfli vor’s Dorf brocht, u. hen̄ sie welle verchaufe <(di͜è hen̄ sie welle verchaufe)>.
+WS35	Das isch rècht von͡ ĕnĕ.
+WS36	Was sitze do für Vögeli oben͡ uf dèm <(em)> Mǖrli?
+WS37	D’ Bure hèn̄ fünf Ochse <(x)> u. nün Chü͡èih und zwölf Schöfli vor’s Dorf brocht, u. hen̄ sie welle verchaufe <(di͡è hen̄ sie welle verchaufe)>.
 WS38	D’Lüt sin hüt alli du[ss]e uf͜em Feld und maihe. <Hüt sin xx>
 WS39	Gang num[???], d’r brūn Hund thu͡èt d’r nü̆t.
 WS40	Ii bi mit dĕ Lütĕ dō hintĕ übĕr d’Mattĕ <(in d’ Frucht (ins Korn) gfahrn.)> goh Frucht holĕ.

--- a/41615_Schopfheim.csv
+++ b/41615_Schopfheim.csv
@@ -11,7 +11,7 @@ Anmerkungen: ''
 WS01	Im Winter fliège die trochene Blätter in dr Luft um̄e.
 WS02	’S hört gli uf z’ schneie, drno wird’s Wetter wieder besser.
 WS03	Thuè Chole in dn Ofe, aß d’ Milch bal afangt z’choche.
-WS04	Dè guet alt Ma isch mit‿ĕm Roß dur’s Is broche und ins chalt Wasser gfalle <(gheit)>.
+WS04	Dè guet alt Ma isch mit⁀ĕm Roß dur’s Is broche und ins chalt Wasser gfalle <(gheit)>.
 WS05	Er ist vor vi͡èr sechs <(x)> Woche gstorbe.
 WS06	’S Füür ist zu stark gsi, d’ Chuèche (Weihe) sin jo unte ganz abrèn̄t <(ver?)>
 WS07	Er isst d’ Eier allewil ohne Salz und Pfeffer.

--- a/41615_Schopfheim.csv
+++ b/41615_Schopfheim.csv
@@ -45,6 +45,6 @@ WS34	Das <(’S)> Wort isch em vo Herzen cho!
 WS35	Das isch rècht von͡ ĕnĕ.
 WS36	Was sitze do für Vögeli oben͡ uf dèm <(em)> Mǖrli?
 WS37	D’ Bure hèn̄ fünf Ochse <(x)> u. nün Chü͡èih und zwölf Schöfli vor’s Dorf brocht, u. hen̄ sie welle verchaufe <(di͡è hen̄ sie welle verchaufe)>.
-WS38	D’Lüt sin hüt alli du[ss]e uf͜em Feld und maihe. <Hüt sin xx>
+WS38	D’Lüt sin hüt alli du[ss]e uf͡em Feld und maihe. <Hüt sin xx>
 WS39	Gang num[???], d’r brūn Hund thu͡èt d’r nü̆t.
 WS40	Ii bi mit dĕ Lütĕ dō hintĕ übĕr d’Mattĕ <(in d’ Frucht (ins Korn) gfahrn.)> goh Frucht holĕ.

--- a/41621_Wehr.csv
+++ b/41621_Wehr.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: REDE
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Im Winter fliè-gè die troch’ně Blätter in d’r Luft ummè.
+WS01	Im Winter fliè-gè die troch’nĕ Blätter in d’r Luft ummè.
 WS02	S‘hört gli uf z’schneiè d’r no wird’s Wètter wieder besser.
 WS03	Thuè Kohle in d’r Ofè aß d’Milch bald an̰fangt z’koché.
 WS04	D’r gúèt alt Man̰ isch mit d’m Roß dur’s Is brochè und is chalt Wasser iè keit.

--- a/41623_Hütten.csv
+++ b/41623_Hütten.csv
@@ -34,7 +34,7 @@ WS23	Mer sind müed und händ Durscht.
 WS24	Wo mer geschtert z’ Obe zrugg cho sind, sind die Andern scho im Bätt gsi und fescht am schlofe.
 WS25	De Schnee isch die Nacht bi äus ligge bliebe, aber hüt früe isch er vergange.
 WS26	Hinder äusem Hus zue schtönd drü schöni Öpfelbäumli mit rote Öpfeli.
-WS27	Chönnet er no en Augeblickli uff is wartè, mer gönnt derno mit‿ich.
+WS27	Chönnet er no en Augeblickli uff is wartè, mer gönnt derno mit⁀ich.
 WS28	Der dȫrfè keini è so Chindereiè drībè.
 WS29	Äus Bärg sind it è so höch, euji sind viel hȫcher.
 WS30	Wie mängi Pfund Wǖrscht und wie viel Brod wennd er hā?

--- a/41829_Friesenried.csv
+++ b/41829_Friesenried.csv
@@ -23,7 +23,7 @@ WS12	Wo gascht na, soll i mit dr gou.
 WS13	Es ischt a kuiza Zeit.
 WS14	Liabs Kiand bleib unt[a] stau, dia bease Gäs beisande toat.
 WS15	Du hascht heut am meisten glernet u. bischt brav gwesa Du darfscht voar huigau. (heimgehen)
-WS16	Du bisch nu it gr̊aß gnua, um a Flescha Wei ausztrink[a], du muaßt wachs[a] u. grö[a]ßer weara.
+WS16	Du bisch nu it gṙaß gnua, um a Flescha Wei ausztrink[a], du muaßt wachs[a] u. grö[a]ßer weara.
 WS17	Gang, sei so guat u. sag dr Schwäst’r, sie soll Muaters Kleid <(Häs)> fertig mach[a] u. ausbürscht[a]
 WS18	Hättest du ihn ken̄t dan̄ wärs andersch kom̄a u. es thät im b[ä]sser  gau.
 WS19	Wear hat miar mein Krett[n] v[a]ll Flaisch gschtohla.

--- a/44770_Mont-Tramelan.csv
+++ b/44770_Mont-Tramelan.csv
@@ -18,7 +18,7 @@ WS07	Är isst d’Eier gäng ohni Sanz u Pfäffer.
 WS08	D’ Füess tüe mer fescht weh, i gloube, i heig se dürgloffe.
 WS09	I bi bi dr Frou gsi u ha es gseit u si het gseit, si wön s o ihrem Meitli säge.
 WS10	I wott’s nümme mache.
-WS11	I zwicke dr eis mit em Chёueli, du Aff.
+WS11	I zwicke dr eis mit em Chëueli, du Aff.
 WS12	Wo geisch hi, sön mer mit dr cho?
 WS13	Es sy schlächti Zyte.
 WS14	Mys liebe Ching, blyb hie nide stah, die böse Gäns tüe di süsch z’tod bysse.
@@ -28,7 +28,7 @@ WS17	Bis so guet u gang säg dyr Schweschter, si sölt d’Chleider für eui Mue
 WS18	He du ne kennt hättisch, so wär es angersch cho u n es würd besser um ihn stah.
 WS19	Wär het mei my Chorb mit em Fleisch gschtole?
 WS20	Är het dnglyche ta, wi we si ne zum Drösche bschtellt hätti, si hei’s aber säuber gmacht.
-WS21	Wäm het är di neui Gschicht verzёut?
+WS21	Wäm het är di neui Gschicht verzëut?
 WS22	Mi muess luut brüele, süsch verschteit er is nid.
 WS23	Mir sy müed u hei Durscht.
 WS24	Wo mer nächti rügg cho sy, sy di angere scho im Bett gsi u hei fescht gschlafe.

--- a/45985_Wengen.csv
+++ b/45985_Wengen.csv
@@ -19,17 +19,17 @@ WS06	Ds Fir ischt z grosses <(z schtarchs)> gsin, die Chüöche si ja unna ganz 
 WS07	Ár isst d’Eier geng oni Salz u Pfáffer.
 WS08	D’Fie+ss tie+ mer schtarch we, i glöuben <(ö schwach ausgeprägt)>, i heig si dirgliffen.
 WS09	I bi m bin der Föu gsin un (d) ha ra s gseid, u die hed (g) <(meistens g statt d)> gseid, si well s͡ a der Techter <(ira Meitschi)> sägen.
-WS10	I will͜ s <(ses)> ó nimme machen.
+WS10	I will͡ s <(ses)> ó nimme machen.
 WS11	I triffen di gli mit dem Chochleffel a d’Oren, du Aff!
 WS12	Wa geischt hin, sellem mer mit der chon? <(gan)>
 WS13	Äs <(ä = leicht)> si schlächt Ziti.
 WS14	Mis lie+bs Chind, blib hie+ aha stan, die+ beseng͜ Gäns bissen di z tod.
-WS15	Du hescht hit am meischte g glerd ub bischt lie+ba gsin, du tarfscht (p) frjeier <(oft p statt f)> hei͜ wan die+ andren.
+WS15	Du hescht hit am meischte g glerd ub bischt lie+ba gsin, du tarfscht (p) frjeier <(oft p statt f)> hei͡ wan die+ andren.
 WS16	Du bischt no ni(d) (g) grossa gnuög fir ne Fläscha Win üsz trichen, du muäscht z erscht no eppis wachsen u greser wärden.
 WS17	Gang, bis so guöd u säg der <(dinĕr)> Schweschter, si sell die+ Chleider fir ewi Muöter fertig näien u mid (t) der Birschte süferi machen.
 WS18	Hättisch du ne bchend! De wäs anders üsa chon un äs schtiend besser um nen <(wurdi besser um ne stan)>.
 WS19	Wär hed (p / b) mie+r mi Chorb mip Fleisch gschtólen?
-WS20	Är hed drgliche ta(n), si heigen͜ ne fir ds Dresche bschtéld; si heis aber sälber gmacht.
+WS20	Är hed drgliche ta(n), si heigen͡ ne fir ds Dresche bschtéld; si heis aber sälber gmacht.
 WS21	Wám hed er die+ niwi Gschicht erzeld?
 WS22	Mu muos lüt (p) brie+le(n), suscht firschteid ĕr is nid <(i dumpf aber lang)>.
 WS23	Mie+r si m mie+d <(m.)> </ mie+du (w.) / mie+di (s.)> un hein Durscht.

--- a/45985_Wengen.csv
+++ b/45985_Wengen.csv
@@ -34,7 +34,7 @@ WS21	Wám hed er die+ niwi Gschicht erzeld?
 WS22	Mu muos lüt (p) brie+le(n), suscht firschteid ĕr is nid <(i dumpf aber lang)>.
 WS23	Mie+r si m mie+d <(m.)> </ mie+du (w.) / mie+di (s.)> un hein Durscht.
 WS24	Wa mer nächti si zrugg cho(n), sin die+ andre schon im Be(tt) g lägen u si fescht am Schlafe gsin. <(her fesch gschlafen)>
-WS25	Dr Schnee ischt disi Nacht bín is blíbe͜ lígen, aber hit am Morgen ischt er gschmolzen.
+WS25	Dr Schnee ischt disi Nacht bín is blíbe͡ lígen, aber hit am Morgen ischt er gschmolzen.
 WS26	Hinder isem Hüs schtan dri scheni Epfelbeimli mid roten Epfĕllenĕn.
 WS27	Chend je+r nid no es Ougemblíkeli uf is warten, deng ga mer mid ach.
 WS28	Jer terft nid seli <(settig / selch)> Chinderii triben.

--- a/45985_Wengen.csv
+++ b/45985_Wengen.csv
@@ -18,7 +18,7 @@ WS05	Är ischt (pf) vor vie+r ol sägs Wuche gschtorben.
 WS06	Ds Fir ischt z grosses <(z schtarchs)> gsin, die Chüöche si ja unna ganz virbrennt.
 WS07	Ár isst d’Eier geng oni Salz u Pfáffer.
 WS08	D’Fie+ss tie+ mer schtarch we, i glöuben <(ö schwach ausgeprägt)>, i heig si dirgliffen.
-WS09	I bi m bin der Föu gsin un (d) ha ra s gseid, u die hed (g) <(meistens g statt d)> gseid, si well s͜ a der Techter <(ira Meitschi)> sägen.
+WS09	I bi m bin der Föu gsin un (d) ha ra s gseid, u die hed (g) <(meistens g statt d)> gseid, si well s͡ a der Techter <(ira Meitschi)> sägen.
 WS10	I will͜ s <(ses)> ó nimme machen.
 WS11	I triffen di gli mit dem Chochleffel a d’Oren, du Aff!
 WS12	Wa geischt hin, sellem mer mit der chon? <(gan)>

--- a/45985_Wengen.csv
+++ b/45985_Wengen.csv
@@ -23,7 +23,7 @@ WS10	I will͡ s <(ses)> ó nimme machen.
 WS11	I triffen di gli mit dem Chochleffel a d’Oren, du Aff!
 WS12	Wa geischt hin, sellem mer mit der chon? <(gan)>
 WS13	Äs <(ä = leicht)> si schlächt Ziti.
-WS14	Mis lie+bs Chind, blib hie+ aha stan, die+ beseng͜ Gäns bissen di z tod.
+WS14	Mis lie+bs Chind, blib hie+ aha stan, die+ beseng͡ Gäns bissen di z tod.
 WS15	Du hescht hit am meischte g glerd ub bischt lie+ba gsin, du tarfscht (p) frjeier <(oft p statt f)> hei͡ wan die+ andren.
 WS16	Du bischt no ni(d) (g) grossa gnuög fir ne Fläscha Win üsz trichen, du muäscht z erscht no eppis wachsen u greser wärden.
 WS17	Gang, bis so guöd u säg der <(dinĕr)> Schweschter, si sell die+ Chleider fir ewi Muöter fertig näien u mid (t) der Birschte süferi machen.

--- a/45985_Wengen.csv
+++ b/45985_Wengen.csv
@@ -46,7 +46,7 @@ WS33	Si m Bruöder wol p mu <(wolt fir ine)> zwei scheni niwi Hiser buwen in ewe
 WS34	Das Wort isch  t/p mu von Härze chon.
 WS35	Das ischt räch(t) gsi von nen.
 WS36	Was sitzen da fir Végelleni <(Vegeni)> oben uf dä́m Mirli.
-WS37	Die Püren hei fif Ogsen u͜ nin Chie+ u zwelf Schäfleni <(Bänzeni)> vor ds Dorf pracht, die wollte s virchäufen.
+WS37	Die Püren hei fif Ogsen u͡ nin Chie+ u zwelf Schäfleni <(Bänzeni)> vor ds Dorf pracht, die wollte s virchäufen.
 WS38	D’Lit sin hit alli üsi uf em Land <(Fäld)> um mäien.
 WS39	Gang numen, där <(dr)> brün Hund tuöd (t) dr nid.
 WS40	I bim mid de Liten da hinna uber ds Land ids Chorl gfaren.

--- a/46367_Giazza.csv
+++ b/46367_Giazza.csv
@@ -28,7 +28,7 @@ WS08	də ts̆íŋkə tü’an mɛr bɛ’a̯, iχ glɔ̅’bə, (i mán nixt ğ�
 WS09	i bĩ`gavɛ’st bai dɛr váib unt i hãs kö’it dar, un zì hä kö͡’i̯t <(oder ğazágat), zì ḇis kö’i̯n àŋka ɛ zái̯ndər tóu̯xtər.
 WS10	ì vis àŋka níχt mɛr túə̯n.
 WS11	i s̆lá̅go žúbite b̄itər kɛ͡’lje unt ɔ’rn.
-WS12	b̄o̅ gà̅stu dú? idu vɛrándre kím bita dír?
+WS12	b̄ō gà̅stu dú? idu vɛrándre kím bita dír?
 WS13	ɛ’s is̆t lái̯xta tsái̯t.
 WS14	mài̯ hái̯js, s̆tía̯n bai mír úntar. di bö’i̯sən ɔ’ğ̅ən báisə dìχ un màxən s̆tɛ’rb̄ən.
 WS15	du has̆t hái̯tə galí̅rnət mɛ’ro unt du bis̆t ğavɛ’st bráb̄ot, dū ma̅ gí̅e̯n húã̯ b̄òr di ándern.

--- a/46367_Giazza.csv
+++ b/46367_Giazza.csv
@@ -22,16 +22,16 @@ WS02	ɛsən látsdà tse s̆nái̯b̄ən, dɔ’pɔ də tsái̯t kimt s̆üa̯n.
 WS03	léi̯gən is kɔ’i̯ in̄ su̯b̄ən, dɛ miləx bahɛ’ne hɛivət án tsɛ ziɛ dən.
 WS04	dɛr gúa̯tə álte mán is ts̆á̅gat bãn ái̯sə b̄ìtəmè rɔ’u̯s un ist gab̄ál͡jet in dèmə kálte ásər.
 WS05	ɛr is̆t gas̆tɔ’rbet in fir sɛ’i vɔ’xən.
-WS06	ɛs fö’ir is̆t fíl s̆tar​χ, die kó̅pən zai̯n úntern álə furtbránt áls s̆várts.
+WS06	ɛs fö’ir is̆t fíl s̆tarχ, die kó̅pən zai̯n úntern álə furtbránt áls s̆várts.
 WS07	ɛr ɛ’sət di ɔ’i̯jər sɛ’mpər ántə zálts unt ántə pfɛ’fər.
 WS08	də ts̆íŋkə tü’an mɛr bɛ’a̯, iχ glɔ̅’bə, (i mán nixt ğàminán
-WS09	i bĩ`gavɛ’st bai dɛr váib unt i hãs kö’it dar, un zì hä kö͡’i̯t <(oder ğazágat), zì ḇis kö’i̯n àŋka ɛ zái̯ndər tóu̯xtər.
+WS09	i bĩ`gavɛ’st bai dɛr váib unt i hãs kö’it dar, un zì hä kö͡’i̯t <(oder ğazágat), zì b̠is kö’i̯n àŋka ɛ zái̯ndər tóu̯xtər.
 WS10	ì vis àŋka níχt mɛr túə̯n.
 WS11	i s̆lá̅go žúbite b̄itər kɛ͡’lje unt ɔ’rn.
 WS12	b̄ō gà̅stu dú? idu vɛrándre kím bita dír?
 WS13	ɛ’s is̆t lái̯xta tsái̯t.
 WS14	mài̯ hái̯js, s̆tía̯n bai mír úntar. di bö’i̯sən ɔ’ğ̅ən báisə dìχ un màxən s̆tɛ’rb̄ən.
-WS15	du has̆t hái̯tə galí̅rnət mɛ’ro unt du bis̆t ğavɛ’st bráb̄ot, dū ma̅ gí̅e̯n húã̯ b̄òr di ándern.
+WS15	du has̆t hái̯tə galí̅rnət mɛ’ro unt du bis̆t ğavɛ’st bráb̄ot, dū mā gí̅e̯n húã̯ b̄òr di ándern.
 WS16	du bis̆t nìχt nau̯ grɔ’a̯s tsə tríŋkɛn a b̄ɔ’tsə vái̯, du músəst náu̯ a b̄é̄ni grɔ’i̯s̆ərn.
 WS17	gé̄, du mús zai̯n gúə̯t, un lɛ’rn in dái̯ndər s̆vɛ’stər, zi müs máxən nɛ̄’n is gaús̆t in dái̯ndər múə̯tər unt brùs̆tein á zau̯bər.
 WS18	
@@ -41,12 +41,12 @@ WS21	b̄ɛ’me hàtər galé̄rt {...} náü̯ze {...}
 WS22	màn mùs s̆rái̯en hɔ̅’ax, ɛr ğasó̅ fɔrs̆tɛ’a̯t niχt sándre.
 WS23	b̄aràndrə zai̯ mü’ə̯de unt hɛ’n dúrs̆t.
 WS24	
-WS25	hàndər náxt hats ğas̆nái̯b̄ət <(ùntər unt ɛ’rdə)> untər s̆né̄ hat bolái̯bət unt ɛ’rdə hí̅r ka nusándrə, nia höi̯tə frúa̯ is̆tər gáŋgən hí̃.
+WS25	hàndər náxt hats ğas̆nái̯b̄ət <(ùntər unt ɛ’rdə)> untər s̆né̄ hat bolái̯bət unt ɛ’rdə hí̅r ka nusándrə, nia höi̯tə frúa̯ is̆tər gáŋgən hí̃.
 WS26	hìntar úžomə háu̯sə zàindar drài̯ s̆ü’ə̯nə ö’pfəlbòmən b̄it rɔ’tə ö’pfəl.
 WS27	b̄ö’ i̯tər bái̯tan hì̅r a b̄éne inunsándrə, dɔ’po gɛ`a̯bər b̄ìt anándər.
 WS28	
 WS29	ǖ’žɛnə bɛ’rgə zai̯n níχt zo hɔ̯’ax, diə unarándro zai̯n mɛ’r hɔ’a̯x.
-WS30	b̄iəvel lí̅vər salá̅də unt b̄ìə̯fəl b̆̅ rɔ̅’t b̄ɔ`i̯tər hɛ’n?
+WS30	b̄iəvel lí̅vər salá̅də unt b̄ìə̯fəl b̆ rɔ̅’t b̄ɔ`i̯tər hɛ’n?
 WS31	i fɔrs̆tɛ’a̯ ina níχt, ir mü’sɛt rɛ’i̯dan a b̄é̄ni hɔ’d̆̅ər.
 WS32	hɛ’tər niχt fúntət a dö’i̯kla bài̯san žɔf o mai̯ d̆ís̆ia for mí̅?
 WS33	zai̯ b̆rúa̯dər vil máxən máu̯ə̯rn tsvɔà s̆ü’ə̯nə nɔ̈`i̯zə háü̯zər in ö’rmə gártə.
@@ -56,4 +56,4 @@ WS36	b̄ɛ’i̯lə fɔ’u̯gilià zai̯n ğafurmá̅t hɔ’a̯x ùntau̯ máu
 WS37	diɛ mán̄ɛ hɛn bráxt fínf ɔ’ksən unt nɔ’və kúe unt dó̅disɛ`i̯ s̆á fɔùr i pái̯səi tsɛzɛ̄’gan b̄ɔ`u̯sə fɔrkó̅fən.
 WS38	diə lái̯tə zai̯n hái̯tə ál͡jə àu̯s in ákər tsə mɛ’n.
 WS39	{...} in húnt s̆prɛ’kolò̅t tùə̯t niχt in níe̯men.
-WS40	i bin ğapasá̅t ḇitən lái̯tən hɛ’r úbər də ví̅sə àu̯s in hákxər.
+WS40	i bin ğapasá̅t b̠itən lái̯tən hɛ’r úbər də ví̅sə àu̯s in hákxər.

--- a/46367_Giazza.csv
+++ b/46367_Giazza.csv
@@ -32,28 +32,28 @@ WS12	b̄ō gà̅stu dú? idu vɛrándre kím bita dír?
 WS13	ɛ’s is̆t lái̯xta tsái̯t.
 WS14	mài̯ hái̯js, s̆tía̯n bai mír úntar. di bö’i̯sən ɔ’ğ̅ən báisə dìχ un màxən s̆tɛ’rb̄ən.
 WS15	du has̆t hái̯tə galí̅rnət mɛ’ro unt du bis̆t ğavɛ’st bráb̄ot, dū ma̅ gí̅e̯n húã̯ b̄òr di ándern.
-WS16	du bis̆t nìχt nau̯ grɔ’a̯s tsə tríŋkɛn a b̄ɔ’tsə vái̯, du músəst náu̯ a b̄é̅ni grɔ’i̯s̆ərn.
-WS17	gé̅, du mús zai̯n gúə̯t, un lɛ’rn in dái̯ndər s̆vɛ’stər, zi müs máxən nɛ̅’n is gaús̆t in dái̯ndər múə̯tər unt brùs̆tein á zau̯bər.
+WS16	du bis̆t nìχt nau̯ grɔ’a̯s tsə tríŋkɛn a b̄ɔ’tsə vái̯, du músəst náu̯ a b̄é̄ni grɔ’i̯s̆ərn.
+WS17	gé̄, du mús zai̯n gúə̯t, un lɛ’rn in dái̯ndər s̆vɛ’stər, zi müs máxən nɛ̄’n is gaús̆t in dái̯ndər múə̯tər unt brùs̆tein á zau̯bər.
 WS18	
 WS19	vɛ’mɛ hat ğas̆tɔ’lt mài tsö’i̯ja fi̯ás̆?
 WS20	
-WS21	b̄ɛ’me hàtər galé̅rt {...} náü̯ze {...}
+WS21	b̄ɛ’me hàtər galé̄rt {...} náü̯ze {...}
 WS22	màn mùs s̆rái̯en hɔ̅’ax, ɛr ğasó̅ fɔrs̆tɛ’a̯t niχt sándre.
 WS23	b̄aràndrə zai̯ mü’ə̯de unt hɛ’n dúrs̆t.
 WS24	
-WS25	hàndər náxt hats ğas̆nái̯b̄ət <(ùntər unt ɛ’rdə)> untər s̆né̅ hat bolái̯bət unt ɛ’rdə hí̅r ka nusándrə, nia höi̯tə frúa̯ is̆tər gáŋgən hí̃.
+WS25	hàndər náxt hats ğas̆nái̯b̄ət <(ùntər unt ɛ’rdə)> untər s̆né̄ hat bolái̯bət unt ɛ’rdə hí̅r ka nusándrə, nia höi̯tə frúa̯ is̆tər gáŋgən hí̃.
 WS26	hìntar úžomə háu̯sə zàindar drài̯ s̆ü’ə̯nə ö’pfəlbòmən b̄it rɔ’tə ö’pfəl.
 WS27	b̄ö’ i̯tər bái̯tan hì̅r a b̄éne inunsándrə, dɔ’po gɛ`a̯bər b̄ìt anándər.
 WS28	
-WS29	ü̅’žɛnə bɛ’rgə zai̯n níχt zo hɔ̯’ax, diə unarándro zai̯n mɛ’r hɔ’a̯x.
+WS29	ǖ’žɛnə bɛ’rgə zai̯n níχt zo hɔ̯’ax, diə unarándro zai̯n mɛ’r hɔ’a̯x.
 WS30	b̄iəvel lí̅vər salá̅də unt b̄ìə̯fəl b̆̅ rɔ̅’t b̄ɔ`i̯tər hɛ’n?
-WS31	i fɔrs̆tɛ’a̯ ina níχt, ir mü’sɛt rɛ’i̯dan a b̄é̅ni hɔ’d̆̅ər.
+WS31	i fɔrs̆tɛ’a̯ ina níχt, ir mü’sɛt rɛ’i̯dan a b̄é̄ni hɔ’d̆̅ər.
 WS32	hɛ’tər niχt fúntət a dö’i̯kla bài̯san žɔf o mai̯ d̆ís̆ia for mí̅?
 WS33	zai̯ b̆rúa̯dər vil máxən máu̯ə̯rn tsvɔà s̆ü’ə̯nə nɔ̈`i̯zə háü̯zər in ö’rmə gártə.
 WS34	das b̄ɔ’rt is kɛ’mən dal kuɔ’re.
 WS35	das is kɛn džústə <ğavɛ’st džústə> <kanus̆ándrə>.
 WS36	b̄ɛ’i̯lə fɔ’u̯gilià zai̯n ğafurmá̅t hɔ’a̯x ùntau̯ máu̯r?
-WS37	diɛ mán̄ɛ hɛn bráxt fínf ɔ’ksən unt nɔ’və kúe unt dó̅disɛ`i̯ s̆á fɔùr i pái̯səi tsɛzɛ̅’gan b̄ɔ`u̯sə fɔrkó̅fən.
+WS37	diɛ mán̄ɛ hɛn bráxt fínf ɔ’ksən unt nɔ’və kúe unt dó̅disɛ`i̯ s̆á fɔùr i pái̯səi tsɛzɛ̄’gan b̄ɔ`u̯sə fɔrkó̅fən.
 WS38	diə lái̯tə zai̯n hái̯tə ál͡jə àu̯s in ákər tsə mɛ’n.
 WS39	{...} in húnt s̆prɛ’kolò̅t tùə̯t niχt in níe̯men.
 WS40	i bin ğapasá̅t ḇitən lái̯tən hɛ’r úbər də ví̅sə àu̯s in hákxər.

--- a/46367_Giazza.csv
+++ b/46367_Giazza.csv
@@ -22,7 +22,7 @@ WS02	ɛsən látsdà tse s̆nái̯b̄ən, dɔ’pɔ də tsái̯t kimt s̆üa̯n.
 WS03	léi̯gən is kɔ’i̯ in̄ su̯b̄ən, dɛ miləx bahɛ’ne hɛivət án tsɛ ziɛ dən.
 WS04	dɛr gúa̯tə álte mán is ts̆á̅gat bãn ái̯sə b̄ìtəmè rɔ’u̯s un ist gab̄ál͡jet in dèmə kálte ásər.
 WS05	ɛr is̆t gas̆tɔ’rbet in fir sɛ’i vɔ’xən.
-WS06	ɛs fö’ir is̆t fíl s̆tarχ, die kó̅pən zai̯n úntern álə furtbránt áls s̆várts.
+WS06	ɛs fö’ir is̆t fíl s̆tarχ, die kṓpən zai̯n úntern álə furtbránt áls s̆várts.
 WS07	ɛr ɛ’sət di ɔ’i̯jər sɛ’mpər ántə zálts unt ántə pfɛ’fər.
 WS08	də ts̆íŋkə tü’an mɛr bɛ’a̯, iχ glɔ̅’bə, (i mán nixt ğàminán
 WS09	i bĩ`gavɛ’st bai dɛr váib unt i hãs kö’it dar, un zì hä kö͡’i̯t <(oder ğazágat), zì b̠is kö’i̯n àŋka ɛ zái̯ndər tóu̯xtər.
@@ -31,29 +31,29 @@ WS11	i s̆lá̅go žúbite b̄itər kɛ͡’lje unt ɔ’rn.
 WS12	b̄ō gà̅stu dú? idu vɛrándre kím bita dír?
 WS13	ɛ’s is̆t lái̯xta tsái̯t.
 WS14	mài̯ hái̯js, s̆tía̯n bai mír úntar. di bö’i̯sən ɔ’ğ̅ən báisə dìχ un màxən s̆tɛ’rb̄ən.
-WS15	du has̆t hái̯tə galí̅rnət mɛ’ro unt du bis̆t ğavɛ’st bráb̄ot, dū mā gí̅e̯n húã̯ b̄òr di ándern.
+WS15	du has̆t hái̯tə galī́rnət mɛ’ro unt du bis̆t ğavɛ’st bráb̄ot, dū mā gī́e̯n húã̯ b̄òr di ándern.
 WS16	du bis̆t nìχt nau̯ grɔ’a̯s tsə tríŋkɛn a b̄ɔ’tsə vái̯, du músəst náu̯ a b̄é̄ni grɔ’i̯s̆ərn.
 WS17	gé̄, du mús zai̯n gúə̯t, un lɛ’rn in dái̯ndər s̆vɛ’stər, zi müs máxən nɛ̄’n is gaús̆t in dái̯ndər múə̯tər unt brùs̆tein á zau̯bər.
 WS18	
 WS19	vɛ’mɛ hat ğas̆tɔ’lt mài tsö’i̯ja fi̯ás̆?
 WS20	
 WS21	b̄ɛ’me hàtər galé̄rt {...} náü̯ze {...}
-WS22	màn mùs s̆rái̯en hɔ̅’ax, ɛr ğasó̅ fɔrs̆tɛ’a̯t niχt sándre.
+WS22	màn mùs s̆rái̯en hɔ̅’ax, ɛr ğasṓ fɔrs̆tɛ’a̯t niχt sándre.
 WS23	b̄aràndrə zai̯ mü’ə̯de unt hɛ’n dúrs̆t.
 WS24	
-WS25	hàndər náxt hats ğas̆nái̯b̄ət <(ùntər unt ɛ’rdə)> untər s̆né̄ hat bolái̯bət unt ɛ’rdə hí̅r ka nusándrə, nia höi̯tə frúa̯ is̆tər gáŋgən hí̃.
+WS25	hàndər náxt hats ğas̆nái̯b̄ət <(ùntər unt ɛ’rdə)> untər s̆né̄ hat bolái̯bət unt ɛ’rdə hī́r ka nusándrə, nia höi̯tə frúa̯ is̆tər gáŋgən hí̃.
 WS26	hìntar úžomə háu̯sə zàindar drài̯ s̆ü’ə̯nə ö’pfəlbòmən b̄it rɔ’tə ö’pfəl.
-WS27	b̄ö’ i̯tər bái̯tan hì̅r a b̄éne inunsándrə, dɔ’po gɛ`a̯bər b̄ìt anándər.
+WS27	b̄ö’ i̯tər bái̯tan hī̀r a b̄éne inunsándrə, dɔ’po gɛ`a̯bər b̄ìt anándər.
 WS28	
 WS29	ǖ’žɛnə bɛ’rgə zai̯n níχt zo hɔ̯’ax, diə unarándro zai̯n mɛ’r hɔ’a̯x.
-WS30	b̄iəvel lí̅vər salá̅də unt b̄ìə̯fəl b̆ rɔ̅’t b̄ɔ`i̯tər hɛ’n?
+WS30	b̄iəvel lī́vər salá̅də unt b̄ìə̯fəl b̆ rɔ̅’t b̄ɔ`i̯tər hɛ’n?
 WS31	i fɔrs̆tɛ’a̯ ina níχt, ir mü’sɛt rɛ’i̯dan a b̄é̄ni hɔ’d̆̅ər.
-WS32	hɛ’tər niχt fúntət a dö’i̯kla bài̯san žɔf o mai̯ d̆ís̆ia for mí̅?
+WS32	hɛ’tər niχt fúntət a dö’i̯kla bài̯san žɔf o mai̯ d̆ís̆ia for mī́?
 WS33	zai̯ b̆rúa̯dər vil máxən máu̯ə̯rn tsvɔà s̆ü’ə̯nə nɔ̈`i̯zə háü̯zər in ö’rmə gártə.
 WS34	das b̄ɔ’rt is kɛ’mən dal kuɔ’re.
 WS35	das is kɛn džústə <ğavɛ’st džústə> <kanus̆ándrə>.
 WS36	b̄ɛ’i̯lə fɔ’u̯gilià zai̯n ğafurmá̅t hɔ’a̯x ùntau̯ máu̯r?
-WS37	diɛ mán̄ɛ hɛn bráxt fínf ɔ’ksən unt nɔ’və kúe unt dó̅disɛ`i̯ s̆á fɔùr i pái̯səi tsɛzɛ̄’gan b̄ɔ`u̯sə fɔrkó̅fən.
+WS37	diɛ mán̄ɛ hɛn bráxt fínf ɔ’ksən unt nɔ’və kúe unt dṓdisɛ`i̯ s̆á fɔùr i pái̯səi tsɛzɛ̄’gan b̄ɔ`u̯sə fɔrkṓfən.
 WS38	diə lái̯tə zai̯n hái̯tə ál͡jə àu̯s in ákər tsə mɛ’n.
 WS39	{...} in húnt s̆prɛ’kolò̅t tùə̯t niχt in níe̯men.
-WS40	i bin ğapasá̅t b̠itən lái̯tən hɛ’r úbər də ví̅sə àu̯s in hákxər.
+WS40	i bin ğapasá̅t b̠itən lái̯tən hɛ’r úbər də vī́sə àu̯s in hákxər.

--- a/46367_Giazza.csv
+++ b/46367_Giazza.csv
@@ -31,7 +31,7 @@ WS11	i s̆lá̅go žúbite b̄itər kɛ͡’lje unt ɔ’rn.
 WS12	b̄o̅ gà̅stu dú? idu vɛrándre kím bita dír?
 WS13	ɛ’s is̆t lái̯xta tsái̯t.
 WS14	mài̯ hái̯js, s̆tía̯n bai mír úntar. di bö’i̯sən ɔ’ğ̅ən báisə dìχ un màxən s̆tɛ’rb̄ən.
-WS15	du has̆t hái̯tə galí̅rnət mɛ’ro unt du bis̆t ğavɛ’st bráb̄ot, du̅ ma̅ gí̅e̯n húã̯ b̄òr di ándern.
+WS15	du has̆t hái̯tə galí̅rnət mɛ’ro unt du bis̆t ğavɛ’st bráb̄ot, dū ma̅ gí̅e̯n húã̯ b̄òr di ándern.
 WS16	du bis̆t nìχt nau̯ grɔ’a̯s tsə tríŋkɛn a b̄ɔ’tsə vái̯, du músəst náu̯ a b̄é̅ni grɔ’i̯s̆ərn.
 WS17	gé̅, du mús zai̯n gúə̯t, un lɛ’rn in dái̯ndər s̆vɛ’stər, zi müs máxən nɛ̅’n is gaús̆t in dái̯ndər múə̯tər unt brùs̆tein á zau̯bər.
 WS18	

--- a/46367_Giazza.csv
+++ b/46367_Giazza.csv
@@ -19,7 +19,7 @@ Anmerkungen: '{Bei der Transliteration ergab sich das Problem, dass nicht alle A
 ...
 WS01	im b̄íntər s̆núran in də húa̯zə de lö’pər dúrən.
 WS02	ɛsən látsdà tse s̆nái̯b̄ən, dɔ’pɔ də tsái̯t kimt s̆üa̯n.
-WS03	léi̯gən is kɔ’i̯ in̅ su̯b̄ən, dɛ miləx bahɛ’ne hɛivət án tsɛ ziɛ dən.
+WS03	léi̯gən is kɔ’i̯ in̄ su̯b̄ən, dɛ miləx bahɛ’ne hɛivət án tsɛ ziɛ dən.
 WS04	dɛr gúa̯tə álte mán is ts̆á̅gat bãn ái̯sə b̄ìtəmè rɔ’u̯s un ist gab̄ál͡jet in dèmə kálte ásər.
 WS05	ɛr is̆t gas̆tɔ’rbet in fir sɛ’i vɔ’xən.
 WS06	ɛs fö’ir is̆t fíl s̆tar​χ, die kó̅pən zai̯n úntern álə furtbránt áls s̆várts.
@@ -53,7 +53,7 @@ WS33	zai̯ b̆rúa̯dər vil máxən máu̯ə̯rn tsvɔà s̆ü’ə̯nə nɔ̈`
 WS34	das b̄ɔ’rt is kɛ’mən dal kuɔ’re.
 WS35	das is kɛn džústə <ğavɛ’st džústə> <kanus̆ándrə>.
 WS36	b̄ɛ’i̯lə fɔ’u̯gilià zai̯n ğafurmá̅t hɔ’a̯x ùntau̯ máu̯r?
-WS37	diɛ mán̅ɛ hɛn bráxt fínf ɔ’ksən unt nɔ’və kúe unt dó̅disɛ`i̯ s̆á fɔùr i pái̯səi tsɛzɛ̅’gan b̄ɔ`u̯sə fɔrkó̅fən.
+WS37	diɛ mán̄ɛ hɛn bráxt fínf ɔ’ksən unt nɔ’və kúe unt dó̅disɛ`i̯ s̆á fɔùr i pái̯səi tsɛzɛ̅’gan b̄ɔ`u̯sə fɔrkó̅fən.
 WS38	diə lái̯tə zai̯n hái̯tə ál͡jə àu̯s in ákər tsə mɛ’n.
 WS39	{...} in húnt s̆prɛ’kolò̅t tùə̯t niχt in níe̯men.
 WS40	i bin ğapasá̅t ḇitən lái̯tən hɛ’r úbər də ví̅sə àu̯s in hákxər.

--- a/46368_Giazza.csv
+++ b/46368_Giazza.csv
@@ -20,7 +20,7 @@ WS09	ì bḭ̀ gavɛ̆st bai̯ dɛr bái̯p un ì hà̰s kö̩ü̯t an. zì hà 
 WS10	ì vìs níχt mɛ̆r túɛ̯n
 WS11	ì slăgɛ s̊übitɛ ùm t ó̩rən bìtər khĕ̥ɬi̯ə
 WS12	bo̥ gœstu dó̥? bí dù vɛrándrə kìm bíta dĭr
-WS13	ɛs is ɬái̯t̊̊s̊ə ts̊ái̯t
+WS13	ɛs is ɬái̯s̊ta ts̊ái̯t
 WS14	mai̯ hái̯jə, stìa̰ bài̯ mir úntər, do bu̯ö̩zan ó̩kan bái̯san dì̩ un maseən s̊tí̩rbən
 WS15	Hái̯tɛ du hàst galìrnət méro̥ un du bìs gavɛ̆st brábŏ̥t; du ma giən húa̰ vò̥u̯ diə̯ ándrə
 WS16	Du bìs nìχt náu̯ gró̩a̯s̊, tsɛ tríŋkhan a bó̩tsɛ báḭ du mùžast nau̯ a bĕnĕ grö̥i̯s̊ərn

--- a/46368_Giazza.csv
+++ b/46368_Giazza.csv
@@ -11,16 +11,16 @@ Anmerkungen: ''
 WS01	Im ƀíntɛr ṡnǫran in də l[?]fsər d[?]rən
 WS02	oèsan láts da tsə snái̯ban, dòpo dɛ tṡài̯t kìm ṡúa̰̯
 WS03	lègən is kŏl in oútan, dɛ mílɛχ hèi̯bət án bahɛnnə tsɛ síə̯dan
-WS04	dɛr guə̯tɛ àltɛ mán is tságat pàr n ái̯zɛ bìtɛmə róu̯ṡ un ìs gaváɬi̯ɛt ín dɛmə kháltə básɛr
+WS04	dɛr guə̯tɛ àltɛ mán is tságat pàr n ái̯zɛ bìtɛmə róu̯ṡ un ìs gaváłi̯ɛt ín dɛmə kháltə básɛr
 WS05	is gastórbat in vĭr, sɛi̯ bŏxə
-WS06	əs föü̯r is màssa ṡtarx <ov: vi(ɬ) ṡtarx>, də kópərn zài̯n àɬɛ fo̩rpránt ùntərn àɬɛs ṡtarts
+WS06	əs föü̯r is màssa ṡtarx <ov: vi(ł) ṡtarx>, də kópərn zài̯n àłɛ fo̩rpránt ùntərn àłɛs ṡtarts
 WS07	ɛr ɛsət di ó̩i̯jɛr sɛmpər àntə sálts un(t) àntə pfɛfər
-WS08	də tṡíŋkə tùa̯mɛr vɛa̯, ìχ gɬóbə <i màniχ gaminán (ich kann nicht mehr gehen)>
+WS08	də tṡíŋkə tùa̯mɛr vɛa̯, ìχ głóbə <i màniχ gaminán (ich kann nicht mehr gehen)>
 WS09	ì bḭ̀ gavɛ̆st bai̯ dɛr bái̯p un ì hà̰s kö̩ü̯t an. zì hà kö̩ü̯t zì vìs kö̩ü̯ən àŋka i(n) zài̯nər tó̥xtər
 WS10	ì vìs níχt mɛ̆r túɛ̯n
-WS11	ì slăgɛ ṡübitɛ ùm t ó̩rən bìtər khĕ̥ɬi̯ə
+WS11	ì slăgɛ ṡübitɛ ùm t ó̩rən bìtər khĕ̥łi̯ə
 WS12	bọ gœstu dó̥? bí dù vɛrándrə kìm bíta dĭr
-WS13	ɛs is ɬái̯ṡta tṡái̯t
+WS13	ɛs is łái̯ṡta tṡái̯t
 WS14	mai̯ hái̯jə, stìa̰ bài̯ mir úntər, do bu̯ö̩zan ó̩kan bái̯san dì̩ un maseən ṡtí̩rbən
 WS15	Hái̯tɛ du hàst galìrnət mérọ un du bìs gavɛ̆st brábŏ̥t; du ma giən húa̰ vò̥u̯ diə̯ ándrə
 WS16	Du bìs nìχt náu̯ gró̩a̯ṡ, tsɛ tríŋkhan a bó̩tsɛ báḭ du mùžast nau̯ a bĕnĕ grö̥i̯ṡərn
@@ -39,12 +39,12 @@ WS28
 WS29	ùzənə bɛrgə zài̯n níχt zò̥ hó̩a̯x diə unarándər zài̯n mɛr hò̩a̯x
 WS30	vìəfəl lìvər ṡaládə unt vìəfəl pró̩a̯t bó̩ü̯tər hɛn?
 WS31	ì fo̩rṡtɛa̯ na nìχt ɛr mùsat rɛi̯dan a bɛ̆nə mɛr hó̩a̯tər
-WS32	hɛtɛr nìχt fúntot a dö̥u̯kla bài̯san ṡó̩f o mài̯ tiṡɬi̯a fó̩r mí
+WS32	hɛtɛr nìχt fúntot a dö̥u̯kla bài̯san ṡó̩f o mài̯ tiṡłi̯a fó̩r mí
 WS33	zaḭ̯ brúo̯dər vìl màxən máu̯rn tsbó̩a̯ sö̥nɛ nœü̯gə hö̥ü̯žər in=óu̯mɛ gártɛ
 WS34	das bó̩rt is kĕ̥mɛn dal ku̯ó̩rə
 WS35	dàs is kɛn <gabɛ̆st> djústɛ <ka nuzandər = bei ŭus>
-WS36	bèɬɛ fŏgiɬi̯ar zài̯n ga=formárt hó̩a̯x untọn̯ máu̯r
+WS36	bèłɛ fŏgiłi̯ar zài̯n ga=formárt hó̩a̯x untọn̯ máu̯r
 WS37	diə mánnɛ hɛn práxt fìnf khĕ̥lpɛr unt nó̩və khúə̯ unt dò̥dətsə ṡă vò̥u̯r im páə̯zə, tṡɛgan tò̥u̯zɛ forkó̥fɛn
-WS38	diə làitə zai̯n hài̯tɛ àɬi̯ɛ áu̯s in də bízɛ <inn ákər> tsɛ mĕ̥n
+WS38	diə làitə zai̯n hài̯tɛ àłi̯ɛ áu̯s in də bízɛ <inn ákər> tsɛ mĕ̥n
 WS39	{...} in hunt ṡprœkulud tùə̯t nìχt in níə̯mən
 WS40	ì bì ga=passát bìtɛn lœü̯tan hìntɛrn hɛr ŭbər də bízɛ áu̯s in hákər

--- a/46368_Giazza.csv
+++ b/46368_Giazza.csv
@@ -9,42 +9,42 @@ Transliterent: Stephanie Leser
 Anmerkungen: ''
 ...
 WS01	Im ƀíntɛr ṡnǫran in də l[?]fsər d[?]rən
-WS02	oèsan láts da tsə snái̯ban, dòpo dɛ ts̊ài̯t kìm s̊úa̰̯
+WS02	oèsan láts da tsə snái̯ban, dòpo dɛ tṡài̯t kìm ṡúa̰̯
 WS03	lègən is kŏl in oútan, dɛ mílɛχ hèi̯bət án bahɛnnə tsɛ síə̯dan
-WS04	dɛr guə̯tɛ àltɛ mán is tságat pàr n ái̯zɛ bìtɛmə róu̯s̊ un ìs gaváɬi̯ɛt ín dɛmə kháltə básɛr
+WS04	dɛr guə̯tɛ àltɛ mán is tságat pàr n ái̯zɛ bìtɛmə róu̯ṡ un ìs gaváɬi̯ɛt ín dɛmə kháltə básɛr
 WS05	is gastórbat in vĭr, sɛi̯ bŏxə
-WS06	əs föü̯r is màssa s̊tarx <ov: vi(ɬ) s̊̊tarx>, də kópərn zài̯n àɬɛ fo̩rpránt ùntərn àɬɛs s̊tarts
+WS06	əs föü̯r is màssa ṡtarx <ov: vi(ɬ) ṡtarx>, də kópərn zài̯n àɬɛ fo̩rpránt ùntərn àɬɛs ṡtarts
 WS07	ɛr ɛsət di ó̩i̯jɛr sɛmpər àntə sálts un(t) àntə pfɛfər
-WS08	də ts̊íŋkə tùa̯mɛr vɛa̯, ìχ gɬóbə <i màniχ gaminán (ich kann nicht mehr gehen)>
+WS08	də tṡíŋkə tùa̯mɛr vɛa̯, ìχ gɬóbə <i màniχ gaminán (ich kann nicht mehr gehen)>
 WS09	ì bḭ̀ gavɛ̆st bai̯ dɛr bái̯p un ì hà̰s kö̩ü̯t an. zì hà kö̩ü̯t zì vìs kö̩ü̯ən àŋka i(n) zài̯nər tó̥xtər
 WS10	ì vìs níχt mɛ̆r túɛ̯n
-WS11	ì slăgɛ s̊übitɛ ùm t ó̩rən bìtər khĕ̥ɬi̯ə
-WS12	bo̥ gœstu dó̥? bí dù vɛrándrə kìm bíta dĭr
-WS13	ɛs is ɬái̯s̊ta ts̊ái̯t
-WS14	mai̯ hái̯jə, stìa̰ bài̯ mir úntər, do bu̯ö̩zan ó̩kan bái̯san dì̩ un maseən s̊tí̩rbən
-WS15	Hái̯tɛ du hàst galìrnət méro̥ un du bìs gavɛ̆st brábŏ̥t; du ma giən húa̰ vò̥u̯ diə̯ ándrə
-WS16	Du bìs nìχt náu̯ gró̩a̯s̊, tsɛ tríŋkhan a bó̩tsɛ báḭ du mùžast nau̯ a bĕnĕ grö̥i̯s̊ərn
-WS17	gĕ, du mùs zài̯n gúə̯t, un lɛrn in dài̯ndər s̊vé̥stər, si mùis màxən năn is garúst in dài̯ndər múo̯tər, un brü̩skináu̯ záu̯bər
+WS11	ì slăgɛ ṡübitɛ ùm t ó̩rən bìtər khĕ̥ɬi̯ə
+WS12	bọ gœstu dó̥? bí dù vɛrándrə kìm bíta dĭr
+WS13	ɛs is ɬái̯ṡta tṡái̯t
+WS14	mai̯ hái̯jə, stìa̰ bài̯ mir úntər, do bu̯ö̩zan ó̩kan bái̯san dì̩ un maseən ṡtí̩rbən
+WS15	Hái̯tɛ du hàst galìrnət mérọ un du bìs gavɛ̆st brábŏ̥t; du ma giən húa̰ vò̥u̯ diə̯ ándrə
+WS16	Du bìs nìχt náu̯ gró̩a̯ṡ, tsɛ tríŋkhan a bó̩tsɛ báḭ du mùžast nau̯ a bĕnĕ grö̥i̯ṡərn
+WS17	gĕ, du mùs zài̯n gúə̯t, un lɛrn in dài̯ndər ṡvé̥stər, si mùis màxən năn is garúst in dài̯ndər múo̯tər, un brü̩skináu̯ záu̯bər
 WS18	
-WS19	vér mì hàt gas̊tŏlt mài̯ ts̊ü̩a̯ja fi̯ái̯s̊?
+WS19	vér mì hàt gaṡtŏlt mài̯ tṡü̩a̯ja fi̯ái̯ṡ?
 WS20	
 WS21	vɛmɛ hàtər rakontát <galɛ̆rt> {...}
-WS22	ma mùs s̊rái̯jɛn ho̩a̯x, ɛr gazó̩ fors̊tɛa̯t niχ zandrə
-WS23	baràndrɛ zain mü̩ə̯dɛ un hɛn dúrs̊t
+WS22	ma mùs ṡrái̯jɛn ho̩a̯x, ɛr gazó̩ forṡtɛa̯t niχ zandrə
+WS23	baràndrɛ zain mü̩ə̯dɛ un hɛn dúrṡt
 WS24	(ìs ɛr gàŋan hí̯)
-WS25	Hàndar násxt hàts gas̊nái̯tət ùn dɛr s̊nœa̯ hàt bolái̯tət unt ɛrdè ka nuzándər, ma háü̯to̩fría̯
-WS26	hìntər ùzəmə háŭ̯zɛ zài̯n da drài s̊önə ö̩pfəlbòmɛn bit rò̩ətə öpfəl
-WS27	vö̩ltɛr pái̯tan hìa̯r a tɛ̆nə in uzándər dò̩po̥ gə̯ábər bìtanándər
+WS25	Hàndar násxt hàts gaṡnái̯tət ùn dɛr ṡnœa̯ hàt bolái̯tət unt ɛrdè ka nuzándər, ma háü̯to̩fría̯
+WS26	hìntər ùzəmə háŭ̯zɛ zài̯n da drài ṡönə ö̩pfəlbòmɛn bit rò̩ətə öpfəl
+WS27	vö̩ltɛr pái̯tan hìa̯r a tɛ̆nə in uzándər dò̩pọ gə̯ábər bìtanándər
 WS28	
 WS29	ùzənə bɛrgə zài̯n níχt zò̥ hó̩a̯x diə unarándər zài̯n mɛr hò̩a̯x
-WS30	vìəfəl lìvər s̊aládə unt vìəfəl pró̩a̯t bó̩ü̯tər hɛn?
-WS31	ì fo̩rs̊tɛa̯ na nìχt ɛr mùsat rɛi̯dan a bɛ̆nə mɛr hó̩a̯tər
-WS32	hɛtɛr nìχt fúntot a dö̥u̯kla bài̯san s̊ó̩f o mài̯ tis̊ɬi̯a fó̩r mí
+WS30	vìəfəl lìvər ṡaládə unt vìəfəl pró̩a̯t bó̩ü̯tər hɛn?
+WS31	ì fo̩rṡtɛa̯ na nìχt ɛr mùsat rɛi̯dan a bɛ̆nə mɛr hó̩a̯tər
+WS32	hɛtɛr nìχt fúntot a dö̥u̯kla bài̯san ṡó̩f o mài̯ tiṡɬi̯a fó̩r mí
 WS33	zaḭ̯ brúo̯dər vìl màxən máu̯rn tsbó̩a̯ sö̥nɛ nœü̯gə hö̥ü̯žər in=óu̯mɛ gártɛ
 WS34	das bó̩rt is kĕ̥mɛn dal ku̯ó̩rə
 WS35	dàs is kɛn <gabɛ̆st> djústɛ <ka nuzandər = bei ŭus>
-WS36	bèɬɛ fŏgiɬi̯ar zài̯n ga=formárt hó̩a̯x unto̥n̯ máu̯r
-WS37	diə mánnɛ hɛn práxt fìnf khĕ̥lpɛr unt nó̩və khúə̯ unt dò̥dətsə s̊ă vò̥u̯r im páə̯zə, ts̊ɛgan tò̥u̯zɛ forkó̥fɛn
+WS36	bèɬɛ fŏgiɬi̯ar zài̯n ga=formárt hó̩a̯x untọn̯ máu̯r
+WS37	diə mánnɛ hɛn práxt fìnf khĕ̥lpɛr unt nó̩və khúə̯ unt dò̥dətsə ṡă vò̥u̯r im páə̯zə, tṡɛgan tò̥u̯zɛ forkó̥fɛn
 WS38	diə làitə zai̯n hài̯tɛ àɬi̯ɛ áu̯s in də bízɛ <inn ákər> tsɛ mĕ̥n
-WS39	{...} in hunt s̊prœkulud tùə̯t nìχt in níə̯mən
+WS39	{...} in hunt ṡprœkulud tùə̯t nìχt in níə̯mən
 WS40	ì bì ga=passát bìtɛn lœü̯tan hìntɛrn hɛr ŭbər də bízɛ áu̯s in hákər

--- a/46370_Mezzaselva.csv
+++ b/46370_Mezzaselva.csv
@@ -11,14 +11,14 @@ Anmerkungen: '<NB: ƀ: bilab[ial] pi[???] Reibelaut, manchmal aber pi[???] Versc
 
   [----------][---------]V[o]kal: Zirkumfleks[???] [?????]>'
 ...
-WS01	Im bíntər lṑfən də blā́tər mitənándər par͡ ḗ̩ər <im ƀintər vallənts lōp>.
-WS02	ṡmolā́rt súƀito ṡo ṡnái̯ƀan un dɛ̀mɛ də ṡái̯t rī́χtət ziχ
+WS01	Im bíntər lṑfən də blä́tər mitənándər par͡ ḗ̩ər <im ƀintər vallənts lōp>.
+WS02	ṡmolä́rt súƀito ṡo ṡnái̯ƀan un dɛ̀mɛ də ṡái̯t rī́χtət ziχ
 WS03	mist lḗgan kǫ̆̀l ín in də formɛ̄́lan, alṓ̩ra də mílχ hö̩̀tət àn zī́dan bohɛ́nɛ
 WS04	dər gū́tə͡àltə mán iṡ gabrǫ̀χət ins ái̯s məmə rǫ́ssɛi̯ unt iṡ gavàlt nī́dor iz kàltə ƀássar
 WS05	ər ìṡ gaṡtǫ́rbɛt in ƀī́r, zɛ́ks bǫ́χɛ̀n
 WS06	stö̩́a̯r is gəvəs ṡù vī́l, un də fo̩gátsən zài̯nt vəbrǘnnət ùntərnín àllə ṡvárts
 WS07	ɛr ísɛ̀t dȫ̩́lin sáldo̩ ùnɛ sálts unt ùnɛ fɛ́hàr
-WS08	də mài̯n tü͂́sɛ̀ tǜa̯mɛr ṡtárχ vḗ̩a̯ iχ glṓbɛ̀, iχ hā̀n zi sopā́rt ṡolṓfan
+WS08	də mài̯n tü͂́sɛ̀ tǜa̯mɛr ṡtárχ vḗ̩a̯ iχ glṓbɛ̀, iχ hā̀n zi sopä́rt ṡolṓfan
 WS09	iχ bìn gəƀḗ̩st kàmɛ ƀái̯bɛ̀ un hánzər kǘ̜t, un zī́ vìls kö̩̆́đan àŋka da zài̯n tö̜́χtərì
 WS10	dítsan tǜi̯χ nɛmɛ̄́a̯rə oder: dítsan vìl iχ ò̩u̯χ níman tǘa̯n
 WS11	iχ júka də pállə mìtər kɛ́llɛ̀n ùmin dṓ̩ɍan <(ɍ sehr weiches r)>
@@ -27,10 +27,10 @@ WS13	ist bȫ̀ṡa sái̯t
 WS14	s mài̯n lī́bə khínt, <[pait]> ƀolái̯p hi͡úntarn dū́ dē pö̩̀ṡə ó̜kɛ̀n pái̯ṡɛn dìχ undɛ̀nnə ṡtírƀəstù
 WS15	hó̜itə hàstu galī́ərnɛt in mái̯stərɛn dú unt bìs gəƀḕst gṹt du man gḕnan hó̜ə̯m ƀṑ̩r den͡ándərn
 WS16	du bis nṑ̜nt gró̩a̯s gənúŋ, tríŋkan an ƀòtsa vái̯n du mus no̜χ kɛman grö̩səro
-WS17	gḕhín, zai̯ gū́t, un kǘ̜t da dài̯n ṡvɛ́stari̥ ắ rī̀ƀa nœ̄́nan s gaƀɛ́ntlɛ dr ö̜̀r mā́mɛ̀n ùntásəs kḕ̩reáu̯s məmə kḗrar
+WS17	gḕhín, zai̯ gū́t, un kǘ̜t da dài̯n ṡvɛ́stari̥ ắ rī̀ƀa nœ̄́nan s gaƀɛ́ntlɛ dr ö̜̀r mä́mɛ̀n ùntásəs kḕ̩reáu̯s məmə kḗrar
 WS18	hö̩̀təst dún du gəkhánt <oder: ƀòn[??] hö̀təst dún gəkhánt> alṓ̩ra vŏ̩s kɛ́mmɛ̀t ìndifərɛnti̥ unt dès ƀö̜r bɛ́søͧr ƀor ìn
 WS19	ƀɛ̀r hàmər gaṡtō̩lt də mài̯n ṡṓ̩na ƀlṓa̯s
-WS20	ər hàt gətánt͡azṓ̩, a ƀìzə hö̩̀ttan òrdinā́t džjúkan͡ìn <oder: drɛ́ṡan ìn> ma hàbɛns gatánt zɛlƀur
+WS20	ər hàt gətánt͡azṓ̩, a ƀìzə hö̩̀ttan òrdinä́t džjúkan͡ìn <oder: drɛ́ṡan ìn> ma hàbɛns gatánt zɛlƀur
 WS21	ƀēmə hátərṡ ĕ̀r kǘ̜t <oder: kontárt> də nó̜i̯jə ṡtó̜ri̯a
 WS22	ƀìr mùzən kó̜i̯kəlɛ ṡtárχ <stárɛχ>, sánṓ̩ ɛr forṡtḗ̩t zi nìχt nozándɛrn
 WS23	varándərə zai̯n mǘdè̩ unt hàbən ùnen dū́ə̯rst
@@ -43,11 +43,11 @@ WS29	di jǘnjɛrn bɛ̀rgə zìn níχt ƀīl hō̜a̯χ, di jȫ̩́ərn zài̯n
 WS30	ƀī̀ƀəl lĭ̀bərn saládən unt ƀī̀ƀəl brṓ̩a̯t víltàr <oder: vìltar háƀan>
 WS31	iχ fərṡtḗ̩a̯χ nɛ̀t ó̩i̯χ i mìsɛt prɛ́χtan an sti̯ɛ̄́ndli mɛ̜̀ro̰ ṡtárχ
 WS32	hàƀɛt ər nɛ̀t gavúnnɛ̀t an tǘ̜klɛ vài̯sar só̜a̯fta àu̯f an mài̯n tísš vùr míχ
-WS33	dr zài̯n brū́dɛr vìl zɛr màχən áu̯ ṡƀḕn ṡö̩́nɛ nó̩i̯ɛ hó̩i̯zar ìnən ö̜̀rn gā́rtɛ̀n
+WS33	dr zài̯n brū́dɛr vìl zɛr màχən áu̯ ṡƀḕn ṡö̩́nɛ nó̩i̯ɛ hó̩i̯zar ìnən ö̜̀rn gä́rtɛ̀n
 WS34	dɛs ƀṓərt ìs mə kɛ́nnt vònə hɛ̄rtsə
 WS35	daz⁀ìst gaƀḕst ƀā̀r <jústo̜> vòr zṓ̩i̯
 WS36	ƀḕ̩li ƀȫ̩́gəlĭ̀ zài̯nt áu̯ in də máu̯ra stìlli
-WS37	də pakā́n hàƀɛnt katrái̯ƀɛt=ṡúa̯ vǖ̀f ó̜kzɛ̀n un nòi̯n kǖ́ unt=ṡƀö̩̀lf ȫ̩́ƀɛn vṑr mə lántɛ̀ zi vö̩̀ltans vrkṑfan
+WS37	də pakä́n hàƀɛnt katrái̯ƀɛt=ṡúa̯ vǖ̀f ó̜kzɛ̀n un nòi̯n kǖ́ unt=ṡƀö̩̀lf ȫ̩́ƀɛn vṑr mə lántɛ̀ zi vö̩̀ltans vrkṑfan
 WS38	àlli di ló̩i̯tɛ zài̯nt hò̯ti àu̯z⁀in ákr un mḗnan
 WS39	gehín dù, dər brū́nətɛ húnt tǘtər nìχt
 WS40	iχ bin passāt mìtɛn mánnɛ̀n ùnə ƀur də bī́zɛ̀n un ìnən ákər da híntɛ̀n

--- a/46370_Mezzaselva.csv
+++ b/46370_Mezzaselva.csv
@@ -25,7 +25,7 @@ WS11	iχ júka də pállə mìtər kɛ́llɛ̀n ùmin dṓ̩ɍan <(ɍ sehr weich
 WS12	ƀa gḗ̩stu dū̀? Víl dù star kɛ́mèn mítìr
 WS13	ist bȫ̀ṡa sái̯t
 WS14	s mài̯n lī́bə khínt, <[pait]> ƀolái̯p hi͡úntarn dū́ dē pö̩̀ṡə ó̜kɛ̀n pái̯ṡɛn dìχ undɛ̀nnə ṡtírƀəstù
-WS15	hó̜itə hàstu galī́ərnɛt in mái̯stərɛn dú unt bìs gəƀḕst gu͂́t du man gḕnan hó̜ə̯m ƀṑ̩r den͡ándərn
+WS15	hó̜itə hàstu galī́ərnɛt in mái̯stərɛn dú unt bìs gəƀḕst gṹt du man gḕnan hó̜ə̯m ƀṑ̩r den͡ándərn
 WS16	du bis nṑ̜nt gró̩a̯s gənúŋ, tríŋkan an ƀòtsa vái̯n du mus no̜χ kɛman grö̩səro
 WS17	gḕhín, zai̯ gū́t, un kǘ̜t da dài̯n ṡvɛ́stari̥ ắ rī̀ƀa nœ̄́nan s gaƀɛ́ntlɛ dr ö̜̀r mā́mɛ̀n ùntásəs kḕ̩reáu̯s məmə kḗrar
 WS18	hö̩̀təst dún du gəkhánt <oder: ƀòn[??] hö̀təst dún gəkhánt> alṓ̩ra vŏ̩s kɛ́mmɛ̀t ìndifərɛnti̥ unt dès ƀö̜r bɛ́søͧr ƀor ìn
@@ -39,7 +39,7 @@ WS25	hài̯nt dr náscht is gəṡtánt dr ṡnḗ̩a̯ ka nozándɛrn, ma ho̜i
 WS26	híntən mǘŋjɛrn háu̯zɛ̀ zaìnta drái̯ ṡö̩́ni̥ ö̜́pfɛlpṑ̩məŋ hàbənt áu̯ rṓ̜tɛi̯ ö̩́pfalìŋ
 WS27	mö̩́χtərət pái̯tan a ṡtīɛ̯ndliŋ ozàndɛrn, dè̩nnə kɛ́mmɛƀɛ̀r mít o̩i̯χ
 WS28	mán ziχ nɛ(t) nɛ́rran <(fyirlen)> vìə̯ də khíndɛ̀r
-WS29	di jǘnjɛrn bɛ̀rgə zìn níχt ƀīl hō̜a̯χ, di jȫ̩́ərn zài̯nt ƀī̀l hȫ̜́gur
+WS29	di jǘnjɛrn bɛ̀rgə zìn níχt ƀīl hō̜a̯χ, di jȫ̩́ərn zài̯nt ƀī̀l hȫ̩́gur
 WS30	ƀī̀ƀəl lĭ̀bərn saládən unt ƀī̀ƀəl brṓ̩a̯t víltàr <oder: vìltar háƀan>
 WS31	iχ fərṡtḗ̩a̯χ nɛ̀t ó̩i̯χ i mìsɛt prɛ́χtan an sti̯ɛ̄́ndli mɛ̜̀ro̰ ṡtárχ
 WS32	hàƀɛt ər nɛ̀t gavúnnɛ̀t an tǘ̜klɛ vài̯sar só̜a̯fta àu̯f an mài̯n tísš vùr míχ

--- a/46370_Mezzaselva.csv
+++ b/46370_Mezzaselva.csv
@@ -27,16 +27,16 @@ WS13	ist bȫ̀ṡa sái̯t
 WS14	s mài̯n lī́bə khínt, <[pait]> ƀolái̯p hi͡úntarn dū́ dē pö̩̀ṡə ó̜kɛ̀n pái̯ṡɛn dìχ undɛ̀nnə ṡtírƀəstù
 WS15	hó̜itə hàstu galī́ərnɛt in mái̯stərɛn dú unt bìs gəƀḕst gu͂́t du man gḕnan hó̜ə̯m ƀṑ̩r den͡ándərn
 WS16	du bis nṑ̜nt gró̩a̯s gənúŋ, tríŋkan an ƀòtsa vái̯n du mus no̜χ kɛman grö̩səro
-WS17	gḕhín, zai̯ gū́t, un kǘ̜t da dài̯n ṡvɛ́stari̜ ắ rī̀ƀa nœ̄́nan s gaƀɛ́ntlɛ dr ö̜̀r mā́mɛ̀n ùntásəs kḕ̩reáu̯s məmə kḗrar
-WS18	hö̩̀təst dún du gəkhánt <oder: ƀòn[??] hö̀təst dún gəkhánt> alṓ̩ra vŏ̩s kɛ́mmɛ̀t ìndifərɛnti̜ unt dès ƀö̜r bɛ́søͧr ƀor ìn
+WS17	gḕhín, zai̯ gū́t, un kǘ̜t da dài̯n ṡvɛ́stari̥ ắ rī̀ƀa nœ̄́nan s gaƀɛ́ntlɛ dr ö̜̀r mā́mɛ̀n ùntásəs kḕ̩reáu̯s məmə kḗrar
+WS18	hö̩̀təst dún du gəkhánt <oder: ƀòn[??] hö̀təst dún gəkhánt> alṓ̩ra vŏ̩s kɛ́mmɛ̀t ìndifərɛnti̥ unt dès ƀö̜r bɛ́søͧr ƀor ìn
 WS19	ƀɛ̀r hàmər gaṡtō̩lt də mài̯n ṡṓ̩na ƀlṓa̯s
 WS20	ər hàt gətánt͡azṓ̩, a ƀìzə hö̩̀ttan òrdinā́t džjúkan͡ìn <oder: drɛ́ṡan ìn> ma hàbɛns gatánt zɛlƀur
 WS21	ƀēmə hátərṡ ĕ̀r kǘ̜t <oder: kontárt> də nó̜i̯jə ṡtó̜ri̯a
 WS22	ƀìr mùzən kó̜i̯kəlɛ ṡtárχ <stárɛχ>, sánṓ̩ ɛr forṡtḗ̩t zi nìχt nozándɛrn
 WS23	varándərə zai̯n mǘdè̩ unt hàbən ùnen dū́ə̯rst
 WS24	ƀi zaìmƀar gəkchḗ̩rt nɛ́χtant, di͡ándərn zin gəƀḗst ins bĕ̩́tè̩ unt zin gəƀḗst int ṡláfet ṡtárχ
-WS25	hài̯nt dr náscht is gəṡtánt dr ṡnḗ̩a̯ ka nozándɛrn, ma ho̜i̯tə mŏ̩́rgandi̜ isər gəƀḗst allər
-WS26	híntən mǘŋjɛrn háu̯zɛ̀ zaìnta drái̯ ṡö̩́ni̜ ö̜́pfɛlpṑ̩məŋ hàbənt áu̯ rṓ̜tɛi̯ ö̩́pfalìŋ
+WS25	hài̯nt dr náscht is gəṡtánt dr ṡnḗ̩a̯ ka nozándɛrn, ma ho̜i̯tə mŏ̩́rgandi̥ isər gəƀḗst allər
+WS26	híntən mǘŋjɛrn háu̯zɛ̀ zaìnta drái̯ ṡö̩́ni̥ ö̜́pfɛlpṑ̩məŋ hàbənt áu̯ rṓ̜tɛi̯ ö̩́pfalìŋ
 WS27	mö̩́χtərət pái̯tan a ṡtīɛ̯ndliŋ ozàndɛrn, dè̩nnə kɛ́mmɛƀɛ̀r mít o̩i̯χ
 WS28	mán ziχ nɛ(t) nɛ́rran <(fyirlen)> vìə̯ də khíndɛ̀r
 WS29	di jǘnjɛrn bɛ̀rgə zìn níχt ƀīl hō̜a̯χ, di jȫ̩́ərn zài̯nt ƀī̀l hȫ̜́gur

--- a/46572_Nebel-auf-Amrum.csv
+++ b/46572_Nebel-auf-Amrum.csv
@@ -33,7 +33,7 @@ WS21	Tå hokkar hæ hi at nai Stak fortælt?
 WS22	Ham mut gratam repp, öthars forstænt-r üs egh.
 WS23	Wi san træt and ha Tharst.
 WS24	Iar wi jistar Inj tåragh kam, då lai a Ötharn al un-t Bad, and wiar fæst în slæppan.
-WS25	A Snæ as auar Naght bai üs laian blæv̅an, man jü Maran as hi smoltan.
+WS25	A Snæ as auar Naght bai üs laian blæv̄an, man jü Maran as hi smoltan.
 WS26	Bæft üs hüs stun tri Âpalbumkan mæd ruad Æppalkan.
 WS27	Kön jam egh an Uganblak üb üs têv, då wæl wi mæd jam gong.
 WS28	Iam mut egh sok Ionganskråm drîv.

--- a/46574_Gröde.csv
+++ b/46574_Gröde.csv
@@ -10,7 +10,7 @@ Anmerkungen: <å = å, æ = ä>{Das Zeichen ist unklar. Es ist eigentlich kein g
   ä, sondern ein a sowohl mit Doppel-Akut als Doppel-Gravis.} <Abschrift vom Formula
   von Nebel (Amrum.)>
 ...
-WS01	In de Wonter flîn de drüḡe Blæe in de Loght ambei.
+WS01	In de Wonter flîn de drüg̅e Blæe in de Loght ambei.
 WS02	Dat hålt glik ap tå snaien, denn ward dat Wêr wi bêr
 WS03	Dün Köl in de Kakkelön, dat de Molke bâle begane tå kogan.
 WS04	Di göe uale Mon is med di Hingste dör-t Is brægen, end in-t köl Wår felen.
@@ -45,7 +45,7 @@ WS32	Heve jam e en Stôk wit Siap fer mi uv de Tafel funnen?
 WS33	San Brör wal ham taue smuke naie Hüsenge in jaren Tun begge.
 WS34	Det Ürd kum ham fon Herten.
 WS35	Dat woas roght fon jam.
-WS36	Wat sat dir fer en litjen Fuḡel uv de Murr?
+WS36	Wat sat dir fer en litjen Fug̅el uv de Murr?
 WS37	De Burre hên fîv Ôkse end njug̅en Ki and twalv Skêpe fer-t Torp broght, dü wêllen-s ferkupe.
 WS38	Dat Föolk is delleng altåmoal büten uv-t Fêl tå hauen.
 WS39	Gong man, di brunne Hingste dêt di niks.

--- a/46578_West-Bordelum.csv
+++ b/46578_West-Bordelum.csv
@@ -9,42 +9,42 @@ Transliterent: Temmo Bosse
 Anmerkungen: <NB. ᴗ = Schärfungszeichen.>
 ...
 WS01	Oun dĭ Wonter fline dĭ drögge Bläe oun dĭ Lŏft ambai.
-WS02	Dat hălt glick ăp to ʃchneien, denn ward dat Wäer wĭ bäer
+WS02	Dat hălt glick ăp to ſchneien, denn ward dat Wäer wĭ bäer
 WS03	Dun Köle oun di Kachelown, dat di Molke bald oun to kogen fanget
-WS04	Di goe ule Moon es mĕ dĭ Hengʃt dör ’t Jß bräg’n ŭn oun dat koul Wăr feelen.
-WS05	Hi es for fjauer oder ʃeeks Werge ʃtürben.
-WS06	Dat Jil weer tŏ hiit, dĭ Karge ʃenn je onner ganz ʃuurt barnt.
+WS04	Di goe ule Moon es mĕ dĭ Hengſt dör ’t Jß bräg’n ŭn oun dat koul Wăr feelen.
+WS05	Hi es for fjauer oder ſeeks Werge ſtürben.
+WS06	Dat Jil weer tŏ hiit, dĭ Karge ſenn je onner ganz ſuurt barnt.
 WS07	Hi eet di Aie jümmer one Salt [u]n {Vielleicht lautet das Wort auch ĕn, dies gilt im Prinzip für alle nachfolgenden Belege von un} Pewwer.
-WS08	Di Fĕit’ dun mĭ banni ʃiir, ick liew, ick hew ʃe dör lebn.
-WS09	Jck benn bai jö Wüff wen, un hew et her ʃaid, un jö ʃäd, jö wäil et ock her Doochter ʃĕje.
+WS08	Di Fĕit’ dun mĭ banni ſiir, ick liew, ick hew ſe dör lebn.
+WS09	Jck benn bai jö Wüff wen, un hew et her ſaid, un jö ſäd, jö wäil et ock her Doochter ſĕje.
 WS10	Jck wall et ock ä wĭ dun!
-WS11	Jck ʃchlun dĭ glick mĕ dĭ Koogʃchies am dĭ Ure, dö Ăwe!
-WS12	Wer gongʃt dö henn, ʃchenn wĭ mĕ dĭ gonge?
-WS13	Dat ʃenn ringe Tidde!
-WS14	Minn liew Beern, blĭw her deele ʃtoune, di dolle Gäis bitte dĭ dud.
-WS15	Dö heʃt delleng am marʃten lierd un beʃt ordi wen, dö maiʃt ir tŏ Höß gonge as dĭ Or.
-WS16	Dö beʃt nŏg ä grott ennoog, am en Boddel Winn ött todrinken, dö mouʃt erʃt nŏch en Jine wakʃe un grotter ward {Hier ist mit ward statt warde eventuell eine Beeinflussung durch den Mittelgoesharder Heimatdialekt des Übersetzers vorhanden, vielleicht fehlt der Buchstabe aber auch nur, weil das Wort klein und eng an den Rand des Bogens geschrieben wurde.}
-WS17	Gong, we ʃŏ goud un ʃĕi dĭn Sö ʃter, jö ʃchoul dĭ Kluge for jernge Memm gangs ʃaie un mĕ di Berʃel riin marge.
-WS18	Häiʃt dö ham kărnd! denn weer et ors kiimen, un et dä bäer am ham ʃtoun’n.
-WS19	Hum het mĭ măn Korf mĕ Flărʃch ʃtehlen?
-WS20	Hi däi ʃö, as häin jĕ hăm to terʃchen beʃtalld; je hew et aber ʃillef däin.
+WS11	Jck ſchlun dĭ glick mĕ dĭ Koogſchies am dĭ Ure, dö Ăwe!
+WS12	Wer gongſt dö henn, ſchenn wĭ mĕ dĭ gonge?
+WS13	Dat ſenn ringe Tidde!
+WS14	Minn liew Beern, blĭw her deele ſtoune, di dolle Gäis bitte dĭ dud.
+WS15	Dö heſt delleng am marſten lierd un beſt ordi wen, dö maiſt ir tŏ Höß gonge as dĭ Or.
+WS16	Dö beſt nŏg ä grott ennoog, am en Boddel Winn ött todrinken, dö mouſt erſt nŏch en Jine wakſe un grotter ward {Hier ist mit ward statt warde eventuell eine Beeinflussung durch den Mittelgoesharder Heimatdialekt des Übersetzers vorhanden, vielleicht fehlt der Buchstabe aber auch nur, weil das Wort klein und eng an den Rand des Bogens geschrieben wurde.}
+WS17	Gong, we ſŏ goud un ſĕi dĭn Sö ſter, jö ſchoul dĭ Kluge for jernge Memm gangs ſaie un mĕ di Berſel riin marge.
+WS18	Häiſt dö ham kărnd! denn weer et ors kiimen, un et dä bäer am ham ſtoun’n.
+WS19	Hum het mĭ măn Korf mĕ Flărſch ſtehlen?
+WS20	Hi däi ſö, as häin jĕ hăm to terſchen beſtalld; je hew et aber ſillef däin.
 WS21	Hum heet hi dat nai Stock verteelt?
-WS22	Hum mout grottem grăle, ors verʃtoont hi üs ä.
-WS23	Wĭ ʃenn trăt un hewe Törʃt.
-WS24	As wĭ jörʃen Eene tŏbeg koumen, deer laien dĭ Or all a’t Beed un weern faʃt oun Schläip.
-WS25	Dĭ Schnäi es auer Nacht bai üs laien blewwen, aber Marleng es hi ʃchmolten.
-WS26	Beefte üs Höß ʃtoune tre lettje ʃchmocke Arpelbume mĕ ruude Apele.
+WS22	Hum mout grottem grăle, ors verſtoont hi üs ä.
+WS23	Wĭ ſenn trăt un hewe Törſt.
+WS24	As wĭ jörſen Eene tŏbeg koumen, deer laien dĭ Or all a’t Beed un weern faſt oun Schläip.
+WS25	Dĭ Schnäi es auer Nacht bai üs laien blewwen, aber Marleng es hi ſchmolten.
+WS26	Beefte üs Höß ſtoune tre lettje ſchmocke Arpelbume mĕ ruude Apele.
 WS27	Kaan jem ä noch en lettj Uugenblack ewer üs teewe, denn gonge wĭ mĕ jem.
-WS28	Jem moun ä ʃock Beerneweerk driwwe.
-WS29	Üs Beerge ʃenn ä ganz (bĕiʃti) huch, jernge ʃenn vaale huger.
-WS30	Hü vaale Pünn Jʃterbiin ĕn hü vaale Brud wenn jem heewe.
-WS31	Jck verʃtoun jem ä, jem moune ĕn bettje grottemer ʃchnăke
+WS28	Jem moun ä ſock Beerneweerk driwwe.
+WS29	Üs Beerge ſenn ä ganz (bĕiſti) huch, jernge ſenn vaale huger.
+WS30	Hü vaale Pünn Jſterbiin ĕn hü vaale Brud wenn jem heewe.
+WS31	Jck verſtoun jem ä, jem moune ĕn bettje grottemer ſchnăke
 WS32	Hewe jem niin lettj Stock Siip tŏ mĭ ă minn Scheef fünn’n?
-WS33	Sann Bror wall ham tou ʃchmocke naie Hösʃenge oun jernge Tünn begge.
+WS33	Sann Bror wall ham tou ſchmocke naie Hösſenge oun jernge Tünn begge.
 WS34	Dat Word koum ham von Herten!
 WS35	Dat weer rocht von jĕ!
-WS36	Watt ʃatte der vor lettje Vägele boben ă di lettje Mürr?
-WS37	Di Bürre häin fiif Aechʃen en njüggen Kĭ en twillef lettje Schäip (bütte) vor datt Torp broocht, dĕ wäin jĕ verkuupe.
+WS36	Watt ſatte der vor lettje Vägele boben ă di lettje Mürr?
+WS37	Di Bürre häin fiif Aechſen en njüggen Kĭ en twillef lettje Schäip (bütte) vor datt Torp broocht, dĕ wäin jĕ verkuupe.
 WS38	Dat Folk es delleng all bütte a dat Fäil to hauen.
 WS39	Gong man, dii brünne Hünn deet dĭ nicks.
-WS40	Jck benn mĕ datt Folk der beeʃte auer’t Mäidloun ount Koorn keerd.
+WS40	Jck benn mĕ datt Folk der beeſte auer’t Mäidloun ount Koorn keerd.

--- a/46707_Risum.csv
+++ b/46707_Risum.csv
@@ -8,18 +8,18 @@ Transliterationsprojekt: Dissertation Temmo Bosse
 Transliterent: Temmo Bosse
 Anmerkungen: '{Buchstaben, die in der Transliteration als hochgestellt erscheinen,
   stehen im Original eigentlich über dem vorherigen Zeichen} <Anmerkung: Die Lautzeichen:
-  ǎ, å und oa sind gleichlautend, gleich dem Vokal im plattdeutschen „holz“. aͤu ist
+  ă, å und oa sind gleichlautend, gleich dem Vokal im plattdeutschen „holz“. aͤu ist
   ein Laut zwischen „eu“ und aŭ. „ou“ klingt wenig dunkler als das deutsche „au“
 
   ˘ bezeichnet die Kürze, - die Länge.>'
 ...
 WS01	Ö̆nj n’ wunter fliee dă dröge bleese ö nj n’ lŭft ămbei.
-WS02	Et hǎlt glĭk ăp mă schneien, dăn wǎrd et wäder wĭder bäder.
-WS03	Fu kōle ö nj n‘ kǎflaͤun, dat et mŭlke ball an tŭ kogen fǎngt.
+WS02	Et hălt glĭk ăp mă schneien, dăn wărd et wäder wĭder bäder.
+WS03	Fu kōle ö nj n‘ kăflaͤun, dat et mŭlke ball an tŭ kogen făngt.
 WS04	Di gaͤeue üle mŭn as ma de hănjst dör’t ĭs brägen en ö nj dat kaͤul wader félen.
 WS05	Hi as vor fjaͤur oder seks wă̄ge stö rwen.
-WS06	Et īlj wǎs ălte hījt, dă kage săn unner swă̄sen.
-WS07	Hi et dă aje altens one sǎlt en pă̄wer.
+WS06	Et īlj wăs ălte hījt, dă kage săn unner swă̄sen.
+WS07	Hi et dă aje altens one sălt en pă̄wer.
 WS08	Dă fētj due mĕ sǔ sīr, ĭk līw ĭk häv’s ră läm.
 WS09	Ĭk băn bei jü wü f wän, ik häw’t hă seijt, jü sä, jü wĕljt ŏk tŭ ha dogder sēde.
 WS10	Ĭk wăl’t ŏk ēy widder dön.

--- a/46748_Utersum.csv
+++ b/46748_Utersum.csv
@@ -15,7 +15,7 @@ WS02	Ät ſkǟs̃t gelik ütj to ſneien, daa wāārt ät Wädder wäller bēder
 WS03	Smitj Kȫlen īn ūn ä Āānk, dat ä Māālk bal̃ bigañt to kȫgin.
 WS04	Di gud ūäl Mān as me ä Hingst īnbrēgen ūn’t Js an īnfēlen ūn’t kul Wēder.
 WS05	Hi as ſtürwen fȫr fjauer of ſēx Weg.
-WS06	Ät J̄äl̃ wīär alter hīät, ä Kūken ſan jaa onner hīäl̃t’nel {Undeutlich. Wahrscheinlich ist sinngemäß etwas wie das moderne hialandaal gemeint.} ſūärt brāñd.
+WS06	Ät j̅äl̃ wīär alter hīät, ä Kūken ſan jaa onner hīäl̃t’nel {Undeutlich. Wahrscheinlich ist sinngemäß etwas wie das moderne hialandaal gemeint.} ſūärt brāñd.
 WS07	Hi at ä Aier lēwen ſanner Sāl̃t än Pöbber.
 WS08	Ä Fet du mi ünwis ſīär, ik līäw, ik ha jaa trogleppen.
 WS09	Jk ſan bi jü Wüf wēſen an hā’t hör ſaid, an jü ſād, jü wul̃ ät uk hör Dāāgter ſai.

--- a/46749_Oldsum.csv
+++ b/46749_Oldsum.csv
@@ -44,7 +44,7 @@ WS33	San Bruller wal ham tau net nei Hüſſeng ūn jammens Guard bag.
 WS34	Det Wurd kām ham vān Harten.
 WS35	Det wiar rocht fan jo.
 WS36	Wat ſat diar för en Vöggelken bowen [ū]b {Auch hier ist wohl ǖb gemeint.} a letj Mǖr.
-WS37	A Bü̅ren hed fīw Okſen an njügen Ki an twālew letj Schep fört Tarep brāācht, dönnen wul jo ferkupe.
+WS37	A Bǖren hed fīw Okſen an njügen Ki an twālew letj Schep fört Tarep brāācht, dönnen wul jo ferkupe.
 WS38	A Lidj ſan daleng altmāl bütjen ǖb Fial an hau.
 WS39	Gung man, a brün Hünj dä di nant - <(niks)>
 WS40	Ik ſan me a Lidj diar beft auer a Miad ūnt Kurn kērd

--- a/46751_Borgsum.csv
+++ b/46751_Borgsum.csv
@@ -34,13 +34,13 @@ WS23	Wi sann träd an ha Tast.
 WS24	Üs wi Jistrinn {In einer anderen Farbe ist das Wort zu Jistrīn korrigiert.} tüs kam, do lai dö ödern al üb Bad en wir fäst un äh Sliep.
 WS25	Äh Snee as jü Nacht bi üs leien blĕwen aber jü Maren as’t abtouid
 WS26	Bäft ǖs Hüs stun trie nett Apelbumer meh roud Apler.
-WS27	Könn jam̅ noch eg en letj Ugenblack efter ü s tēw dann gung wi meh jamm
-WS28	Jam̅ mut eg sock Jongenskrom driew.
+WS27	Könn jam̄ noch eg en letj Ugenblack efter ü s tēw dann gung wi meh jamm
+WS28	Jam̄ mut eg sock Jongenskrom driew.
 WS29	Ussens {Wahrscheinlich ist Üssens gemeint.} Berger san eg so huch, jamensen san föll huger.
 WS30	Hü föll Pünj Maregs en hü föll Bruad well jamm ha.
-WS31	Ick verstunn jam̅ eg jamm mut en betj gratem̅er snaake.
-WS32	Ha jam̅ mien Stack witj Siap för mi ǖb măn Bōsel fünjen.
-WS33	San Brud er wall ham̅ taw nett nei Hüssing un jaw Guard băg
+WS31	Ick verstunn jam̄ eg jamm mut en betj gratem̄er snaake.
+WS32	Ha jam̄ mien Stack witj Siap för mi ǖb măn Bōsel fünjen.
+WS33	San Brud er wall ham̄ taw nett nei Hüssing un jaw Guard băg
 WS34	Et Wurd kam hăm fān Harten.
 WS35	Det wir rocht fan jăr
 WS36	Watt satt dier för Vögler boven üb äh Mür.

--- a/46754_Midlum.csv
+++ b/46754_Midlum.csv
@@ -14,7 +14,7 @@ WS02	Hát hǟlt gelik ap tú ſchneien, dann wordt ä̆́t Wedder weller bēder.
 WS03	Dū Köhlen ūn á Onk, dát ét Mōlk bál tú kȫgin bigant.
 WS04	Dí gūd ūal Mān ás mé ä̆́ Hingſt tróch’t J́s brēgen, en ūn et kull Wēder fǟlen.
 WS05	Hí ás vȫr vjáwer of sǟks Weg ſtǘrwen.
-WS06	Ét <(NB J iſt ein Vokal)> J̄él wīér tú hīét, ä̆́ Kúken ſán jó onner gánß ſūárt brānd.
+WS06	Ét <(NB J iſt ein Vokal)> j̅él wīér tú hīét, ä̆́ Kúken ſán jó onner gánß ſūárt brānd.
 WS07	Hí át á Aier allēwen ſanner Sālt en Pöbber.
 WS08	Á Fét dú mí fālég ſīér, ik līáv, ik hā’s troch leppen.
 WS09	Jk ſán bí jǘ Wüff weſen, én ha’t hér ſád, én jǘ ſād, jǘ wull’t úk hér Dōchter ſai.

--- a/46755_Oevenum-Föhr.csv
+++ b/46755_Oevenum-Föhr.csv
@@ -36,7 +36,7 @@ WS23	Wih ſann trät an ha Taſtj.
 WS24	As wi göſtern Abend torüg kämen, da legen de Andern all int Bett un waren int ſlapen.
 WS25	Ah Schneh as [disſe] {Der ganze Satz ist wegen Beschädigung beeinträchtigt, aber nur dieses Wort bleibt dabei spekulativ.} Nacht bi üs leihen blewwen, man marleng ſchmolten.
 WS26	Achter uns Huus ſtahn dre ſmukke klene Appelbȫm meh rode klene Appeln.
-WS27	Kön Jam noch eg an lett Ugenblack ü̅b üs tew, dann gung wi meh jam.
+WS27	Kön Jam noch eg an lett Ugenblack ǖb üs tew, dann gung wi meh jam.
 WS28	I ſch ſkölt nich ſo’n Kinderien driewen
 WS29	Üs Bergen ſann eg ſīr hūch, jammenſen ſann hūger
 WS30	Wo vēl Pund Worſt un wo vēl Brod wullt I hebben?

--- a/46763_Nord-Ockholm.csv
+++ b/46763_Nord-Ockholm.csv
@@ -14,7 +14,7 @@ WS02	Datt halt glick ap to sneien, denn wardt datt wäer wi bäer
 WS03	Duhn stienkohle a³une kachlumm, datt de molke ball a³unfanget to kogen
 WS04	Die ga³ue uhle mon es mer san hengst dör datt iss brägen en es a³un datt ka³[u]l waer fehlen.
 WS05	Hie es for fiouer oder sėx {Es ist nicht ganz klar, ob der Punkt über dem Wort beabsichtigt oder wie er gemeint ist.} wäge störwen
-WS06	Datt iehl was to hiet, de kage senn je⁴ ûnner {Das Zeichen über dem u nicht ganz klar, möglicherweise handelt es sich auch um eine missglückte Umlautmarkierung.}  ganz suhrt b[ȧ]rnt.
+WS06	Datt iehl was to hiet, de kage senn je⁴ ûnner {Das Zeichen über dem u nicht ganz klar, möglicherweise handelt es sich auch um eine missglückte Umlautmarkierung.}  ganz suhrt b[å]rnt.
 WS07	Hie et de⁴ aje jümmer ohne soldt en perwer.
 WS08	De fejt duhne mi ordie sier, ick liew, ick hävs dörläb’m
 WS09	Jck benn bei je² {Die Zahl ist offenbar von 4 zu 2 korrigiert.} wüff wähn en häw’d her sajt, ennje² sä, je² wäjlt datt her dochder säje.

--- a/47776_Rendsburg.csv
+++ b/47776_Rendsburg.csv
@@ -6,7 +6,7 @@ Bogentyp: NMD_1879/80
 Erhebung: ''
 Transliterationsprojekt: REDE
 Transliterent: Philipp Spang
-Anmerkungen: '<Erklärung der Zeichen:  ̆ = Schärfung ¯ = Dehnung [bei ä,ö,ü steht
+Anmerkungen: '<Erklärung der Zeichen: ̆ = Schärfung ¯ = Dehnung [bei ä,ö,ü steht
   das Dehnungszeichen aus darstellungstechnischen Gründen unterhalb der Umlautpunkte
   PS]  äö = zwischen ä und ö gesprochen.>'
 ...

--- a/47776_Rendsburg.csv
+++ b/47776_Rendsburg.csv
@@ -15,7 +15,7 @@ WS02	Dăt hö̆lt gliek ŏb tō schnien, denn ward dăt Werrer werrer bā̈der.
 WS03	Lĕg <(Dō)> Käöhln in’n Afm, dăt dē Melk bald anfangt tō kāk’n.
 WS04	Dē gōde ohln Mann is mit dăt Perd dörch’t Īs brāk’n und nā dăt kōhln Wāter rinne fulln.
 WS05	Hē ĭs väör veer oder sö̆s Wochen dōt blā̈m.
-WS06	Dăt fṻr wēer tō hitt, dē Kōk’n sünd ja unner ganz swart brennt.
+WS06	Dăt fǖr wēer tō hitt, dē Kōk’n sünd ja unner ganz swart brennt.
 WS07	Hē itt dē Eier ümmer ahn Salt und Pā̈per.
 WS08	Dē Fō̈t dōt mi banni <(hellisch)> weh, ick glōf, ick heff sē twei <(dörch)> lōb’n.
 WS09	Ick bünn bī dē Frū wĕßt  ŭn heff ähr dăt sĕgt, ŭn sē sā̈, sē wull ähr Dochder dăt ock seng.
@@ -24,7 +24,7 @@ WS11	Ick schlag dĭ gliek mit denn Schleef um dē Ohrn, du Aab.
 WS12	Wo geihs du hin, sü̆lt wĭ mit di gahn?
 WS13	Dăt sünd schlechte Tied’n!
 WS14	Mīn lēwes Kind, bliev hier unner stahn, dē bösen Gō̈s biet di dodt.
-WS15	Du hĕs hṻt am mehrsten lehrt ŭn bü̆ß ārti wēsen, du dörfst fröher nā huß gahn ăs de Annern.
+WS15	Du hĕs hǖt am mehrsten lehrt ŭn bü̆ß ārti wēsen, du dörfst fröher nā huß gahn ăs de Annern.
 WS16	Du bü̆ß nā nĭ grōt nŭg, dăt du’n Boddel Wien utdrink’n kanns, du muß ērs noch’n Enn wass’n un grō̈der wărn.
 WS17	Gah hin, sī so gut ŭn segg dīn Schwester, sē soll dē Klēder for fäör dien Mudder ferdi neihn ŭn mit dē Börs rein māk’n.
 WS18	Hărs du ĕm kennt! Denn wēer dăt anners kam, un dăt stünn bā̈der ŭm ĕm.
@@ -34,7 +34,7 @@ WS21	Wōăn hett hē dē nie Geschich vertellt?
 WS22	Man mutt lūt schrien, <([p]rahl’n)> sŏns versteiht hē uns ni.
 WS23	Wi sund mō̈d ŭn hemm Dö̆rs.
 WS24	Ăs wi güßern Abend torüch kēm, dō lēgen dē Annern all in’t Bett ŭn schlēb’n ganz făß.
-WS25	Dē Schnee ĭs äöwer Nach bī uns ling’n blew blā̈m, āwer hṻt Morgen ĭs hē schmö̆lt.
+WS25	Dē Schnee ĭs äöwer Nach bī uns ling’n blew blā̈m, āwer hǖt Morgen ĭs hē schmö̆lt.
 WS26	Achter uns Huß staht dree lüdde schöne Abbelböhm mit lüdde rōde Abbeln.
 WS27	Könnt jā̈ nĭ noch’n lüdd’n Ogenblick ŏb uns tō̈b’n denn gaht wĭ mit ju.
 WS28	Jü dörft ni sŏ‘n Kinnerkram drieb’n.
@@ -42,11 +42,11 @@ WS29	Unse Barg’n sind nĭ ganz hoch, ju sind vā̈l höger.
 WS30	Wievā̈l Pfund Wŭß  ŭn wievā̈l Brod wöllt ju hemm?
 WS31	Ick verstah jü nĭ, jü mödd’n bā̈t’n lūder sprā̈ken’n.
 WS32	Hĕbt jü mih’n lüdd Stück widde Seep fā̈r mĭk ŏb mīn Disch funn?
-WS33	Sien Brōder will twē schöne nüe Hṻser in ju Gaarn buhn.
+WS33	Sien Brōder will twē schöne nüe Hǖser in ju Gaarn buhn.
 WS34	Dat Wōrd kēm ĕm von Hard’n.
 WS35	Dăt wēr recht von sē.
 WS36	Wăt sitt dār fäör lüdde Vageln bāb’m ob de lüdd Muer.
 WS37	Dē Buern harn fief Oss’n ŭn nā̈g’n Köh un twölf lüdde Schāp vor väör dat Dörp broā̈ch, de woll’n se verkōp’n.
-WS38	Dē Lüd sind hṻt all būt’n ob dă feld un meiht.
+WS38	Dē Lüd sind hǖt all būt’n ob dă feld un meiht.
 WS39	Gah man, de brune Hund deiht di nix.
 WS40	Ick bin mit de Lüd dar achter äöwer de Wisch int Kōrn fahrn.

--- a/47776_Rendsburg.csv
+++ b/47776_Rendsburg.csv
@@ -10,15 +10,15 @@ Anmerkungen: '<Erklärung der Zeichen:  ̆ = Schärfung ¯ = Dehnung [bei ä,ö,
   das Dehnungszeichen aus darstellungstechnischen Gründen unterhalb der Umlautpunkte
   PS]  äö = zwischen ä und ö gesprochen.>'
 ...
-WS01	In Winder flēg’n de drō̈g’n Blā̈der in dē Lŭf rŭm.
-WS02	Dăt hö̆lt gliek ŏb tō schnien, denn ward dăt Werrer werrer bā̈der.
+WS01	In Winder flēg’n de drō̈g’n Blǟder in dē Lŭf rŭm.
+WS02	Dăt hö̆lt gliek ŏb tō schnien, denn ward dăt Werrer werrer bǟder.
 WS03	Lĕg <(Dō)> Käöhln in’n Afm, dăt dē Melk bald anfangt tō kāk’n.
 WS04	Dē gōde ohln Mann is mit dăt Perd dörch’t Īs brāk’n und nā dăt kōhln Wāter rinne fulln.
-WS05	Hē ĭs väör veer oder sö̆s Wochen dōt blā̈m.
+WS05	Hē ĭs väör veer oder sö̆s Wochen dōt blǟm.
 WS06	Dăt fǖr wēer tō hitt, dē Kōk’n sünd ja unner ganz swart brennt.
-WS07	Hē itt dē Eier ümmer ahn Salt und Pā̈per.
+WS07	Hē itt dē Eier ümmer ahn Salt und Pǟper.
 WS08	Dē Fō̈t dōt mi banni <(hellisch)> weh, ick glōf, ick heff sē twei <(dörch)> lōb’n.
-WS09	Ick bünn bī dē Frū wĕßt  ŭn heff ähr dăt sĕgt, ŭn sē sā̈, sē wull ähr Dochder dăt ock seng.
+WS09	Ick bünn bī dē Frū wĕßt  ŭn heff ähr dăt sĕgt, ŭn sē sǟ, sē wull ähr Dochder dăt ock seng.
 WS10	Ick will dăt ock nĭ werrer dohn.
 WS11	Ick schlag dĭ gliek mit denn Schleef um dē Ohrn, du Aab.
 WS12	Wo geihs du hin, sü̆lt wĭ mit di gahn?
@@ -27,26 +27,26 @@ WS14	Mīn lēwes Kind, bliev hier unner stahn, dē bösen Gō̈s biet di dodt.
 WS15	Du hĕs hǖt am mehrsten lehrt ŭn bü̆ß ārti wēsen, du dörfst fröher nā huß gahn ăs de Annern.
 WS16	Du bü̆ß nā nĭ grōt nŭg, dăt du’n Boddel Wien utdrink’n kanns, du muß ērs noch’n Enn wass’n un grō̈der wărn.
 WS17	Gah hin, sī so gut ŭn segg dīn Schwester, sē soll dē Klēder for fäör dien Mudder ferdi neihn ŭn mit dē Börs rein māk’n.
-WS18	Hărs du ĕm kennt! Denn wēer dăt anners kam, un dăt stünn bā̈der ŭm ĕm.
+WS18	Hărs du ĕm kennt! Denn wēer dăt anners kam, un dăt stünn bǟder ŭm ĕm.
 WS19	Wer hett mien Kārf mit Fleesch wegstahl’n?
 WS20	Hē deh <(beer)> so, as als wenn se ĕm to’n Dö̆schen bestellt hărn; se hebt dăt aber selbst dahn.
 WS21	Wōăn hett hē dē nie Geschich vertellt?
 WS22	Man mutt lūt schrien, <([p]rahl’n)> sŏns versteiht hē uns ni.
 WS23	Wi sund mō̈d ŭn hemm Dö̆rs.
 WS24	Ăs wi güßern Abend torüch kēm, dō lēgen dē Annern all in’t Bett ŭn schlēb’n ganz făß.
-WS25	Dē Schnee ĭs äöwer Nach bī uns ling’n blew blā̈m, āwer hǖt Morgen ĭs hē schmö̆lt.
+WS25	Dē Schnee ĭs äöwer Nach bī uns ling’n blew blǟm, āwer hǖt Morgen ĭs hē schmö̆lt.
 WS26	Achter uns Huß staht dree lüdde schöne Abbelböhm mit lüdde rōde Abbeln.
-WS27	Könnt jā̈ nĭ noch’n lüdd’n Ogenblick ŏb uns tō̈b’n denn gaht wĭ mit ju.
+WS27	Könnt jǟ nĭ noch’n lüdd’n Ogenblick ŏb uns tō̈b’n denn gaht wĭ mit ju.
 WS28	Jü dörft ni sŏ‘n Kinnerkram drieb’n.
-WS29	Unse Barg’n sind nĭ ganz hoch, ju sind vā̈l höger.
-WS30	Wievā̈l Pfund Wŭß  ŭn wievā̈l Brod wöllt ju hemm?
-WS31	Ick verstah jü nĭ, jü mödd’n bā̈t’n lūder sprā̈ken’n.
-WS32	Hĕbt jü mih’n lüdd Stück widde Seep fā̈r mĭk ŏb mīn Disch funn?
+WS29	Unse Barg’n sind nĭ ganz hoch, ju sind vǟl höger.
+WS30	Wievǟl Pfund Wŭß  ŭn wievǟl Brod wöllt ju hemm?
+WS31	Ick verstah jü nĭ, jü mödd’n bǟt’n lūder sprǟken’n.
+WS32	Hĕbt jü mih’n lüdd Stück widde Seep fǟr mĭk ŏb mīn Disch funn?
 WS33	Sien Brōder will twē schöne nüe Hǖser in ju Gaarn buhn.
 WS34	Dat Wōrd kēm ĕm von Hard’n.
 WS35	Dăt wēr recht von sē.
 WS36	Wăt sitt dār fäör lüdde Vageln bāb’m ob de lüdd Muer.
-WS37	Dē Buern harn fief Oss’n ŭn nā̈g’n Köh un twölf lüdde Schāp vor väör dat Dörp broā̈ch, de woll’n se verkōp’n.
+WS37	Dē Buern harn fief Oss’n ŭn nǟg’n Köh un twölf lüdde Schāp vor väör dat Dörp broǟch, de woll’n se verkōp’n.
 WS38	Dē Lüd sind hǖt all būt’n ob dă feld un meiht.
 WS39	Gah man, de brune Hund deiht di nix.
 WS40	Ick bin mit de Lüd dar achter äöwer de Wisch int Kōrn fahrn.

--- a/47862_Helgoland.csv
+++ b/47862_Helgoland.csv
@@ -16,7 +16,7 @@ WS03	Dǒ̆́ Kēl ūne Ōwen, dat dēt Mòlk bāl tŏ̀kkḗken ūnfàŋet.
 WS04	De gŏ̆́/ ṓl Mànn e ̀s mè / ſsīn He ̆́ŋs däärt eös brḗken en ūn et kūl Wḗter fŏ̀ln
 WS05	He ̆́ e ̀s vȫr stjūr ŏ̆́dder ſsȍss We ̀cken stęö rre̯wen. {Hier wird nicht deutlich, zu welchem Zeichen das Breve gehören soll. Hier wurde es dem hochgestellten ö zugeordnet, das eigentlich über dem ę steht.}
 WS06	De I̯ā̀l we ̆́ar tŏ̀ stārk, de Kucken ßsen ȍnner hḗl ſswāt vörbā̀(r)nt.
-WS07	Hé ätt de Āїer öemmer ſsöenner Ssôlt e ̀n Pö ppe(r).
+WS07	Hé ätt de Āïer öemmer ſsöenner Ssôlt e ̀n Pö ppe(r).
 WS08	De Fóttn dŏ̆́mme sḗa, èk lḗw, èk hò djàm dēērlöͥeppm.
 WS09	Ek bèn be ̆́rre Wüöe,iff wḗⁱñ èn {Dieses i ist tatsächlich lediglich hochgestellt und nicht über dem ü notiert.} hò höₑret sṓit èn dje ſsṓit, dje wull heörrem Fṓmel et ŏ̆́ck sṓi
 WS10	Ek wèllet ŏ̆́ck gṑr niwwḗr dŏ̆́/.

--- a/47862_Helgoland.csv
+++ b/47862_Helgoland.csv
@@ -26,7 +26,7 @@ WS13	Dēt ſse ̀n ſsle ̀ch Tĭnn.
 WS14	Mīn gŏ̆́ kkinn, blīw hēar ȍnne(r) stŏ̆́nn, de bĕ̆́östek Gūs bĕ̆́t de dōă.
 WS15	De hàs dòllóng am mḗas’n lēa(r)t ĕ̀n bĕ̀s ṓrtĕ/ wḗñ, de dö s ĕ̀dderer hĕ̆́nt‘ hoüĕⁱs {Unter dem Wort steht noch etwas, das nicht zu entziffern und möglicherweise ausgestrichen ist.} góng alse ūrn.
 WS16	De bès nònnĭ/ grṓttenŏ̀(χ) tò en bō rel Wīn eöĭütttodrinken, de mŏ̆́s jā̀s wṓks ĕ̀n grṓter wö /.
-WS17	Góng, wḗs so gŏ̆́/ e ̀n sṓi dīn sȍste(r), dje skŭl de Klḗtn fȫr djȅr Mḕm klṑ(r) sāi e ̀n djam me ̀m Bòssel rīn mṓke.
+WS17	Góng, wḗs so gŏ̆́/ e ̀n sṓi dīn sȍste(r), dje skŭl de Klḗtn fȫr djër Mḕm klṑ(r) sāi e ̀n djam me ̀m Bòssel rīn mṓke.
 WS18	Héste hèm kī, dan herret ūster wḗñ ĕ̀n dēt wḗar bḗter ŏ̆́m hĕ̀m stónn.
 WS19	Wèlk hàt mīn Köerro mĕ̀f͡ Flḗsk stṓln.
 WS20	Hè dāit so, als hḗ djà hèm tòm drösken bestellt, djà hṑret ṓber sàllo döé̮ñ.

--- a/47862_Helgoland.csv
+++ b/47862_Helgoland.csv
@@ -28,7 +28,7 @@ WS15	De hàs dòllóng am mḗas’n lēa(r)t ĕ̀n bĕ̀s ṓrtĕ/ wḗñ, de d
 WS16	De bès nònnĭ/ grṓttenŏ̀(χ) tò en bō rel Wīn eöĭütttodrinken, de mŏ̆́s jā̀s wṓks ĕ̀n grṓter wö /.
 WS17	Góng, wḗs so gŏ̆́/ e ̀n sṓi dīn sȍste(r), dje skŭl de Klḗtn fȫr djȅr Mḕm klṑ(r) sāi e ̀n djam me ̀m Bòssel rīn mṓke.
 WS18	Héste hèm kī, dan herret ūster wḗñ ĕ̀n dēt wḗar bḗter ŏ̆́m hĕ̀m stónn.
-WS19	Wèlk hàt mīn Köerro mĕ̀f͜ Flḗsk stṓln.
+WS19	Wèlk hàt mīn Köerro mĕ̀f͡ Flḗsk stṓln.
 WS20	Hè dāit so, als hḗ djà hèm tòm drösken bestellt, djà hṑret ṓber sàllo döé̮ñ.
 WS21	Wèlk hàtte de nāi Geśχichte vööēēr {Die beiden ē stehen eigentlich über den beiden ö.} snakket?
 WS22	We mot dix² skrik, sonst hēarte ĕ̆́s ni ̆́/.

--- a/47862_Helgoland.csv
+++ b/47862_Helgoland.csv
@@ -33,7 +33,7 @@ WS20	Hè dāit so, als hḗ djà hèm tòm drösken bestellt, djà hṑret ṓbe
 WS21	Wèlk hàtte de nāi Geśχichte vööēēr {Die beiden ē stehen eigentlich über den beiden ö.} snakket?
 WS22	We mot dix² skrik, sonst hēarte ĕ̆́s ni ̆́/.
 WS23	We sĕ̀n mḗ ĕ̆́n hṑ tȍ è}s(t).
-WS24	Als we djisterĭ̆́n hent‘ hüöss kö m, dò lṓi de ūrn āl ūm Bā̀(r) ĕ̀n wēar fȁss ūn ślöͥeppm.
+WS24	Als we djisterĭ̆́n hent‘ hüöss kö m, dò lṓi de ūrn āl ūm Bā̀(r) ĕ̀n wēar fäss ūn ślöͥeppm.
 WS25	Dētͥ Snĕ̆́/ e ̀s dehīr Nṓch bĕ ĕ̆́s lāin bleöwwen, ṓber dje Mṑ(i)n ès dēt ſsmòltet
 WS26	Bḗf ī hü ö ss stónn trē Ōpelbóamen me/ rṓa Ṓpele.
 WS27	Kàn djem nĭ en Ōgenblĕ̆́ck īp ĕ̆́s tḗu̯, dàn góng we mĕ̀ddjém

--- a/47862_Helgoland.csv
+++ b/47862_Helgoland.csv
@@ -10,35 +10,35 @@ Anmerkungen: '{Das Helgoländer Formular ist eines der beiden nachträglich von 
   in direkter Befragung aufgenommenen Exemplare.} </ = ſcharf abgebrochene Kürze
   −̆́ geſchloſſen, −  offen>'
 ...
-WS01	Ūn de Wónte(r) fle ̆́dde drī Blḗn ūnne lŏ̀ch ŏ̆́mbe ̆́/
+WS01	Ūn de Wónte(r) flĕ́dde drī Blḗn ūnne lŏ̀ch ŏ̆́mbĕ́/
 WS02	Dēt hēat bāl å p to ſsnāin, dan wà ttēt Wèdde(r) wḗr bḗter
 WS03	Dŏ̆́ Kēl ūne Ōwen, dat dēt Mòlk bāl tŏ̀kkḗken ūnfàŋet.
-WS04	De gŏ̆́/ ṓl Mànn e ̀s mè / ſsīn He ̆́ŋs däärt eös brḗken en ūn et kūl Wḗter fŏ̀ln
-WS05	He ̆́ e ̀s vȫr stjūr ŏ̆́dder ſsȍss We ̀cken stęö rre̯wen. {Hier wird nicht deutlich, zu welchem Zeichen das Breve gehören soll. Hier wurde es dem hochgestellten ö zugeordnet, das eigentlich über dem ę steht.}
-WS06	De I̯ā̀l we ̆́ar tŏ̀ stārk, de Kucken ßsen ȍnner hḗl ſswāt vörbā̀(r)nt.
-WS07	Hé ätt de Āïer öemmer ſsöenner Ssôlt e ̀n Pö ppe(r).
+WS04	De gŏ̆́/ ṓl Mànn ès mè / ſsīn Hĕ́ŋs däärt eös brḗken en ūn et kūl Wḗter fŏ̀ln
+WS05	Hĕ́ ès vȫr stjūr ŏ̆́dder ſsöss Wècken stęö rre̯wen. {Hier wird nicht deutlich, zu welchem Zeichen das Breve gehören soll. Hier wurde es dem hochgestellten ö zugeordnet, das eigentlich über dem ę steht.}
+WS06	De I̯ā̀l wĕ́ar tŏ̀ stārk, de Kucken ßsen önner hḗl ſswāt vörbā̀(r)nt.
+WS07	Hé ätt de Āïer öemmer ſsöenner Ssôlt èn Pö ppe(r).
 WS08	De Fóttn dŏ̆́mme sḗa, èk lḗw, èk hò djàm dēērlöͥeppm.
-WS09	Ek bèn be ̆́rre Wüöe,iff wḗⁱñ èn {Dieses i ist tatsächlich lediglich hochgestellt und nicht über dem ü notiert.} hò höₑret sṓit èn dje ſsṓit, dje wull heörrem Fṓmel et ŏ̆́ck sṓi
+WS09	Ek bèn bĕ́rre Wüöe,iff wḗⁱñ èn {Dieses i ist tatsächlich lediglich hochgestellt und nicht über dem ü notiert.} hò höₑret sṓit èn dje ſsṓit, dje wull heörrem Fṓmel et ŏ̆́ck sṓi
 WS10	Ek wèllet ŏ̆́ck gṑr niwwḗr dŏ̆́/.
-WS11	Ek ſslṓ de me ̆́jāns mèrre Lḗpel ŏ̆́mme Wā̀rn, dĕ̆́ Ṓp.
-WS12	Wéăr góŋste he ̀n, skèlwe mèddĕ góŋ?
-WS13	Dēt ſse ̀n ſsle ̀ch Tĭnn.
-WS14	Mīn gŏ̆́ kkinn, blīw hēar ȍnne(r) stŏ̆́nn, de bĕ̆́östek Gūs bĕ̆́t de dōă.
+WS11	Ek ſslṓ de mĕ́jāns mèrre Lḗpel ŏ̆́mme Wā̀rn, dĕ̆́ Ṓp.
+WS12	Wéăr góŋste hèn, skèlwe mèddĕ góŋ?
+WS13	Dēt ſsèn ſslèch Tĭnn.
+WS14	Mīn gŏ̆́ kkinn, blīw hēar önne(r) stŏ̆́nn, de bĕ̆́östek Gūs bĕ̆́t de dōă.
 WS15	De hàs dòllóng am mḗas’n lēa(r)t ĕ̀n bĕ̀s ṓrtĕ/ wḗñ, de dö s ĕ̀dderer hĕ̆́nt‘ hoüĕⁱs {Unter dem Wort steht noch etwas, das nicht zu entziffern und möglicherweise ausgestrichen ist.} góng alse ūrn.
 WS16	De bès nònnĭ/ grṓttenŏ̀(χ) tò en bō rel Wīn eöĭütttodrinken, de mŏ̆́s jā̀s wṓks ĕ̀n grṓter wö /.
-WS17	Góng, wḗs so gŏ̆́/ e ̀n sṓi dīn sȍste(r), dje skŭl de Klḗtn fȫr djër Mḕm klṑ(r) sāi e ̀n djam me ̀m Bòssel rīn mṓke.
+WS17	Góng, wḗs so gŏ̆́/ èn sṓi dīn söste(r), dje skŭl de Klḗtn fȫr djër Mḕm klṑ(r) sāi èn djam mèm Bòssel rīn mṓke.
 WS18	Héste hèm kī, dan herret ūster wḗñ ĕ̀n dēt wḗar bḗter ŏ̆́m hĕ̀m stónn.
 WS19	Wèlk hàt mīn Köerro mĕ̀f͡ Flḗsk stṓln.
 WS20	Hè dāit so, als hḗ djà hèm tòm drösken bestellt, djà hṑret ṓber sàllo döé̮ñ.
 WS21	Wèlk hàtte de nāi Geśχichte vööēēr {Die beiden ē stehen eigentlich über den beiden ö.} snakket?
-WS22	We mot dix² skrik, sonst hēarte ĕ̆́s ni ̆́/.
-WS23	We sĕ̀n mḗ ĕ̆́n hṑ tȍ è}s(t).
+WS22	We mot dix² skrik, sonst hēarte ĕ̆́s nĭ́/.
+WS23	We sĕ̀n mḗ ĕ̆́n hṑ tö è}s(t).
 WS24	Als we djisterĭ̆́n hent‘ hüöss kö m, dò lṓi de ūrn āl ūm Bā̀(r) ĕ̀n wēar fäss ūn ślöͥeppm.
-WS25	Dētͥ Snĕ̆́/ e ̀s dehīr Nṓch bĕ ĕ̆́s lāin bleöwwen, ṓber dje Mṑ(i)n ès dēt ſsmòltet
+WS25	Dētͥ Snĕ̆́/ ès dehīr Nṓch bĕ ĕ̆́s lāin bleöwwen, ṓber dje Mṑ(i)n ès dēt ſsmòltet
 WS26	Bḗf ī hü ö ss stónn trē Ōpelbóamen me/ rṓa Ṓpele.
 WS27	Kàn djem nĭ en Ōgenblĕ̆́ck īp ĕ̆́s tḗu̯, dàn góng we mĕ̀ddjém
 WS28	Djém däönnĭ(ch) Sseök Kinne(r)spell mṓke. (drīu̯)
-WS29	Ī Berjen sèn nĭ ōrĭ/ hṓ, dje(rr)emen sèn vèȍ hṓɣe(r)
+WS29	Ī Berjen sèn nĭ ōrĭ/ hṓ, dje(rr)emen sèn vèö hṓɣe(r)
 WS30	Hå̀ vĕ̀l péön màrrĕ̆́ en hå̀vel brūͦa wèl djém hṑ
 WS31	Ik verstónn djém nĕ/, djém mŏ̆́t em bĕ̆́tjen dichter snakke.
 WS32	Hṑ djém nĭ en stéök wĭt Ssēap fōr mĕ/ īb mīn taffel fĭnn?
@@ -48,5 +48,5 @@ WS35	Dēt wēar rĕ̀ch vàn djā̀m.
 WS36	Wàt sètt dēar vöör Fénken bòppm ībpe Mī(r)?
 WS37	De būrn hḗ fiu̯ Òssen èn nēgen kĕ̆́/ en twallo skēäp vöör dēt dȫrp brŏ̀ch, de wul djà vō̈rkṓpe.
 WS38	De lĕ̆́/ (Mènsken) sèn dòllóng állemōl béüötten īpt stéck gā(r)s èn māie.
-WS39	Góng màn tŏ̀, de bre ̀öüns Hinn dāit de niks.
+WS39	Góng màn tŏ̀, de brèöüns Hinn dāit de niks.
 WS40	Ék bèn mèrre lĕ̆́ (Mènsken) dēar bḗf ōwer dēt gā̀(r)s ūn et Kòrn fö(ä)nn.

--- a/47862_Helgoland.csv
+++ b/47862_Helgoland.csv
@@ -12,7 +12,7 @@ Anmerkungen: '{Das Helgoländer Formular ist eines der beiden nachträglich von 
 ...
 WS01	Ūn de Wónte(r) fle ̆́dde drī Blḗn ūnne lŏ̀ch ŏ̆́mbe ̆́/
 WS02	Dēt hēat bāl å p to ſsnāin, dan wà ttēt Wèdde(r) wḗr bḗter
-WS03	Dǒ̆́ Kēl ūne Ōwen, dat dēt Mòlk bāl tŏ̀kkḗken ūnfàŋet.
+WS03	Dŏ̆́ Kēl ūne Ōwen, dat dēt Mòlk bāl tŏ̀kkḗken ūnfàŋet.
 WS04	De gŏ̆́/ ṓl Mànn e ̀s mè / ſsīn He ̆́ŋs däärt eös brḗken en ūn et kūl Wḗter fŏ̀ln
 WS05	He ̆́ e ̀s vȫr stjūr ŏ̆́dder ſsȍss We ̀cken stęö rre̯wen. {Hier wird nicht deutlich, zu welchem Zeichen das Breve gehören soll. Hier wurde es dem hochgestellten ö zugeordnet, das eigentlich über dem ę steht.}
 WS06	De I̯ā̀l we ̆́ar tŏ̀ stārk, de Kucken ßsen ȍnner hḗl ſswāt vörbā̀(r)nt.

--- a/50656_Demmin.csv
+++ b/50656_Demmin.csv
@@ -18,7 +18,7 @@ WS01	In’n Windă fleig’n dei drȫg’n Blära in na Luoft rü̆m.
 WS02	’t  hü͡ăt gliek tau snig’n ŭp, denn ward’t Wära werra bädă.
 WS03	Leg‘ Ko͡ahl’n in’n O͡am, dät dä Melk băl, an tau ko͡ak’n fingt.
 WS04	Dei gau’r oll Mann is mit’t Pie͡ad in’t Īs bro͡ak’n unn in’t kull Wo͡ada foll’n.
-WS05	Hei is vö͜ă vie͡ă orra söß Wochen stor’m.
+WS05	Hei is vö͡ă vie͡ă orra söß Wochen stor’m.
 WS06	Dat Fü͡ă wi͡ă tau heit, dei Kàuk’n sünd ja uonna ganz swart brennt.
 WS07	Hei ĕtt dei Eiă o͡ahn Sult un Päba.
 WS08	Dei Föut douhn mi sī͡ă wei, ick ‘lȫw, ick hä̆v’s mi dörch lōp’n.
@@ -42,7 +42,7 @@ WS25	Dei Snei is dēs‘ Nacht bi uns lig’n ble’m ö͡äwă hüt Mor’n is�
 WS26	Hinna uns’n Hūs sto͡ah’n drei schön Äppelböhm mit rohr Äppel.
 WS27	Kö͡än’n jie nich noch’n Ogenblick up uns täuw’n, denn go͡ah= wi mit jūch.
 WS28	Jī dörm‘ nich son’n Kinnarie drie’m.
-WS29	Uns‘ Barg sünd nich sih͡a hoch, jūch sünd väl höga.
+WS29	Uns‘ Barg sünd nich sih͜a hoch, jūch sünd väl höga.
 WS30	Wu͡äväl Pund Wust un wu͡äväl Brot wĭ_jī hämm’n?
 WS31	Ick vö̆sto͡ah jūch nich, jī mȫt’n bät’n lūra rĕ/är’n.
 WS32	Hämm’n jī nich’n Stück witt Seep fö̆ mi up min’n Disch fun’n?
@@ -53,4 +53,4 @@ WS36	Wat sitt’n do͡ă vö̆ Vö̆g’l bo͡ab’n up dei lüt Muă.
 WS37	Dei Būr’n har’n fief Oss’n un näg’n Käuh‘ und twelv lüt Scho͡ap vö̆ dat Därp brö̆cht, dei wull’ns vö̆kȫp’n.
 WS38	Dei Lǖr‘ sünd hǖt all but’n up’n Fĕll un meih’n.
 WS39	Gah man, dei brūn Hund deiht di nicks.
-WS40	Ick bün mit dei Lǖr do͡ă hinna ö͡äw‘ră Wisch in’t Ku͡ăn füh͡ăt.
+WS40	Ick bün mit dei Lǖr do͡ă hinna ö͡äw‘ră Wisch in’t Ku͡ăn füh͜ăt.

--- a/50656_Demmin.csv
+++ b/50656_Demmin.csv
@@ -42,7 +42,7 @@ WS25	Dei Snei is dēs‘ Nacht bi uns lig’n ble’m ö͡äwă hüt Mor’n is�
 WS26	Hinna uns’n Hūs sto͡ah’n drei schön Äppelböhm mit rohr Äppel.
 WS27	Kö͡än’n jie nich noch’n Ogenblick up uns täuw’n, denn go͡ah= wi mit jūch.
 WS28	Jī dörm‘ nich son’n Kinnarie drie’m.
-WS29	Uns‘ Barg sünd nich sih͜a hoch, jūch sünd väl höga.
+WS29	Uns‘ Barg sünd nich sih͡a hoch, jūch sünd väl höga.
 WS30	Wu͡äväl Pund Wust un wu͡äväl Brot wĭ_jī hämm’n?
 WS31	Ick vö̆sto͡ah jūch nich, jī mȫt’n bät’n lūra rĕ/är’n.
 WS32	Hämm’n jī nich’n Stück witt Seep fö̆ mi up min’n Disch fun’n?
@@ -53,4 +53,4 @@ WS36	Wat sitt’n do͡ă vö̆ Vö̆g’l bo͡ab’n up dei lüt Muă.
 WS37	Dei Būr’n har’n fief Oss’n un näg’n Käuh‘ und twelv lüt Scho͡ap vö̆ dat Därp brö̆cht, dei wull’ns vö̆kȫp’n.
 WS38	Dei Lǖr‘ sünd hǖt all but’n up’n Fĕll un meih’n.
 WS39	Gah man, dei brūn Hund deiht di nicks.
-WS40	Ick bün mit dei Lǖr do͡ă hinna ö͡äw‘ră Wisch in’t Ku͡ăn füh͜ăt.
+WS40	Ick bün mit dei Lǖr do͡ă hinna ö͡äw‘ră Wisch in’t Ku͡ăn füh͡ăt.

--- a/51186_Bergen.csv
+++ b/51186_Bergen.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: REDE
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	In’n (in den) Winte flēg’n dē drȫg’n Blär̊e dör̥ch dē Luft her̥rüm.
-WS02	Dăt hǖrt glīk up tō schnīj’n <(snīj’n)>, denn wăt dăt Wēr̊e bēte.
+WS01	In’n (in den) Winte flēg’n dē drȫg’n Bläṙe dör̥ch dē Luft her̥rüm.
+WS02	Dăt hǖrt glīk up tō schnīj’n <(snīj’n)>, denn wăt dăt Wēṙe bēte.
 WS03	Lĕg (dō) Kāōl’n in dĕn Aob’n, dat dē Mĕlk băld ăn tō kaok’n fängt <(fänkt)>.
-WS04	Dē gōr̊e olln Mann ĭs mit dat Pir̥d dör̥ch’t Īs braok’n un in dat kŏlln Wāōte fŏll’n.
-WS05	Hē ĭs vȫr vīr̥ ŏr̊e sö̆s Woch’n stor̥b’n.
+WS04	Dē gōṙe olln Mann ĭs mit dat Pir̥d dör̥ch’t Īs braok’n un in dat kŏlln Wāōte fŏll’n.
+WS05	Hē ĭs vȫr vīr̥ ŏṙe sö̆s Woch’n stor̥b’n.
 WS06	Dăt Fǖr̥ was tō hēt, dē Kōk’n sünd jō unne ganz schwar̥t <(swar̥t)> brennt.
 WS07	Hē ĕt dē Eie ümme āōne Sŏlt un Pēpe.
 WS08	Dē Fȫt dōn mī sī wē, ick glȫw, ick hĕw se dör̥ch lōpen.
-WS09	Ick bü̆n bī dē Frū wēst un hĕw ēr̥ dat segt <(secht)>, un se sǟr̊, se wĕll dat ōk ēr̥ <(ēr̥n)> Dochte seggen.
-WS10	Ick will dat ōk nich <nīr̥> wĕr̊e dōn.
+WS09	Ick bü̆n bī dē Frū wēst un hĕw ēr̥ dat segt <(secht)>, un se sǟṙ, se wĕll dat ōk ēr̥ <(ēr̥n)> Dochte seggen.
+WS10	Ick will dat ōk nich <nīr̥> wĕṙe dōn.
 WS11	Ick schlāō <(slāō)> di glīk mit dĕn Kaoklēpel ü̆m dē Ūr̥n, du Aop.
 WS12	Wur̥ gē dū hĕn, sȫll’n wī mit dī gāōn
 WS13	Dat sünd schlĭchte Tīd’n.
 WS14	Mīn lēwes kind, blīw hīr̥ unne stāon, dē bȫsen Gȫs bīt’n dī dōd.
 WS15	Du hĕß hǖt am meisten <(mīr̥sten)> līr̥t un büß ōr̥rig west, du dör̥wst īre <(eher)> naoh Hūs gāon ăs dē Annen.
 WS16	Du büß nŏch nich grōt nōg <(nōch)>, ü̆m ēne Bŭtt’l <(Flasch)> Wīn ŭttōdrink’n, du mȫst nŏch ēn Ĕnn wăss’n un grȫte wār̥d’n.
-WS17	Gāo, wes so gōd un sĕg <(sech)> dīn Schwĕste, se sŭll de Klēr̊e vȫr̥ jūje Mudde far̥rig neij’n un mit de Bö̆st rein māōk’n.
-WS18	Har̥rst du em kennt! denn wīr̥ dăt annes kāōm’n un das stünn bēte ü̆m em <(der̊ bēte stāōn)>.
+WS17	Gāo, wes so gōd un sĕg <(sech)> dīn Schwĕste, se sŭll de Klēṙe vȫr̥ jūje Mudde far̥rig neij’n un mit de Bö̆st rein māōk’n.
+WS18	Har̥rst du em kennt! denn wīr̥ dăt annes kāōm’n un das stünn bēte ü̆m em <(deṙ bēte stāōn)>.
 WS19	Wekke <(selten wer̥)> het mī mīn’n Kor̥f mit Flēsch stāol’n?
-WS20	He dēr̊ sō, as har̥r’n sē ĕm tō’t <(tō dat)> Dö̆schen bĕstellt, sē hebben dăt ȫwe süllst (sülw) dāon. 
+WS20	He dēṙ sō, as har̥r’n sē ĕm tō’t <(tō dat)> Dö̆schen bĕstellt, sē hebben dăt ȫwe süllst (sülw) dāon. 
 WS21	Wekken <(wen)> hĕt hē dē nīje Geschicht vĕtellt.
-WS22	Man mȫt lūd <(lūr̊)> schrij’n, sünst vestēt he uns <(ēn’n)> nich.
-WS23	Wī sünd mȫr̊ un hebben Döst.
-WS24	As wī gĭsten Āobend tōrü̆ch kēm’n, don <(dor̥)> lēg’n dē Annen ăll tō Ber̊ un schlēp’n fast.
+WS22	Man mȫt lūd <(lūṙ)> schrij’n, sünst vestēt he uns <(ēn’n)> nich.
+WS23	Wī sünd mȫṙ un hebben Döst.
+WS24	As wī gĭsten Āobend tōrü̆ch kēm’n, don <(dor̥)> lēg’n dē Annen ăll tō Beṙ un schlēp’n fast.
 WS25	Dē Schnē ĭs dĭsse Nacht bī uns lĭgg’n blēb’n <(blēw’n)>, ȫwe hǖt Morgen is he schmölt.
-WS26	Hinne uns’n Hūs stāon drē schöne Eppelbȫmings mit lütte rōr̊e Eppel.
+WS26	Hinne uns’n Hūs stāon drē schöne Eppelbȫmings mit lütte rōṙe Eppel.
 WS27	Kȫn’n jī nich nŏch ēn’n lütt’n Ōg’nblick up uns töben <(töw’n)>, denn gāōn mī mit juch.
 WS28	Ji dör̥b’n nich sōne Kĭnnerīen drīw’n.
 WS29	Juje Bar̥g sünd nich hoch, uns’n sünd vēl hȫje. 
 WS30	Wūr̥vēl Pund Wust un wūr̥vēl Brod will’n ji hebb’n.
-WS31	Ick vestāo juch nich, ji mȫt’n ēn bēten lūr̊e sgrēk’n.
+WS31	Ick vestāo juch nich, ji mȫt’n ēn bēten lūṙe sgrēk’n.
 WS32	Hĕbb’n ji kēn Stücking <(besser k. lüttes Stück)> witte Sēp fȫr̥ mī up minnen Disch fun’n.
-WS33	Sīn Brōr̊e will sich twē schöne nīje Hǖse in juj’n Gōr̥‘n buj’n.
+WS33	Sīn Brōṙe will sich twē schöne nīje Hǖse in juj’n Gōr̥‘n buj’n.
 WS34	Dat Wūr̥d kēm em von Har̥zen.
 WS35	Dăt was recht von ēn!
 WS36	Wăt sitt’n dŏr̥ för̥ Vöglings baob’n up de lütte Mūr̥?
 WS37	De Būr̥‘n har̥r’n fīw Ossen un nēg’n Keu <(Koi)> un twölw Schöpings <(besser lütte Schaop)> vör̥ dat Dör̥b brö̆cht, dē wull’n sē vekȫpen.
-WS38	De Lǖr̊ <(Lǖd)> sünd hǖt all būteb up dat Fĕld un meij’n.
+WS38	De Lǖṙ <(Lǖd)> sünd hǖt all būteb up dat Fĕld un meij’n.
 WS39	Gāo man, de brūne Hund det dī nicks.
-WS40	Ick bün mit de Lǖr̊ daor̥ hinn ȫwe dē Wisch in’t <(für in dat)> Kūr̥n fǖr̥t.
+WS40	Ick bün mit de Lǖṙ daor̥ hinn ȫwe dē Wisch in’t <(für in dat)> Kūr̥n fǖr̥t.

--- a/51488_Pasewalk.csv
+++ b/51488_Pasewalk.csv
@@ -25,7 +25,7 @@ WS13	’t sind schlecht Tid’n.
 WS14	Min lew Kind, bliw’ hia unna stōhn, de bös’n Gäns’ bit’n di doot.
 WS15	Du hest hüt am meist’n leat un büst artig wes’t, du darst eha no_ Hus go_hn as de Annern. 
 WS16	Du bist noch nich grot nooch, ‚n Flasch‘ Win ut to drink’n, du müßt east noch’n Enn wassenun gröta warn.
-WS17	Go_, wäs‘ so goot un seg dien Schwesta, se süll de Klera fö͜ar ju Mutta fartig näg’n un met de Böst rein mo_k’n. 
+WS17	Go_, wäs‘ so goot un seg dien Schwesta, se süll de Klera fö͡ar ju Mutta fartig näg’n un met de Böst rein mo_k’n. 
 WS18	Härrst du em kennt! Donn weer’t anners kom’n un’t deer bessa üm em sto͡ahn.
 WS19	Wer hätt mi mien’n Korv mit Fleesch sto_hl’n?
 WS20	He deer so, as härrn se em tum Doschen bestellt; se heb’n’t awer alleen do_hn. 
@@ -40,12 +40,12 @@ WS28	Ji darw’n nicht sun’n Kinnarien driw’n.
 WS29	Uns’ Barg’ sind nich sea hoch, ju sind väl höga. 
 WS30	Wo väl Pund Wost un woväl Brot wull’n ji heb’n?
 WS31	Ick vastōh ju nich, ji müd’n bät’n luda red’n. 
-WS32	Heb’n ji keen Stück’n witt Seep fö͜ar mi up mien Disch fun’n? 
+WS32	Heb’n ji keen Stück’n witt Seep fö͡ar mi up mien Disch fun’n? 
 WS33	Sien Brora will sick twe schön nieg’ Hüsa in ju’n Go͡arn bug’n. 
 WS34	Dat Wo͡art keem em von Herzen! 
 WS35	Dat was recht von ihn’n <(auch ju)>. 
 WS36	Wat sid’n do͡a fō Vōgelken bo͡ab’n up dat Mü͡ark’n. 
-WS37	De Bu͡an harn fiew Ossen un näg’n Kög’ un twölw Schōpken vö͜ar dat Dōrp brōcht, de will’n se vaköp’n. 
+WS37	De Bu͡an harn fiew Ossen un näg’n Kög’ un twölw Schōpken vö͡ar dat Dōrp brōcht, de will’n se vaköp’n. 
 WS38	De Lüd sind hüt all but’n up’t Feld un mäg’n. 
 WS39	Gō man, de brun Hund deiht die nischt. 
-WS40	Ick bin mit de Lüd’ do͡a hin’n ö͜awa d Wisch in’t Ko͡an föat.
+WS40	Ick bin mit de Lüd’ do͡a hin’n ö͡awa d Wisch in’t Ko͡an föat.

--- a/51488_Pasewalk.csv
+++ b/51488_Pasewalk.csv
@@ -12,7 +12,7 @@ Anmerkungen: <NB! „o“ u. „ö“ mit einem (-) werden hart u. breit gesproc
 WS01	Im Winta fleg’n de drög’n Blära dörch de Luft rümher <(ümher, rüm na.)>
 WS02	t hö͡at glik up to schnig’n, denn wad dat Wära werra besser <(auch: bäter)>.
 WS03	Do Kōl’n in’n Ōb’m, dat de Melk bald an to kōk’n fängt. 
-WS04	"De god’ oll Mann is mit dat Pä͜ad dörch dat Is <(das ""i"" dehnen)> bro͡ak’n un in dat kolle Wōta fall’n. "
+WS04	"De god’ oll Mann is mit dat Pä͡ad dörch dat Is <(das ""i"" dehnen)> bro͡ak’n un in dat kolle Wōta fall’n. "
 WS05	He is vör fe͡a örra söß Wochen storb’n. 
 WS06	Dat Füa was so heet, de Kok’n sind jo unna ganz schwart brennt. 
 WS07	He et de Eia ümma o͡an Solt un Päpa.

--- a/51488_Pasewalk.csv
+++ b/51488_Pasewalk.csv
@@ -12,40 +12,40 @@ Anmerkungen: <NB! „o“ u. „ö“ mit einem (-) werden hart u. breit gesproc
 WS01	Im Winta fleg’n de drög’n Blära dörch de Luft rümher <(ümher, rüm na.)>
 WS02	t hö͡at glik up to schnig’n, denn wad dat Wära werra besser <(auch: bäter)>.
 WS03	Do Kōl’n in’n Ōb’m, dat de Melk bald an to kōk’n fängt. 
-WS04	"De god’ oll Mann is mit dat Pä͜ad dörch dat Is <(das ""i"" dehnen)> bro͜ak’n un in dat kolle Wōta fall’n. "
+WS04	"De god’ oll Mann is mit dat Pä͜ad dörch dat Is <(das ""i"" dehnen)> bro͡ak’n un in dat kolle Wōta fall’n. "
 WS05	He is vör fe͜a örra söß Wochen storb’n. 
 WS06	Dat Füa was so heet, de Kok’n sind jo unna ganz schwart brennt. 
-WS07	He et de Eia ümma o͜an Solt un Päpa.
+WS07	He et de Eia ümma o͡an Solt un Päpa.
 WS08	De Fööt dohn mi sea weh, ick glöw’, ick hew se dörchloop’n.
 WS09	Ick bünn bie de Fru wes’t un hew äa segt, un se segt, se wull’t ook äa Dochta segg’n. 
 WS10	Ick will’t ook nich me͜a dohn. 
-WS11	Ick schlo͜a die glik mit’n Kōkläpel üm de Oan, du Ōp!
+WS11	Ick schlo͡a die glik mit’n Kōkläpel üm de Oan, du Ōp!
 WS12	Wo gehst Du henn, söl’n wi mit die gōhn? 
 WS13	’t sind schlecht Tid’n. 
 WS14	Min lew Kind, bliw’ hia unna stōhn, de bös’n Gäns’ bit’n di doot.
 WS15	Du hest hüt am meist’n leat un büst artig wes’t, du darst eha no_ Hus go_hn as de Annern. 
 WS16	Du bist noch nich grot nooch, ‚n Flasch‘ Win ut to drink’n, du müßt east noch’n Enn wassenun gröta warn.
 WS17	Go_, wäs‘ so goot un seg dien Schwesta, se süll de Klera fö͜ar ju Mutta fartig näg’n un met de Böst rein mo_k’n. 
-WS18	Härrst du em kennt! Donn weer’t anners kom’n un’t deer bessa üm em sto͜ahn.
+WS18	Härrst du em kennt! Donn weer’t anners kom’n un’t deer bessa üm em sto͡ahn.
 WS19	Wer hätt mi mien’n Korv mit Fleesch sto_hl’n?
 WS20	He deer so, as härrn se em tum Doschen bestellt; se heb’n’t awer alleen do_hn. 
 WS21	Wem hätt he de nieg‘ Geschicht vatellt?
 WS22	Man müt lud‘ schrieg’n, süs vasteiht he uns nich. 
 WS23	Wi sind möd‘ un heb’n Döst.
-WS24	As we gistan Ōb’nd torüg keem’n, do͜a leg’n de Annern all to Bett un wean fest an’t Schlōp’n. 
+WS24	As we gistan Ōb’nd torüg keem’n, do͡a leg’n de Annern all to Bett un wean fest an’t Schlōp’n. 
 WS25	De Schnee is dis Nacht bi uns ligg’n bläb’n, awer hüt Morg’n ist he schmollt’n. 
-WS26	Hinna uns’ Hus sto͜ahn dre schön Appelbömk’n mit rod’n Aeppelk’n. 
-WS27	Kön ji nich noch ’n Ogenblick up uns töw’n, denn go͜ahn wi mit ju. 
+WS26	Hinna uns’ Hus sto͡ahn dre schön Appelbömk’n mit rod’n Aeppelk’n. 
+WS27	Kön ji nich noch ’n Ogenblick up uns töw’n, denn go͡ahn wi mit ju. 
 WS28	Ji darw’n nicht sun’n Kinnarien driw’n. 
 WS29	Uns’ Barg’ sind nich sea hoch, ju sind väl höga. 
 WS30	Wo väl Pund Wost un woväl Brot wull’n ji heb’n?
 WS31	Ick vastōh ju nich, ji müd’n bät’n luda red’n. 
 WS32	Heb’n ji keen Stück’n witt Seep fö͜ar mi up mien Disch fun’n? 
-WS33	Sien Brora will sick twe schön nieg’ Hüsa in ju’n Go͜arn bug’n. 
-WS34	Dat Wo͜art keem em von Herzen! 
+WS33	Sien Brora will sick twe schön nieg’ Hüsa in ju’n Go͡arn bug’n. 
+WS34	Dat Wo͡art keem em von Herzen! 
 WS35	Dat was recht von ihn’n <(auch ju)>. 
-WS36	Wat sid’n do͜a fō Vōgelken bo͜ab’n up dat Mü͜ark’n. 
+WS36	Wat sid’n do͡a fō Vōgelken bo͡ab’n up dat Mü͡ark’n. 
 WS37	De Bu͡an harn fiew Ossen un näg’n Kög’ un twölw Schōpken vö͜ar dat Dōrp brōcht, de will’n se vaköp’n. 
 WS38	De Lüd sind hüt all but’n up’t Feld un mäg’n. 
 WS39	Gō man, de brun Hund deiht die nischt. 
-WS40	Ick bin mit de Lüd’ do͜a hin’n ö͜awa d Wisch in’t Ko͜an föat.
+WS40	Ick bin mit de Lüd’ do͡a hin’n ö͜awa d Wisch in’t Ko͡an föat.

--- a/51488_Pasewalk.csv
+++ b/51488_Pasewalk.csv
@@ -45,7 +45,7 @@ WS33	Sien Brora will sick twe schön nieg’ Hüsa in ju’n Go͜arn bug’n.
 WS34	Dat Wo͜art keem em von Herzen! 
 WS35	Dat was recht von ihn’n <(auch ju)>. 
 WS36	Wat sid’n do͜a fō Vōgelken bo͜ab’n up dat Mü͜ark’n. 
-WS37	De Bu͜an harn fiew Ossen un näg’n Kög’ un twölw Schōpken vö͜ar dat Dōrp brōcht, de will’n se vaköp’n. 
+WS37	De Bu͡an harn fiew Ossen un näg’n Kög’ un twölw Schōpken vö͜ar dat Dōrp brōcht, de will’n se vaköp’n. 
 WS38	De Lüd sind hüt all but’n up’t Feld un mäg’n. 
 WS39	Gō man, de brun Hund deiht die nischt. 
 WS40	Ick bin mit de Lüd’ do͜a hin’n ö͜awa d Wisch in’t Ko͜an föat.

--- a/51488_Pasewalk.csv
+++ b/51488_Pasewalk.csv
@@ -13,12 +13,12 @@ WS01	Im Winta fleg’n de drög’n Blära dörch de Luft rümher <(ümher, rüm
 WS02	t hö͡at glik up to schnig’n, denn wad dat Wära werra besser <(auch: bäter)>.
 WS03	Do Kōl’n in’n Ōb’m, dat de Melk bald an to kōk’n fängt. 
 WS04	"De god’ oll Mann is mit dat Pä͜ad dörch dat Is <(das ""i"" dehnen)> bro͡ak’n un in dat kolle Wōta fall’n. "
-WS05	He is vör fe͜a örra söß Wochen storb’n. 
+WS05	He is vör fe͡a örra söß Wochen storb’n. 
 WS06	Dat Füa was so heet, de Kok’n sind jo unna ganz schwart brennt. 
 WS07	He et de Eia ümma o͡an Solt un Päpa.
 WS08	De Fööt dohn mi sea weh, ick glöw’, ick hew se dörchloop’n.
 WS09	Ick bünn bie de Fru wes’t un hew äa segt, un se segt, se wull’t ook äa Dochta segg’n. 
-WS10	Ick will’t ook nich me͜a dohn. 
+WS10	Ick will’t ook nich me͡a dohn. 
 WS11	Ick schlo͡a die glik mit’n Kōkläpel üm de Oan, du Ōp!
 WS12	Wo gehst Du henn, söl’n wi mit die gōhn? 
 WS13	’t sind schlecht Tid’n. 

--- a/52963D_Westerland-auf-Sylt.csv
+++ b/52963D_Westerland-auf-Sylt.csv
@@ -11,11 +11,11 @@ Anmerkungen: '{Diese Dublette ist eines der beiden nachträglich von Georg Wenke
   Sylt, W.> <Als Dbl. zugelegt 1. IX 1903. {Diese Notiz ist nur sehr schwach zu lesen.}>'
 ...
 WS01	Ȍ̆m Wùnterem flȍ / de ̆́/ drü χ blḕärn (gutt) ȍ n de lŏ̀χ³t òmbĭ/.
-WS02	Hȁt ha lt dò lkenst a ̄p tȍ snīen, dȁ/ ūr (gutt) dit we ̀rer (lg) we ̀rer bēter.
+WS02	Hät ha lt dò lkenst a ̄p tȍ snīen, dä/ ūr (gutt) dit we ̀rer (lg) we ̀rer bēter.
 WS03	Lī (dȍ/) kȫln ȍn de ka χelaun, dat dit Mò lk băl tȍ kȫken bege ̀nt.
 WS04	De gŭ̀r ṑal ma n ès me ̀ dé hingst dȫr dit ĭs brḗken ȍn ȍn dit kūl wḗter fḕlen.
 WS05	he ̆́ ès fòr fjūr ŏ̀f sŏ̀ks wḗken stü ̀rwen. {Hier ist nicht eindeutig zu erkennen, ob der Gravis oder das Breve oben stehen soll oder ob das Breve sogar zum r gehört.}
-WS06	Dit jȍ l wḕr tȍ sta rk (wȁrem), dit kuck ès jŏ̀ ȍnner ga nz sūrt brònnen.
+WS06	Dit jȍ l wḕr tȍ sta rk (wärem), dit kuck ès jŏ̀ ȍnner ga nz sūrt brònnen.
 WS07	He e ̀t de eier laŋsen sȍnner sṑlt ȍn pḗper.
 WS08	De fè tt dȍ mĕ sīr, ik līw ik hṑ’s dō r lȍ ppen.
 WS09	Ik sè n bĭ de wüff wèssen ȍn hṑ’t hȫr sa r (lg) ȍn jü sa r jü wĭl’t ŭk hȫr fṑmen sī.
@@ -26,8 +26,8 @@ WS13	Ha t sèn grü ̀j³jelk {Auch hier ist nicht zu entscheiden, ob Gravis ode
 WS14	Mĭn le ̀f jù ŋen, blīf jīr ȍnner stūnen, de ā riɣ² gȍ ss bittĭ dṑar (lg)
 WS15	Dü hēst dè lliŋ ăm mīsten līrt ȍn bèst frāi wèssen, dü mŏ̆́st jè r tü s gùŋ ü s de ü rern (lg).
 WS16	Dü bè st jit è k gŭrt enò ch, òm en bò rrel (lg) wīn ü ttȍdriŋken, dü móst jè st jit wat wŭkse ȍn gŭrter ūr.
-WS17	Guŋ, wīs sȁ gŭ̀r ȍn sī dĭn sè ster, jü skè l de klṑarer fòr jū mōter klṑr sī ȍn me ̀ de bȍ stel rīn mṑké
-WS18	Ha rstü hȍ m kü r (lg), dȁ/ wḗrt ü rers {Hier wurde offenbar ein d zu einem r korrigiert.} (lg) kèmmen ȍn ha t hè r (lg) bḗter ò m hȍ m stȍnnen.
+WS17	Guŋ, wīs sä gŭ̀r ȍn sī dĭn sè ster, jü skè l de klṑarer fòr jū mōter klṑr sī ȍn me ̀ de bȍ stel rīn mṑké
+WS18	Ha rstü hȍ m kü r (lg), dä/ wḗrt ü rers {Hier wurde offenbar ein d zu einem r korrigiert.} (lg) kèmmen ȍn ha t hè r (lg) bḗter ò m hȍ m stȍnnen.
 WS19	Hò kken hḗ me ̀ mĭn kò rref me ̀ mḗt stḕlen?
 WS20	Hĕ dȍ r (lg) sa / ü s hè r ja hȍ m tȍ tḕrsken bestè llt, jă hṑ’t ṑber sa llef dȍ n.
 WS21	Hò kken hḗ he ̆́ de nī Gešĭχ²te fortè llt?
@@ -38,7 +38,7 @@ WS25	De sne ̀ ès jü năcht bi ǖs līen blè wwen, man jümḕärn ès he sm�
 WS26	Ȁ̆chter {Auch stehen Doppel-Gravis und Brevis nebeneinander.} ǖs hü s stūn trī ā̀pelbōmer me ̀ rṑar ṑbeler.
 WS27	Ke ̆́n ĭ/ jĭt èk en ṓɣ³enblè ck ü p ū̎s tḗwf, dă guŋ wü me ̀ jū.
 WS28	I mŏ̆́t è k sòkk juŋenstrēken drīf.
-WS29	U ̅̈s bȁrriɣe sè n e ̀k sa ̄ hōch, jūen se ̀n fūl hōɣ³er
+WS29	U ̅̈s bärriɣe sè n e ̀k sa ̄ hōch, jūen se ̀n fūl hōɣ³er
 WS30	Hŭr fūl pü n mā riɣ ȍn hŭrfūl brṑar wèle ĭ hṑ.
 WS31	Ik fŏrstūn jū èk, ĭ mŏ̆́t wăt en bè tken gūrtemer snakki(e)
 WS32	hṑ ĭ nīn stè k witt sīp tȍ mĭ üp mĭn stṑl fönnen? {Das Wort fönnen stand ursprünglich vor üp.}

--- a/52963D_Westerland-auf-Sylt.csv
+++ b/52963D_Westerland-auf-Sylt.csv
@@ -10,43 +10,43 @@ Anmerkungen: '{Diese Dublette ist eines der beiden nachträglich von Georg Wenke
   direkter Befragung aufgenommenen Formulare} <Aufgenommen 5. Auguſt 1889, Westerland
   Sylt, W.> <Als Dbl. zugelegt 1. IX 1903. {Diese Notiz ist nur sehr schwach zu lesen.}>'
 ...
-WS01	Ȍ̆m Wùnterem flȍ / de ̆́/ drü χ blḕärn (gutt) ȍ n de lŏ̀χ³t òmbĭ/.
-WS02	Hät ha lt dò lkenst a ̄p tȍ snīen, dä/ ūr (gutt) dit we ̀rer (lg) we ̀rer bēter.
-WS03	Lī (dȍ/) kȫln ȍn de ka χelaun, dat dit Mò lk băl tȍ kȫken bege ̀nt.
-WS04	De gŭ̀r ṑal ma n ès me ̀ dé hingst dȫr dit ĭs brḗken ȍn ȍn dit kūl wḗter fḕlen.
-WS05	he ̆́ ès fòr fjūr ŏ̀f sŏ̀ks wḗken stü ̀rwen. {Hier ist nicht eindeutig zu erkennen, ob der Gravis oder das Breve oben stehen soll oder ob das Breve sogar zum r gehört.}
-WS06	Dit jȍ l wḕr tȍ sta rk (wärem), dit kuck ès jŏ̀ ȍnner ga nz sūrt brònnen.
-WS07	He e ̀t de eier laŋsen sȍnner sṑlt ȍn pḗper.
-WS08	De fè tt dȍ mĕ sīr, ik līw ik hṑ’s dō r lȍ ppen.
-WS09	Ik sè n bĭ de wüff wèssen ȍn hṑ’t hȫr sa r (lg) ȍn jü sa r jü wĭl’t ŭk hȫr fṑmen sī.
-WS10	Ik we ̀l’t ù k èk mūar wè rer dȍ /.
-WS11	Ik slṑ dĭ mitjèns me ̀ de ̆́ kȫkskā r òm ṑrn, dü ṑp.
+WS01	Ȍ̆m Wùnterem flö / dĕ́/ drü χ blḕärn (gutt) ö n de lŏ̀χ³t òmbĭ/.
+WS02	Hät ha lt dò lkenst a ̄p tö snīen, dä/ ūr (gutt) dit wèrer (lg) wèrer bēter.
+WS03	Lī (dö/) kȫln ön de ka χelaun, dat dit Mò lk băl tö kȫken begènt.
+WS04	De gŭ̀r ṑal ma n ès mè dé hingst dȫr dit ĭs brḗken ön ön dit kūl wḗter fḕlen.
+WS05	hĕ́ ès fòr fjūr ŏ̀f sŏ̀ks wḗken stǜrwen. {Hier ist nicht eindeutig zu erkennen, ob der Gravis oder das Breve oben stehen soll oder ob das Breve sogar zum r gehört.}
+WS06	Dit jö l wḕr tö sta rk (wärem), dit kuck ès jŏ̀ önner ga nz sūrt brònnen.
+WS07	He èt de eier laŋsen sönner sṑlt ön pḗper.
+WS08	De fè tt dö mĕ sīr, ik līw ik hṑ’s dō r lö ppen.
+WS09	Ik sè n bĭ de wüff wèssen ön hṑ’t hȫr sa r (lg) ön jü sa r jü wĭl’t ŭk hȫr fṑmen sī.
+WS10	Ik wèl’t ù k èk mūar wè rer dö /.
+WS11	Ik slṑ dĭ mitjèns mè dĕ́ kȫkskā r òm ṑrn, dü ṑp.
 WS12	Hŭr ga ͡istü hè n, skèl wü mĕ dĭ gù ŋ?
-WS13	Ha t sèn grü ̀j³jelk {Auch hier ist nicht zu entscheiden, ob Gravis oder Breve oben steht.} te ̆́rn.
-WS14	Mĭn le ̀f jù ŋen, blīf jīr ȍnner stūnen, de ā riɣ² gȍ ss bittĭ dṑar (lg)
-WS15	Dü hēst dè lliŋ ăm mīsten līrt ȍn bèst frāi wèssen, dü mŏ̆́st jè r tü s gùŋ ü s de ü rern (lg).
-WS16	Dü bè st jit è k gŭrt enò ch, òm en bò rrel (lg) wīn ü ttȍdriŋken, dü móst jè st jit wat wŭkse ȍn gŭrter ūr.
-WS17	Guŋ, wīs sä gŭ̀r ȍn sī dĭn sè ster, jü skè l de klṑarer fòr jū mōter klṑr sī ȍn me ̀ de bȍ stel rīn mṑké
-WS18	Ha rstü hȍ m kü r (lg), dä/ wḗrt ü rers {Hier wurde offenbar ein d zu einem r korrigiert.} (lg) kèmmen ȍn ha t hè r (lg) bḗter ò m hȍ m stȍnnen.
-WS19	Hò kken hḗ me ̀ mĭn kò rref me ̀ mḗt stḕlen?
-WS20	Hĕ dȍ r (lg) sa / ü s hè r ja hȍ m tȍ tḕrsken bestè llt, jă hṑ’t ṑber sa llef dȍ n.
-WS21	Hò kken hḗ he ̆́ de nī Gešĭχ²te fortè llt?
+WS13	Ha t sèn grǜj³jelk {Auch hier ist nicht zu entscheiden, ob Gravis oder Breve oben steht.} tĕ́rn.
+WS14	Mĭn lèf jù ŋen, blīf jīr önner stūnen, de ā riɣ² gö ss bittĭ dṑar (lg)
+WS15	Dü hēst dè lliŋ ăm mīsten līrt ön bèst frāi wèssen, dü mŏ̆́st jè r tü s gùŋ ü s de ü rern (lg).
+WS16	Dü bè st jit è k gŭrt enò ch, òm en bò rrel (lg) wīn ü ttödriŋken, dü móst jè st jit wat wŭkse ön gŭrter ūr.
+WS17	Guŋ, wīs sä gŭ̀r ön sī dĭn sè ster, jü skè l de klṑarer fòr jū mōter klṑr sī ön mè de bö stel rīn mṑké
+WS18	Ha rstü hö m kü r (lg), dä/ wḗrt ü rers {Hier wurde offenbar ein d zu einem r korrigiert.} (lg) kèmmen ön ha t hè r (lg) bḗter ò m hö m stönnen.
+WS19	Hò kken hḗ mè mĭn kò rref mè mḗt stḕlen?
+WS20	Hĕ dö r (lg) sa / ü s hè r ja hö m tö tḕrsken bestè llt, jă hṑ’t ṑber sa llef dö n.
+WS21	Hò kken hḗ hĕ́ de nī Gešĭχ²te fortè llt?
 WS22	Ȍ̆m {Der doppelte Gravis und das Breve stehen im Original - wohl platzbedingt - nebeneinander.} mŏ̆́t gŭrtem skrīl, ǜrers (lg) forstṑnt hĕ ǖs è k.
-WS23	Wü sè n trḕt ȍn hṑ tȍ st.
-WS24	Ü̆s {Auch hier steht das Breve wohl aus Platzgründen neben den Umlautzeichen.} wü jüsteriñ tȍbḗk kā m, dă la ̄ de ü rern à ll ȍp de bḗär ȍn wḕr fa st tȍ slȍppen {Darunter steht „zugeschlafen“.} (ȍn slīp).
-WS25	De sne ̀ ès jü năcht bi ǖs līen blè wwen, man jümḕärn ès he smè lt
-WS26	Ȁ̆chter {Auch stehen Doppel-Gravis und Brevis nebeneinander.} ǖs hü s stūn trī ā̀pelbōmer me ̀ rṑar ṑbeler.
-WS27	Ke ̆́n ĭ/ jĭt èk en ṓɣ³enblè ck ü p ū̎s tḗwf, dă guŋ wü me ̀ jū.
+WS23	Wü sè n trḕt ön hṑ tö st.
+WS24	Ü̆s {Auch hier steht das Breve wohl aus Platzgründen neben den Umlautzeichen.} wü jüsteriñ töbḗk kā m, dă la ̄ de ü rern à ll öp de bḗär ön wḕr fa st tö slöppen {Darunter steht „zugeschlafen“.} (ön slīp).
+WS25	De snè ès jü năcht bi ǖs līen blè wwen, man jümḕärn ès he smè lt
+WS26	Ȁ̆chter {Auch stehen Doppel-Gravis und Brevis nebeneinander.} ǖs hü s stūn trī ā̀pelbōmer mè rṑar ṑbeler.
+WS27	Kĕ́n ĭ/ jĭt èk en ṓɣ³enblè ck ü p ū̎s tḗwf, dă guŋ wü mè jū.
 WS28	I mŏ̆́t è k sòkk juŋenstrēken drīf.
-WS29	U ̅̈s bärriɣe sè n e ̀k sa ̄ hōch, jūen se ̀n fūl hōɣ³er
-WS30	Hŭr fūl pü n mā riɣ ȍn hŭrfūl brṑar wèle ĭ hṑ.
+WS29	Ǖs bärriɣe sè n èk sa ̄ hōch, jūen sèn fūl hōɣ³er
+WS30	Hŭr fūl pü n mā riɣ ön hŭrfūl brṑar wèle ĭ hṑ.
 WS31	Ik fŏrstūn jū èk, ĭ mŏ̆́t wăt en bè tken gūrtemer snakki(e)
-WS32	hṑ ĭ nīn stè k witt sīp tȍ mĭ üp mĭn stṑl fönnen? {Das Wort fönnen stand ursprünglich vor üp.}
-WS33	Sĭn brȍ rer (lg) wèll hȍm tau da ͡ilk (nè tt) nī hǖſiŋ ȍn jū gṑart bè ch.
-WS34	Dit Ūrt (gutt) kā m hȍm fan hārten
+WS32	hṑ ĭ nīn stè k witt sīp tö mĭ üp mĭn stṑl fönnen? {Das Wort fönnen stand ursprünglich vor üp.}
+WS33	Sĭn brö rer (lg) wèll höm tau da ͡ilk (nè tt) nī hǖſiŋ ön jū gṑart bè ch.
+WS34	Dit Ūrt (gutt) kā m höm fan hārten
 WS35	Dit wè̄r rŏ̀cht făn jū.
 WS36	Wat sètt dḕr fò r fü ɣɣelkén bṓwen ü p de mǖr?
-WS37	 De būrn ha r fĭf Ausen ȍn nīɣen kinn ȍn twè llef litj shĭp fòr dit tḕrp brṑcht, da nnen will ja forkōpĭ.
-WS38	De le ̆́r sèn dèllig allta mṑl bütten üp Mărk tȍ hauen.
+WS37	 De būrn ha r fĭf Ausen ön nīɣen kinn ön twè llef litj shĭp fòr dit tḕrp brṑcht, da nnen will ja forkōpĭ.
+WS38	De lĕ́r sèn dèllig allta mṑl bütten üp Mărk tö hauen.
 WS39	Gŭŋ măn, de brü n hü n {Bei brü̆n steht im Original das Breve über den Umlautstrichen, bei hü̆n darunter.} dè̄t di niks (nŏ nt)
-WS40	Ik sèn me ̀ de lĕ́ r (lg) dēr a chter a/ur de Ĭŋe ȍn’t kūrn kȫrt.
+WS40	Ik sèn mè de lĕ́ r (lg) dēr a chter a/ur de Ĭŋe ön’t kūrn kȫrt.

--- a/52969D_Hallig-Gröde.csv
+++ b/52969D_Hallig-Gröde.csv
@@ -30,9 +30,9 @@ WS18	Häſt Du ham kaant! dann wås et öhrs kummen, en et de bēr om ham ſtön
 WS19	Hok het min Körfw med Floaſk stehlen?
 WS20	He deh ſö, es hän jo ham to teerſken beſtellt, Ju häweſt awer ſelweſt dehn.
 WS21	Hok het hi jo nei Geſkichte fortellt?
-WS22	Der mötʼem hārt tidde, örs verſtohnd hi us eh.
+WS22	Der möt’em hārt tidde, örs verſtohnd hi us eh.
 WS23	Wi ſind tråd, en häwe Torſt.
-WS24	Es wi en joſsern Ehn tobēg kummen, der lejen de Oern all to Bed, en weren faſt inʼt ſlepen.
+WS24	Es wi en joſsern Ehn tobēg kummen, der lejen de Oern all to Bed, en weren faſt in’t ſlepen.
 WS25	De Snie is ju her Nācht bei us leien blewen, awer måling is hi ſmōlten.
 WS26	Achter us Hus ſtöhne trei nette Abelboome me roude ltje Abele.
 WS27	Könn Jam eh noch en Ohm[la]k {Schwierig zu entziffern, vielleicht auch Ohmbek.} uf us tewe, den gång wi me Jam.
@@ -48,4 +48,4 @@ WS36	Wat ſadde der for litje Fugele bewen of Ju lit Mur?
 WS37	Dö Bürre hēn fiw Ochſe en niugen Ki en twelef litje Skepe ver dat Tōrp brāgt, dö wēn Jö verkuppe.
 WS38	Dat Föelk ſenn delling all bötten uf da Fehl en haue.
 WS39	Gung man, de brunne Hun deht Dö nix.
-WS40	Ik bin med det Föelk {Unklar, weil etwas verschmiert.} der achter awer dat Meedlönd inʼt Körn kehrt.
+WS40	Ik bin med det Föelk {Unklar, weil etwas verschmiert.} der achter awer dat Meedlönd in’t Körn kehrt.

--- a/53538_Szyroslaw.csv
+++ b/53538_Szyroslaw.csv
@@ -37,7 +37,7 @@ WS26	Za naszym domem stoią trzy piękne jabłoneczki zczerwonemy jabłuszkamy.
 WS27	Niemożecie wy momencik na nas czekac, to pojdziemy z wamy.
 WS28	Takich dziecinstw niepowinniśćie prowadzić.
 WS29	Nasze góry niesą bardzo wysokie, wasze są wiele wyźsze.
-WS30	Wiele funtow kiełbasy i jaḱ wiele chleba chcecie mieć?
+WS30	Wiele funtow kiełbasy i jak wiele chleba chcecie mieć?
 WS31	Nierozumiem was, muśicie cokolwiek głośniej mowić.
 WS32	Nieznalezliśćie na moim stoliku kawałek bjałego mydła?  
 WS33	Brat jego chce dwa piękne nowe domy w waszym ogrodzie wybudować.

--- a/53721_Neuwelt.csv
+++ b/53721_Neuwelt.csv
@@ -44,7 +44,7 @@ WS33	Iego brat chce sobie dwa nowe domy w waszym ogrodzie budować.
 WS34	To słowo poszło mu z serca.
 WS35	To było słusznie od niego.
 WS36	Co za ptaszki siedzą tam ugóry na mureczku?
-WS37	Gbury przyprowadzili̹ pięć wołów i dziewięć krów i dwanaście owieczek przed wieś, te chcą oni sprzedać.
+WS37	Gbury przyprowadzili̥ pięć wołów i dziewięć krów i dwanaście owieczek przed wieś, te chcą oni sprzedać.
 WS38	Ludzie są dzisiaj wszysey na polu i rzną.
 WS39	Idz tylko, ten brunatny pies ci nic niezrobi. 
 WS40	Ia pojechałem z ludzmi do tyłu przez łąkę w zborze.

--- a/53917_Werben.csv
+++ b/53917_Werben.csv
@@ -8,8 +8,8 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W lěśe leśe te suche łoṕena přez powětř. W lějsche lejsche te ßuchje wopjena psches powětsch.
-WS02	Sněg přestańo se hyś, přeto ẃedro se polepšujo. Sněg pschestanjo ße hüsch, pscheto wjedro ße polepschujo.
+WS01	W lĕśe leśe te suche łoṕena přez powĕtř. W lĕjsche lejsche te ßuchje wopjena psches powĕtsch.
+WS02	Snĕg přestańo se hyś, přeto ẃedro se polepšujo. Snĕg pschestanjo ße hüsch, pscheto wjedro ße polepschujo.
 WS03	Scyn hugle do kaḿen, ab’ mloko skóro se wariś chopiło. Szün hugle do kamjen, ab’ mloko skóro ße warisch chopiwo.
 WS04	Ten dobry stary muž jo z kóńom přez lod přepadńuł a jo do zymneje wódy padnuł. Ten dobrÿ starÿ musch jo s konjom psches lod pschepadnuł a jo do sÿmneje wódy padnuw.
 WS05	

--- a/54895_Warschau.csv
+++ b/54895_Warschau.csv
@@ -41,7 +41,7 @@ WS08	d̥i fīs tīn mir wąi, mir d̥axd si ̽͜ χ <(= ich glaube)>, d̥as i ̽
 WS09	i ̽͜ χ b̥ǐn b̥ai d̥ęr frǫu gəwē̜isn̥ īn i ̽͜ χ ͜  ǫb <(aber hab in 8!)> es īər gəs̥u̬gd, in sī hǫd gəs̥u̬gd, sǐ węd su̬dən əs ǫux īər toxtər.
 WS10	i ̽͜ χ węl <(scheinbar auch wǫl üblich!)> əs ǫux n̥id̥ mē̜ər wid̥ər maxən.
 WS11	ǐ ̽͜ χ šlu̬g di ̽͜ χ b̥ald <(’gleich’ nicht üblich)> mid d̥ē̜im Kǫxlǫfəl <(großer Holzlöffel)> in di ǫirən, du mal̥pə <(m. u. f.; pl. Málpįs; ’Affe’ ist deutsch, nicht jiddisch)>!
-WS12	wīən gē̜isti ahī́n, s̥ol̥n mīər mid diər mi ́dga͜in?
+WS12	wīən gē̜isti ahī́n, s̥ol̥n mīər mid diər mi ́dga͡in?
 WS13	s̥ǐ šlaxtə dsąitən!
 WS14	main līb Kind, b̥ląib dō intən šdąin, di b̥aisə g̥ens b̥aisn di ̽͜ χ tōt.
 WS15	d̥i hǫsd haĩnt dsə <(oder: ãm)> maĩəstən gəlęarənd<(nach a hin!)> in di bist ǫrəndli ̽͜ χ gəwē̜isn, d̥i d̥arfsd frīər ahąi ́mgąin wī di ͜  ãndərə <(oder: wī ͜  alə)>.

--- a/54895_Warschau.csv
+++ b/54895_Warschau.csv
@@ -49,14 +49,14 @@ WS16	d̥i bisd nǫx dsi kląin <(’nicht groß genug’ würde man nicht sagen)
 WS17	g̥ąi sai ás̥oi g̥id in s̥u̬g dąin šwęstęr, s̥i s̥ol di Klaidęr fę ͜ r <(ę stark nach a)> ͜  ǫirə mitər fęrtig <(ę stark nach a)> maxn in mid d̥i bęaršd <(ęa starl nach a)> ú̜püdsən <(=abputzen; ’sauber machen’ nicht üblich!)>.
 WS18	hǫsdə d̥ū ē̜im gəkõnd! sō <(’dann’ nicht üblich!)> wē̜ərd ęd mid ē̜im ãndərš gəwǫrən <(gəkumən wäre hier nicht zu gebrauchen)>, in ęs w ē̜ərd ͜   <(tē̜itə wäre hier nicht zu gebrauchen)> ͜   ē̜im bęsər sąin.
 WS19	wēər hǫd mīər mąin Kǫrb mid flaiš gəgãmfid <(’gestohlen’ ist deutsch)>?
-WS20	ē̜ər waisd <(=weisen =zeigen =sich stellen, als ob)>, mǫn hǫd ē̜im dsəm mli ́dš̥ən <(’dreschen’ nicht üblich)> bǫšdęld; sai hǫbm ə́s ǫbər sęlbsd gəmli᷄dš̥əd <(’getan’ würde durch ’gemacht’ ersetzt werden)>.
+WS20	ē̜ər waisd <(=weisen =zeigen =sich stellen, als ob)>, mǫn hǫd ē̜im dsəm mli ́dš̥ən <(’dreschen’ nicht üblich)> bǫšdęld; sai hǫbm ə́s ǫbər sęlbsd gəmlídš̥əd <(’getan’ würde durch ’gemacht’ ersetzt werden)>.
 WS21	wē̜imən <(ə mit i-Klang!)> hǫd ē̜ər d̥i nājə gəšixdə də́rdsaild <(ə́ mit o-Färbung!)>?
 WS22	men mis hōjəx <(=höher; ’laut’ nicht üblich)> ə̌rāin, wail ē̜ər fəršdąid ins nid <(in Südpolen, z. B. Zwangorod und Lublin, soll dafür ništ eintreten)>.
 WS23	mīər senə mīd in mīər habm <(vgl. 20 u. 24)> dǫršd.
 WS24	so wī mīər senə nęxtən u̬wənd dsəríg gəkumən, dō senə dī ãndərə šōin gəlē̜igən dsu bəd in hǫbm šdarg gišlǫfən.
 WS25	dęr šnąi is̥ dī <(oder: dīs̥ə)> naxt b̥ai ins legŋ̥ gəblebm <(ə und ě mit i-Färbung)>, ǫbęr hąint mǫrgən, wen di sin hǫd u̬fgəšaĩnt, is̥ ęr dsigã́ŋgə <(ə mit i-Färbung)>.
 WS26	hintęr insərm hō̜s šdąiən drai šaĩne ępəl̥bąĩmər mid rǫitə ępərləx <(beide ə stark nach a hin!)>.
-WS27	Kend īər nid nǫx ąĩn kląĩn bisəl̥ <(selten: ōl̜xənbligxən, nie -əlxən!)> ǫf ins wartən, nǫxē̜ ́ər <(statt: ’dann’)> gąin mīər mid aix.
+WS27	Kend īər nid nǫx ąĩn kląĩn bisəl̥ <(selten: ōl̥xənbligxən, nie -əlxən!)> ǫf ins wartən, nǫxē̜ ́ər <(statt: ’dann’)> gąin mīər mid aix.
 WS28	īər dǫrft nid āsé̜lxə Kindərąi <(dafür meist hebr. Katṓəs, nie ‚Spaß’)> šbīlən <(’treiben’ nicht üblich)>.
 WS29	insərə bęrgə <(stark getrilltes Zungen-r)> senən nid saiər hō̜ix, ǫbęr āirə senən fīl hö̜xər <(oder: nid asói hō̜ix wi āirə)>.
 WS30	wi ́fil find wūəšd in wi ́fil brǫid wild īər hǫbm?

--- a/54895_Warschau.csv
+++ b/54895_Warschau.csv
@@ -24,7 +24,7 @@ Anmerkungen: "{Anmerkungen der Transliterierenden: Sowohl Kurrent-e (‚n’) nu
   gRō   grau\tsęxdsig   60\twē̜ig (M.) } Weg\nhãnd   Hand\thũndęrt   100\twē̜igən\
   \ (Pl.)}  “\nhẽ̜nd   Hände\ttō̜sęnd   1000\tfęRtig   fertig\nflags   Flachs\twaisən\
   \   zeigen\tRījig   ruhig\nwagsd   wächst\tbaigen   biegen\tfastən   fasten\nbē̜sən\
-  \   Besen\ttrųgən   tragen\tmisd   Mist\nflō̜mən   Pflaumen\td̥rųgən   drücken \t\
+  \   Besen\ttru̬gən   tragen\tmisd   Mist\nflō̜mən   Pflaumen\td̥ru̬gən   drücken \t\
   potšt   Post\nbRē̜if   Brief\tfRē̜igən   fragen\t-ch- immer wie –x-: \nhǫif  \
   \ Hof\tlaigən   legen\tštęxən   stechen\njiŋg   jung\tligən   liegen\tštęxt   sticht\n\
   kRim   krumm\tdsigəl   Ziegel\tdsaixn   Zeichen\nęləf, dswęlf   11, 12\tkō̜əl  \
@@ -38,23 +38,23 @@ WS05	ē̜r ͜  is̥ faər fīər ͜  ǫdər sęgs wǫxn̥ gəšdǫrbm̥.
 WS06	das faiər is̥ gəwē̜isn̥ dsi šdarg, d̥ī̜ Ki ̽͜ χən se̩nən untn̥ dsïgəbręnd <(ï = etwas gerundetes ǐ)> ge̩worən <(oder: sie sind unten untergebrannt geworden)>.
 WS07	ē̜r ͜  ęst d̥ī aiər štęndig <(’immer’ ist deutsch, nicht jiddisch!)> ū̜n <(ū̜ nach ō!)> s̥alds in pfęfęr.
 WS08	d̥i fīs tīn mir wąi, mir d̥axd si ̽͜ χ <(= ich glaube)>, d̥as i ̽͜ χ hab̥ sąi fęrkīld <(’durchgelaufen’ ist nicht jiddisch!)>.
-WS09	i ̽͜ χ b̥ǐn b̥ai d̥ęr frǫu gəwē̜isn̥ īn i ̽͜ χ ͜  ǫb <(aber hab in 8!)> es īər gəs̥ųgd, in sī hǫd gəs̥ųgd, sǐ węd sųdən əs ǫux īər toxtər.
+WS09	i ̽͜ χ b̥ǐn b̥ai d̥ęr frǫu gəwē̜isn̥ īn i ̽͜ χ ͜  ǫb <(aber hab in 8!)> es īər gəs̥u̬gd, in sī hǫd gəs̥u̬gd, sǐ węd su̬dən əs ǫux īər toxtər.
 WS10	i ̽͜ χ węl <(scheinbar auch wǫl üblich!)> əs ǫux n̥id̥ mē̜ər wid̥ər maxən.
-WS11	ǐ ̽͜ χ šlųg di ̽͜ χ b̥ald <(’gleich’ nicht üblich)> mid d̥ē̜im Kǫxlǫfəl <(großer Holzlöffel)> in di ǫirən, du mal̥pə <(m. u. f.; pl. Málpįs; ’Affe’ ist deutsch, nicht jiddisch)>!
+WS11	ǐ ̽͜ χ šlu̬g di ̽͜ χ b̥ald <(’gleich’ nicht üblich)> mid d̥ē̜im Kǫxlǫfəl <(großer Holzlöffel)> in di ǫirən, du mal̥pə <(m. u. f.; pl. Málpįs; ’Affe’ ist deutsch, nicht jiddisch)>!
 WS12	wīən gē̜isti ahī́n, s̥ol̥n mīər mid diər mi ́dga͜in?
 WS13	s̥ǐ šlaxtə dsąitən!
 WS14	main līb Kind, b̥ląib dō intən šdąin, di b̥aisə g̥ens b̥aisn di ̽͜ χ tōt.
 WS15	d̥i hǫsd haĩnt dsə <(oder: ãm)> maĩəstən gəlęarənd<(nach a hin!)> in di bist ǫrəndli ̽͜ χ gəwē̜isn, d̥i d̥arfsd frīər ahąi ́mgąin wī di ͜  ãndərə <(oder: wī ͜  alə)>.
 WS16	d̥i bisd nǫx dsi kląin <(’nicht groß genug’ würde man nicht sagen)> dsī ͜  a flaš wąin mid aĩmō̜al <(sinngemäß zugesetzt)> ó̜us dsətriŋkən; di misd ē̜əšd <(oder: nǫx)> ętwəs gręsər wē̜rən.
-WS17	g̥ąi sai ás̥oi g̥id in s̥ųg dąin šwęstęr, s̥i s̥ol di Klaidęr fę ͜ r <(ę stark nach a)> ͜  ǫirə mitər fęrtig <(ę stark nach a)> maxn in mid d̥i bęaršd <(ęa starl nach a)> ú̜püdsən <(=abputzen; ’sauber machen’ nicht üblich!)>.
+WS17	g̥ąi sai ás̥oi g̥id in s̥u̬g dąin šwęstęr, s̥i s̥ol di Klaidęr fę ͜ r <(ę stark nach a)> ͜  ǫirə mitər fęrtig <(ę stark nach a)> maxn in mid d̥i bęaršd <(ęa starl nach a)> ú̜püdsən <(=abputzen; ’sauber machen’ nicht üblich!)>.
 WS18	hǫsdə d̥ū ē̜im gəkõnd! sō <(’dann’ nicht üblich!)> wē̜ərd ęd mid ē̜im ãndərš gəwǫrən <(gəkumən wäre hier nicht zu gebrauchen)>, in ęs w ē̜ərd ͜   <(tē̜itə wäre hier nicht zu gebrauchen)> ͜   ē̜im bęsər sąin.
 WS19	wēər hǫd mīər mąin Kǫrb mid flaiš gəgãmfid <(’gestohlen’ ist deutsch)>?
 WS20	ē̜ər waisd <(=weisen =zeigen =sich stellen, als ob)>, mǫn hǫd ē̜im dsəm mli ́dš̥ən <(’dreschen’ nicht üblich)> bǫšdęld; sai hǫbm ə́s ǫbər sęlbsd gəmli᷄dš̥əd <(’getan’ würde durch ’gemacht’ ersetzt werden)>.
 WS21	wē̜imən <(ə mit i-Klang!)> hǫd ē̜ər d̥i nājə gəšixdə də́rdsaild <(ə́ mit o-Färbung!)>?
 WS22	men mis hōjəx <(=höher; ’laut’ nicht üblich)> ə̌rāin, wail ē̜ər fəršdąid ins nid <(in Südpolen, z. B. Zwangorod und Lublin, soll dafür ništ eintreten)>.
 WS23	mīər senə mīd in mīər habm <(vgl. 20 u. 24)> dǫršd.
-WS24	so wī mīər senə nęxtən ųwənd dsəríg gəkumən, dō senə dī ãndərə šōin gəlē̜igən dsu bəd in hǫbm šdarg gišlǫfən.
-WS25	dęr šnąi is̥ dī <(oder: dīs̥ə)> naxt b̥ai ins legŋ̥ gəblebm <(ə und ě mit i-Färbung)>, ǫbęr hąint mǫrgən, wen di sin hǫd ųfgəšaĩnt, is̥ ęr dsigã́ŋgə <(ə mit i-Färbung)>.
+WS24	so wī mīər senə nęxtən u̬wənd dsəríg gəkumən, dō senə dī ãndərə šōin gəlē̜igən dsu bəd in hǫbm šdarg gišlǫfən.
+WS25	dęr šnąi is̥ dī <(oder: dīs̥ə)> naxt b̥ai ins legŋ̥ gəblebm <(ə und ě mit i-Färbung)>, ǫbęr hąint mǫrgən, wen di sin hǫd u̬fgəšaĩnt, is̥ ęr dsigã́ŋgə <(ə mit i-Färbung)>.
 WS26	hintęr insərm hō̜s šdąiən drai šaĩne ępəl̥bąĩmər mid rǫitə ępərləx <(beide ə stark nach a hin!)>.
 WS27	Kend īər nid nǫx ąĩn kląĩn bisəl̥ <(selten: ōl̜xənbligxən, nie -əlxən!)> ǫf ins wartən, nǫxē̜ ́ər <(statt: ’dann’)> gąin mīər mid aix.
 WS28	īər dǫrft nid āsé̜lxə Kindərąi <(dafür meist hebr. Katṓəs, nie ‚Spaß’)> šbīlən <(’treiben’ nicht üblich)>.
@@ -64,7 +64,7 @@ WS31	i ̽͜ χ fəršdąi aix nid, īər misd ąin bisəl̥ lō̜tərə rē̜id�
 WS32	hǫd īər kąin šdigəl̥ wąisə sąif fər <(ə mit o-Färbung)> mīər auf maĩn tiš gəfĩnən?
 WS33	saĩn brīdər wil si ̽͜ χ dswąi šaĩnə nājə hąisər in āirən gurtən maxən <(’bauen’ nicht üblich)>.
 WS34	d̥as wort <(stark getrilltes Zungen-r)> is gəkumən <(dazu: kimd 3. Sg. Praes., kumən 3. Pl Praes.)> fin hęrdsən <(stark getr. Zungen-r)>!
-WS35	d̥as i̥s gəwē̜isn̥ rixtig fu̥n <(u̥ nach i!)> sai <(3. pl.; dagegen 2. sg. d̥īr, 2. pl. aix und ǐnən <(Ihnen)>)>!
+WS35	d̥as i̥s gəwē̜isn̥ rixtig fu̯n <(u̯ nach i!)> sai <(3. pl.; dagegen 2. sg. d̥īr, 2. pl. aix und ǐnən <(Ihnen)>)>!
 WS36	wos sidsən dō fö̜r faigərləx <(Vogel: foigəl, Vögel faigəl. Vöglein Sg. foigərlə, Pl. faigərləx)> oiwm̥ auf dəm klaĩnən plǫt? <(plǫt = Gartenmauer <(Diminutiv besteht nicht)>, ‚Mauer’ = Hausmauer, Wand)>.
 WS37	d̥i pǫurən <(stimmlose Fortis!)> hǫbm̥ <(statt ’hatten’: haben gehabt)> gəbriŋd finəf ǫgsən in nąin Kī <(Sg. Kū)> in dswęlf šępsən fęr dē̜im dǫərf; s̥ai hǫbm̥ gəwǫld sai fərkǫifən.
 WS38	d̥i menšən <(’Leute’ nicht üblich)> senən hąĩnt alə drǫusən ǫf dē̜im fęl̥d in šnaidən <(’mähen’ nicht üblich)>.

--- a/54895_Warschau.csv
+++ b/54895_Warschau.csv
@@ -25,15 +25,15 @@ Anmerkungen: "{Anmerkungen der Transliterierenden: Sowohl Kurrent-e (‚n’) nu
   \ (Pl.)}  “\nhẽ̜nd   Hände\ttō̜sęnd   1000\tfęRtig   fertig\nflags   Flachs\twaisən\
   \   zeigen\tRījig   ruhig\nwagsd   wächst\tbaigen   biegen\tfastən   fasten\nbē̜sən\
   \   Besen\ttru̬gən   tragen\tmisd   Mist\nflō̜mən   Pflaumen\td̥ru̬gən   drücken \t\
-  potšt   Post\nbRē̜if   Brief\tfRē̜igən   fragen\t-ch- immer wie –x-: \nhǫif  \
+  potšt   Post\nbRē̜if   Brief\tfRē̜igən   fragen\t-ch- immer wie -x-: \nhǫif  \
   \ Hof\tlaigən   legen\tštęxən   stechen\njiŋg   jung\tligən   liegen\tštęxt   sticht\n\
   kRim   krumm\tdsigəl   Ziegel\tdsaixn   Zeichen\nęləf, dswęlf   11, 12\tkō̜əl  \
   \ Kugel\tKirxe   kath. Kirche;\nfĩnəf   5>"
 ...
-WS01	im wintęr flī̜en <(ī̜ stark nach ē!)> d̥ī trigənə b̥lętər in d̥ē̜ə lifd ęr i ́m.
-WS02	ęs hē̜ərd šoin <(’gleich’ nicht üblich!)> auf dsī šnąiən, naxē̜ ́r <(’dann’ nicht üblich!)> is d̥ē̜ə wędər wīdər šenər.
+WS01	im wintęr flī̜en <(ī̜ stark nach ē!)> d̥ī trigənə b̥lętər in d̥ē̜ə lifd ęr ím.
+WS02	ęs hē̜ərd šoin <(’gleich’ nicht üblich!)> auf dsī šnąiən, naxḗ̜r <(’dann’ nicht üblich!)> is d̥ē̜ə wędər wīdər šenər.
 WS03	tī Koilən in dəm oiwm, du̯s də milx sol̥ b̥ald̥ koxn̥.
-WS04	d̥ęr g̥itęr al̥tęr mãn is̥ mi ͜  dęm pfē̜rd auf dəm ais gərǐdn̥ ǐn dəs ais is̥ dsubrǫxn̥ gẹwǫrən <(’mit dem Pferd durchs Eis brochen’ kann nur durch diese Umschreibung wiedergegeben werden!)> in ͜  ē̜r ͜  is̥ ͜  ərąi ́ngəfalən in kaltn̥ wasər.
+WS04	d̥ęr g̥itęr al̥tęr mãn is̥ mi ͜  dęm pfē̜rd auf dəm ais gərǐdn̥ ǐn dəs ais is̥ dsubrǫxn̥ gẹwǫrən <(’mit dem Pferd durchs Eis brochen’ kann nur durch diese Umschreibung wiedergegeben werden!)> in ͜  ē̜r ͜  is̥ ͜  ərąíngəfalən in kaltn̥ wasər.
 WS05	ē̜r ͜  is̥ faər fīər ͜  ǫdər sęgs wǫxn̥ gəšdǫrbm̥.
 WS06	das faiər is̥ gəwē̜isn̥ dsi šdarg, d̥ī̜ Ki ̽͜ χən sẹnən untn̥ dsïgəbręnd <(ï = etwas gerundetes ǐ)> gẹworən <(oder: sie sind unten untergebrannt geworden)>.
 WS07	ē̜r ͜  ęst d̥ī aiər štęndig <(’immer’ ist deutsch, nicht jiddisch!)> ū̜n <(ū̜ nach ō!)> s̥alds in pfęfęr.
@@ -41,25 +41,25 @@ WS08	d̥i fīs tīn mir wąi, mir d̥axd si ̽͜ χ <(= ich glaube)>, d̥as i ̽
 WS09	i ̽͜ χ b̥ǐn b̥ai d̥ęr frǫu gəwē̜isn̥ īn i ̽͜ χ ͜  ǫb <(aber hab in 8!)> es īər gəs̥u̬gd, in sī hǫd gəs̥u̬gd, sǐ węd su̬dən əs ǫux īər toxtər.
 WS10	i ̽͜ χ węl <(scheinbar auch wǫl üblich!)> əs ǫux n̥id̥ mē̜ər wid̥ər maxən.
 WS11	ǐ ̽͜ χ šlu̬g di ̽͜ χ b̥ald <(’gleich’ nicht üblich)> mid d̥ē̜im Kǫxlǫfəl <(großer Holzlöffel)> in di ǫirən, du mal̥pə <(m. u. f.; pl. Málpįs; ’Affe’ ist deutsch, nicht jiddisch)>!
-WS12	wīən gē̜isti ahī́n, s̥ol̥n mīər mid diər mi ́dga͡in?
+WS12	wīən gē̜isti ahī́n, s̥ol̥n mīər mid diər mídga͡in?
 WS13	s̥ǐ šlaxtə dsąitən!
 WS14	main līb Kind, b̥ląib dō intən šdąin, di b̥aisə g̥ens b̥aisn di ̽͜ χ tōt.
-WS15	d̥i hǫsd haĩnt dsə <(oder: ãm)> maĩəstən gəlęarənd<(nach a hin!)> in di bist ǫrəndli ̽͜ χ gəwē̜isn, d̥i d̥arfsd frīər ahąi ́mgąin wī di ͜  ãndərə <(oder: wī ͜  alə)>.
+WS15	d̥i hǫsd haĩnt dsə <(oder: ãm)> maĩəstən gəlęarənd<(nach a hin!)> in di bist ǫrəndli ̽͜ χ gəwē̜isn, d̥i d̥arfsd frīər ahąímgąin wī di ͜  ãndərə <(oder: wī ͜  alə)>.
 WS16	d̥i bisd nǫx dsi kląin <(’nicht groß genug’ würde man nicht sagen)> dsī ͜  a flaš wąin mid aĩmō̜al <(sinngemäß zugesetzt)> ó̜us dsətriŋkən; di misd ē̜əšd <(oder: nǫx)> ętwəs gręsər wē̜rən.
 WS17	g̥ąi sai ás̥oi g̥id in s̥u̬g dąin šwęstęr, s̥i s̥ol di Klaidęr fę ͜ r <(ę stark nach a)> ͜  ǫirə mitər fęrtig <(ę stark nach a)> maxn in mid d̥i bęaršd <(ęa starl nach a)> ú̜püdsən <(=abputzen; ’sauber machen’ nicht üblich!)>.
 WS18	hǫsdə d̥ū ē̜im gəkõnd! sō <(’dann’ nicht üblich!)> wē̜ərd ęd mid ē̜im ãndərš gəwǫrən <(gəkumən wäre hier nicht zu gebrauchen)>, in ęs w ē̜ərd ͜   <(tē̜itə wäre hier nicht zu gebrauchen)> ͜   ē̜im bęsər sąin.
 WS19	wēər hǫd mīər mąin Kǫrb mid flaiš gəgãmfid <(’gestohlen’ ist deutsch)>?
-WS20	ē̜ər waisd <(=weisen =zeigen =sich stellen, als ob)>, mǫn hǫd ē̜im dsəm mli ́dš̥ən <(’dreschen’ nicht üblich)> bǫšdęld; sai hǫbm ə́s ǫbər sęlbsd gəmlídš̥əd <(’getan’ würde durch ’gemacht’ ersetzt werden)>.
+WS20	ē̜ər waisd <(=weisen =zeigen =sich stellen, als ob)>, mǫn hǫd ē̜im dsəm mlídš̥ən <(’dreschen’ nicht üblich)> bǫšdęld; sai hǫbm ə́s ǫbər sęlbsd gəmlídš̥əd <(’getan’ würde durch ’gemacht’ ersetzt werden)>.
 WS21	wē̜imən <(ə mit i-Klang!)> hǫd ē̜ər d̥i nājə gəšixdə də́rdsaild <(ə́ mit o-Färbung!)>?
 WS22	men mis hōjəx <(=höher; ’laut’ nicht üblich)> ə̌rāin, wail ē̜ər fəršdąid ins nid <(in Südpolen, z. B. Zwangorod und Lublin, soll dafür ništ eintreten)>.
 WS23	mīər senə mīd in mīər habm <(vgl. 20 u. 24)> dǫršd.
 WS24	so wī mīər senə nęxtən u̬wənd dsəríg gəkumən, dō senə dī ãndərə šōin gəlē̜igən dsu bəd in hǫbm šdarg gišlǫfən.
 WS25	dęr šnąi is̥ dī <(oder: dīs̥ə)> naxt b̥ai ins legŋ̥ gəblebm <(ə und ĕ mit i-Färbung)>, ǫbęr hąint mǫrgən, wen di sin hǫd u̬fgəšaĩnt, is̥ ęr dsigã́ŋgə <(ə mit i-Färbung)>.
 WS26	hintęr insərm hō̜s šdąiən drai šaĩne ępəl̥bąĩmər mid rǫitə ępərləx <(beide ə stark nach a hin!)>.
-WS27	Kend īər nid nǫx ąĩn kląĩn bisəl̥ <(selten: ōl̥xənbligxən, nie -əlxən!)> ǫf ins wartən, nǫxē̜ ́ər <(statt: ’dann’)> gąin mīər mid aix.
+WS27	Kend īər nid nǫx ąĩn kląĩn bisəl̥ <(selten: ōl̥xənbligxən, nie -əlxən!)> ǫf ins wartən, nǫxḗ̜ər <(statt: ’dann’)> gąin mīər mid aix.
 WS28	īər dǫrft nid āsé̜lxə Kindərąi <(dafür meist hebr. Katṓəs, nie ‚Spaß’)> šbīlən <(’treiben’ nicht üblich)>.
 WS29	insərə bęrgə <(stark getrilltes Zungen-r)> senən nid saiər hō̜ix, ǫbęr āirə senən fīl hö̜xər <(oder: nid asói hō̜ix wi āirə)>.
-WS30	wi ́fil find wūəšd in wi ́fil brǫid wild īər hǫbm?
+WS30	wífil find wūəšd in wífil brǫid wild īər hǫbm?
 WS31	i ̽͜ χ fəršdąi aix nid, īər misd ąin bisəl̥ lō̜tərə rē̜idən <(’sprechen’ ist nicht üblich)>.
 WS32	hǫd īər kąin šdigəl̥ wąisə sąif fər <(ə mit o-Färbung)> mīər auf maĩn tiš gəfĩnən?
 WS33	saĩn brīdər wil si ̽͜ χ dswąi šaĩnə nājə hąisər in āirən gurtən maxən <(’bauen’ nicht üblich)>.

--- a/54895_Warschau.csv
+++ b/54895_Warschau.csv
@@ -14,7 +14,7 @@ Anmerkungen: "{Anmerkungen der Transliterierenden: Sowohl Kurrent-e (‚n’) nu
   \ vor, sondern werden stets durch Perfektformen wiedergegeben.\n’... und vom Bahnhof,\
   \ wenn er (der Unteroffizier) braucht was, schickt mich wieder raus ins Lager.’\n\
   ’... wenn er zu klein ist, um zu wollen eine Sache machen’ (Satz 1b).\n’Ich habe\
-  \ das Rauchen weggeschmissen, auch im Fělde’ = ich rauche nicht.\n\nb̥lid   Blut\t\
+  \ das Rauchen weggeschmissen, auch im Fĕlde’ = ich rauche nicht.\n\nb̥lid   Blut\t\
   blansən   Blasen am Fuß\tKaid (F.)   Kette.\nAnfrage = Fragezeichen\thuŋgęr   Hunger\t\
   šiərp (M.)   Sichel\nKašdən (m.)\t} Kastanie\tgədRąid   gedreht\tKǫsə (F.[?])  \
   \ Sense\nKášdənis (Pl.)}     “\tfāənd   fährt (3. Sg.)\thais   heiß\n\nJuden können\
@@ -33,9 +33,9 @@ Anmerkungen: "{Anmerkungen der Transliterierenden: Sowohl Kurrent-e (‚n’) nu
 WS01	im wintęr flī̜en <(ī̜ stark nach ē!)> d̥ī trigənə b̥lętər in d̥ē̜ə lifd ęr i ́m.
 WS02	ęs hē̜ərd šoin <(’gleich’ nicht üblich!)> auf dsī šnąiən, naxē̜ ́r <(’dann’ nicht üblich!)> is d̥ē̜ə wędər wīdər šenər.
 WS03	tī Koilən in dəm oiwm, du̯s də milx sol̥ b̥ald̥ koxn̥.
-WS04	d̥ęr g̥itęr al̥tęr mãn is̥ mi ͜  dęm pfē̜rd auf dəm ais gərǐdn̥ ǐn dəs ais is̥ dsubrǫxn̥ ge̩wǫrən <(’mit dem Pferd durchs Eis brochen’ kann nur durch diese Umschreibung wiedergegeben werden!)> in ͜  ē̜r ͜  is̥ ͜  ərąi ́ngəfalən in kaltn̥ wasər.
+WS04	d̥ęr g̥itęr al̥tęr mãn is̥ mi ͜  dęm pfē̜rd auf dəm ais gərǐdn̥ ǐn dəs ais is̥ dsubrǫxn̥ gẹwǫrən <(’mit dem Pferd durchs Eis brochen’ kann nur durch diese Umschreibung wiedergegeben werden!)> in ͜  ē̜r ͜  is̥ ͜  ərąi ́ngəfalən in kaltn̥ wasər.
 WS05	ē̜r ͜  is̥ faər fīər ͜  ǫdər sęgs wǫxn̥ gəšdǫrbm̥.
-WS06	das faiər is̥ gəwē̜isn̥ dsi šdarg, d̥ī̜ Ki ̽͜ χən se̩nən untn̥ dsïgəbręnd <(ï = etwas gerundetes ǐ)> ge̩worən <(oder: sie sind unten untergebrannt geworden)>.
+WS06	das faiər is̥ gəwē̜isn̥ dsi šdarg, d̥ī̜ Ki ̽͜ χən sẹnən untn̥ dsïgəbręnd <(ï = etwas gerundetes ǐ)> gẹworən <(oder: sie sind unten untergebrannt geworden)>.
 WS07	ē̜r ͜  ęst d̥ī aiər štęndig <(’immer’ ist deutsch, nicht jiddisch!)> ū̜n <(ū̜ nach ō!)> s̥alds in pfęfęr.
 WS08	d̥i fīs tīn mir wąi, mir d̥axd si ̽͜ χ <(= ich glaube)>, d̥as i ̽͜ χ hab̥ sąi fęrkīld <(’durchgelaufen’ ist nicht jiddisch!)>.
 WS09	i ̽͜ χ b̥ǐn b̥ai d̥ęr frǫu gəwē̜isn̥ īn i ̽͜ χ ͜  ǫb <(aber hab in 8!)> es īər gəs̥u̬gd, in sī hǫd gəs̥u̬gd, sǐ węd su̬dən əs ǫux īər toxtər.
@@ -54,7 +54,7 @@ WS21	wē̜imən <(ə mit i-Klang!)> hǫd ē̜ər d̥i nājə gəšixdə də́rds
 WS22	men mis hōjəx <(=höher; ’laut’ nicht üblich)> ə̌rāin, wail ē̜ər fəršdąid ins nid <(in Südpolen, z. B. Zwangorod und Lublin, soll dafür ništ eintreten)>.
 WS23	mīər senə mīd in mīər habm <(vgl. 20 u. 24)> dǫršd.
 WS24	so wī mīər senə nęxtən u̬wənd dsəríg gəkumən, dō senə dī ãndərə šōin gəlē̜igən dsu bəd in hǫbm šdarg gišlǫfən.
-WS25	dęr šnąi is̥ dī <(oder: dīs̥ə)> naxt b̥ai ins legŋ̥ gəblebm <(ə und ě mit i-Färbung)>, ǫbęr hąint mǫrgən, wen di sin hǫd u̬fgəšaĩnt, is̥ ęr dsigã́ŋgə <(ə mit i-Färbung)>.
+WS25	dęr šnąi is̥ dī <(oder: dīs̥ə)> naxt b̥ai ins legŋ̥ gəblebm <(ə und ĕ mit i-Färbung)>, ǫbęr hąint mǫrgən, wen di sin hǫd u̬fgəšaĩnt, is̥ ęr dsigã́ŋgə <(ə mit i-Färbung)>.
 WS26	hintęr insərm hō̜s šdąiən drai šaĩne ępəl̥bąĩmər mid rǫitə ępərləx <(beide ə stark nach a hin!)>.
 WS27	Kend īər nid nǫx ąĩn kląĩn bisəl̥ <(selten: ōl̥xənbligxən, nie -əlxən!)> ǫf ins wartən, nǫxē̜ ́ər <(statt: ’dann’)> gąin mīər mid aix.
 WS28	īər dǫrft nid āsé̜lxə Kindərąi <(dafür meist hebr. Katṓəs, nie ‚Spaß’)> šbīlən <(’treiben’ nicht üblich)>.

--- a/56269_Dambinietz.csv
+++ b/56269_Dambinietz.csv
@@ -35,7 +35,7 @@ WS24	Jak mem wtszora wjieszór nazad psziśli, to tśi drudzy jusz byli w łósz
 WS25	Źniek w nozę ostał leźets ale źiśe rano stajał.
 WS26	Za naszem dómem są tszi jabónki z tszerwonemi jabkami.
 WS27	Moźetśze jeszcze trochę nanas czekadz, to chcemy zwami iszcz
-WS28	"W{'Wǵ' wohl geschrieben. 'Wy' wohl ""gemeint"". 'Woj' nicht undenkbar...} ńemacie takie dzeczenskie rzecze robić."
+WS28	"W{'Wġ' wohl geschrieben. 'Wy' wohl ""gemeint"". 'Woj' nicht undenkbar...} ńemacie takie dzeczenskie rzecze robić."
 WS29	Naszej Góry są ne bardzo wysoky, te wasej są owjele wyschsey.
 WS30	Wiela pfuntóv wursitov i wiela chleba hzsetsie {eig. unleserlich} miec.
 WS31	Jach was nerosumię wę muschice trochę goschnię mówic.

--- a/56290_Groß-Hoschütz.csv
+++ b/56290_Groß-Hoschütz.csv
@@ -10,43 +10,43 @@ Anmerkungen: '{teilweise ‚y’ mit nicht genau einschätzbarem Diakritikum; wi
   als „ÿ“ (auch ij wäre möglich), Satz 20 enthält ein Wort in Kurrentschrift „schtelowali“
   sowie Satz 38 ‚na’.}'
 ...
-WS01	W zimě letaju suche listi w luftě.
-WS02	Přestaně hned snich padat̆, potem zas budě lepši čas.
-WS03	Přilož uhla do peca, aš mleko hned začně wřeč.
-WS04	Ten debrÿ starÿ chlop se skoniem na ledě zalomil a do žimne wodÿ wpat.
+WS01	W zimĕ letaju suche listi w luftĕ.
+WS02	Přestanĕ hned snich padat̆, potem zas budĕ lepši čas.
+WS03	Přilož uhla do peca, aš mleko hned začnĕ wřeč.
+WS04	Ten debrÿ starÿ chlop se skoniem na ledĕ zalomil a do žimne wodÿ wpat.
 WS05	On před čtÿrma aneb ššest tÿdnama umřel.
-WS06	Oheň byl hrubě horkÿ, kolače jsou na spodku spalene.
+WS06	Oheň byl hrubĕ horkÿ, kolače jsou na spodku spalene.
 WS07	On ji wajca dyckÿ bez soli a pepřu.
-WS08	Nohÿ mě hrubě bolu, mÿslim že su zmožene.
-WS09	Ja sem byl při té robě a sěm ji to powědel, a ona prawěla, že to chce jeji dceře powěd̆et̆.
+WS08	Nohÿ mĕ hrubĕ bolu, mÿslim že su zmožene.
+WS09	Ja sem byl při té robĕ a sĕm ji to powĕdel, a ona prawĕla, že to chce jeji dceře powĕd̆et̆.
 WS10	Ja už to ne zrobym.
-WS11	Chřapnú tě hned s wařechu přes ušši, tÿ opico! 
-WS12	Kai iděš, mame stebu išt̆?
+WS11	Chřapnú tĕ hned s wařechu přes ušši, tÿ opico! 
+WS12	Kai idĕš, mame stebu išt̆?
 WS13	Su zle časÿ! 
-WS14	Moje mile ditě, zustan tu stat̆, bo tě hussi zakryzu.
-WS15	Tÿ si se dnes nejlepssi učil a byl si poslušnÿ, možeš spěšs dodum išt, jak ti druzi.
-WS16	Tÿ si esté neni tak welkÿ, žebys flaššu wina z much, mušiš děprem porošt̆, abys wětssi bÿl.
+WS14	Moje mile ditĕ, zustan tu stat̆, bo tĕ hussi zakryzu.
+WS15	Tÿ si se dnes nejlepssi učil a byl si poslušnÿ, možeš spĕšs dodum išt, jak ti druzi.
+WS16	Tÿ si esté neni tak welkÿ, žebys flaššu wina z much, mušiš dĕprem porošt̆, abys wĕtssi bÿl.
 WS17	Di, bud̆ tak dobry, a řekni twoje sestře, že ma šatÿ pro wassu matičku ussit̆ a ich wybirsstowat̆.
 WS18	Dy by si ho byl znal, to bÿ to bylo lepssi wÿpadlo, a stalo by lepssi snim.
 WS19	Kdo mi muj košik š masem ukrat?
 WS20	On tak robil, jakbÿ ho bili za mlacka schtelowali, oni to ale samÿ zrobili.
-WS21	Komu tu nowinu powěd̆al?
-WS22	Musi se křičet̆, bo bÿ nas nerozuměl.
+WS21	Komu tu nowinu powĕd̆al?
+WS22	Musi se křičet̆, bo bÿ nas nerozumĕl.
 WS23	My sme su unaweni, a mame dursst.
 WS24	Jak sme wčeraj wečer naspadek přissli, už wssici w ložu leželi, a spali fest.
 WS25	Snich unas tu noc zostal ležet̆, ale rano stal.
-WS26	Za nasse chalupě stoju tři pěkne jabloñkÿ s čerwenyma jablečkama.
-WS27	Nemožet̆e ešště okamženi na nas čekat̆, potÿm pujd̆em swami.
+WS26	Za nasse chalupĕ stoju tři pĕkne jabloñkÿ s čerwenyma jablečkama.
+WS27	Nemožet̆e ešštĕ okamženi na nas čekat̆, potÿm pujd̆em swami.
 WS28	Nesmiče  tak zbytkowat̆!
 WS29	Nasse hory nesu tak wysoke, wasse su wyšše.
-WS30	Kelko funtuw wurstu a jak moc chleba chcet̆ě?
-WS31	Ja was nerozumim, mussitě trossku hlasnejssi řadit̆.
-WS32	Něnassli ště kusek bileho mydla na mojem stole?
-WS33	Jeho bratr se chce dwa ssumne nowe domÿ we wassej zahradě budowat̆.
+WS30	Kelko funtuw wurstu a jak moc chleba chcet̆ĕ?
+WS31	Ja was nerozumim, mussitĕ trossku hlasnejssi řadit̆.
+WS32	Nĕnassli štĕ kusek bileho mydla na mojem stole?
+WS33	Jeho bratr se chce dwa ssumne nowe domÿ we wassej zahradĕ budowat̆.
 WS34	To slowo mu přišlo ze srdca.
 WS35	To bylo recht od was.
 WS36	Čo tu sed̆u za ptačkÿ na tÿm murku?
-WS37	Sedlacÿ přiwedli pět woluw, a dewět kraw a dwanast oweček před dědinu a chtěli ich przedat̆.
+WS37	Sedlacÿ přiwedli pĕt woluw, a dewĕt kraw a dwanast oweček před dĕdinu a chtĕli ich przedat̆.
 WS38	Lude su dneskaj wssici na polu a sseču. 
 WS39	Ene di, ten brunatnÿ pes ti nic nezrobi.
 WS40	Ja sem z lud̆mi tu nazadku, přes luku do rži wjel. 

--- a/56454_Drachhausen.csv
+++ b/56454_Drachhausen.csv
@@ -14,9 +14,9 @@ WS03	Zyṅ huglé do Kamen, aż to Mlȯko malßṅe ße sachopijo warisch.
 WS04	Ten dobry stary Muż jo s’tym Koṅom wö tom lȯżé ße pschėlamal a do teje symneje Wody padnul.
 WS05	Won jo pschėd styrimi abo schescż tyżéṅami samrėl.
 WS06	Ten hogeṅ bėscho welgin <(oder zu)> <warezy> palézy; te masaṅze ga ßu sposy [ganz] zele zarne ßpalȯne.
-WS07	Won jė te jaja pschézej mimo ßoli a péprȧ.
+WS07	Won jė te jaja pschézej mimo ßoli a péprå.
 WS08	Te nogi mė boli, ja ménim, ja ßom ßebé je pschégṅal.
-WS09	Ja ßom plȧ teje żeṅskeje byl a ßom jej gronil, a wona groṅascho, wona zo jo téke ßwojej żȯwcże gronisch.
+WS09	Ja ßom plå teje żeṅskeje byl a ßom jej gronil, a wona groṅascho, wona zo jo téke ßwojej żȯwcże gronisch.
 WS10	Ja ṅok jo też wėzej zynisch.
 WS11	Ja ṙagnom schi ned s’teju schupku sa huschy, ty nalpa.
 WS12	Żo żȯsch ty hin? dejmy my s’tobu hysch?
@@ -31,8 +31,8 @@ WS20	Won nadschawaschȯ ße, aby woni jogo k’mloschen[oj]u hopstellowali: woni
 WS21	Komu jo won to nowe <tschj> tschojeṅe hulizowal?
 WS22	Wono mußy ße <laut> welgin drėsch; howazej ṅerosmejo won nas.
 WS23	My ßmy muzne a mamy laznoscż.
-WS24	Ako my zora wȧzor saßej pschiźachmy, tam lȧžachu te druge južor postolach a spachu twarżé.
-WS25	Ten ßnėg jo tu ßamu Noz pschi naß wostal lȧžezy, żinßa pak žajtscha jo won [stajal] wotajal.
+WS24	Ako my zora wåzor saßej pschiźachmy, tam låžachu te druge južor postolach a spachu twarżé.
+WS25	Ten ßnėg jo tu ßamu Noz pschi naß wostal låžezy, żinßa pak žajtscha jo won [stajal] wotajal.
 WS26	Slėsy naschogo domu stoje tschi rėdne jablukowe [bomaschki] bomki s’zerwėnymi jabluschkami.
 WS27	Ṅamoscho wy hyschcżér jadno hokognusche na nas zakasch? potom żȯmy my s’wami.
 WS28	Wy ṅederbischo take Schelmischtuki zynisch.

--- a/56454_Drachhausen.csv
+++ b/56454_Drachhausen.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Symim lėtaju te ßuche lopéna hokolo we lu̇fsché.
+WS01	Symim lėtaju te ßuche lopéna hokolo we lůfsché.
 WS02	Wono ße ned pschéstaṅo ßnėgowisch a potom hordujo to wédro saßej lėpsche.
 WS03	Zyṅ huglé do Kamen, aż to Mlȯko malßṅe ße sachopijo warisch.
 WS04	Ten dobry stary Muż jo s’tym Koṅom wö tom lȯżé ße pschėlamal a do teje symneje Wody padnul.
@@ -21,7 +21,7 @@ WS10	Ja ṅok jo też wėzej zynisch.
 WS11	Ja ṙagnom schi ned s’teju schupku sa huschy, ty nalpa.
 WS12	Żo żȯsch ty hin? dejmy my s’tobu hysch?
 WS13	Wono ßu ṅedobre <sle> Zaße.
-WS14	Mojo lu̇be golė, wostaṅ how sposy stojéze; te slė Gußy sakuße schi do ßmérschi.
+WS14	Mojo lůbe golė, wostaṅ how sposy stojéze; te slė Gußy sakuße schi do ßmérschi.
 WS15	Ty ßy żinßa nejwėzej huknul a ßy radny byl; ty <mussysch> derbisch <raney> ranej domoj hysch ako te druge.
 WS16	Ty ṅejßy hyschcżér weliki doscż, aby jadnu flaschu Wina hupisch mogal; ty mußysch perej jaden Kußk [roscż] roscż a wėtschy hordowasch.
 WS17	Żi, byż tak dobry a groṅ twojej ßotschy, wona dejala tu drastwu sa waschu Mamu huschysch a s’teju Berschtu zyste gotowasch.

--- a/56455_Drehnow.csv
+++ b/56455_Drehnow.csv
@@ -45,6 +45,6 @@ WS34	To slowo pschiże jomu wot hutschoby.
 WS35	To bėscho pschawė wot ṅich.
 WS36	Zo ssejże tam sa taschazki swėrcha na tej muṙze.
 WS37	Te buṙa bėchu pėschoch wolow a żewesch krow a dwanascżo wojzkow psched tu wjass pschiwjadli, te kschėchu woṅi pschedasch.
-WS38	Te lu̇że ssu żinza schykne wönze na poli a sseku.
+WS38	Te lůże ssu żinza schykne wönze na poli a sseku.
 WS39	Żij jan, ten bruny pjass schi niz ṅezyni.
-WS40	Ja ssom s’tymi lu̇żimi tam slėsy psches tu luku do żyta jel.
+WS40	Ja ssom s’tymi lůżimi tam slėsy psches tu luku do żyta jel.

--- a/56457_Tauer.csv
+++ b/56457_Tauer.csv
@@ -13,8 +13,8 @@ WS02	Wonno ße pschėstano nėd Ssnėk padasch, potom <bu> bżo to Wedro saße l
 WS03	Szin Hugle do Kameṅ, aź to Mloko skoro ße sawario.
 WS04	Ten dobry, stary Musch <Zlowek> jo stym Koṅom na Loże ße pschelammal, a to teje symneje Wodi padnul.
 WS05	Wȯn jo pretk styri abo schestcź Tyźen humrel.
-WS06	Ten Wogeṅ bescho zu schoply, te Tykȧnze ga ßu sposy zarne <palone> plone.
-WS07	Won je te Jeija pschetze mimo Ssolli a Peprȧ.
+WS06	Ten Wogeṅ bescho zu schoply, te Tykånze ga ßu sposy zarne <palone> plone.
+WS07	Won je te Jeija pschetze mimo Ssolli a Peprå.
 WS08	Te Nogi mė welgin bolė, ja wėrim, ja ßom je psches to Hysche bolezéh krydnul.
 WS09	Jo ßom pschi te Żeṅsze byl a ßom je o gronil, a wona gronascho, wona kschyla jo teke jeje Źowze gronisch.
 WS10	Ja ṅok jo teke saße zėnisch.
@@ -31,16 +31,16 @@ WS20	Won zyṅascho tak, aby jogo kMoscheṅu hobstellowali, woni pak ßu jo ßa
 WS21	Komu jo wȯn tu nowu Geschichtu hulizowal?
 WS22	<Jaden> Wono mussy ße jaden welgin drysch, howaze won naß nėrosmejo <nėrosmejo>.
 WS23	My ßmy muzne a latzne <oder: a zo ße nam pisch>.
-WS24	Ako my zora Wȧzor naßlėtk pschischechmy ga laźachu te druge juźo Postoli a spachu twardo.
+WS24	Ako my zora Wåzor naßlėtk pschischechmy ga laźachu te druge juźo Postoli a spachu twardo.
 WS25	Ten Ssnėg jo tu Noz pschi naß laźetzy wostal, ale źinza Źaitschcźa jo wottaijal.
-WS26	Sslėsy nascheje Wȧźe stoje tschi rydne Jabluzinki szėrenymi Jabluschkami.
-WS27	Nȧmźoscho wy hyschcźi jadno Hokkognuschko na naß zakkasch, potom źomy (pojźomy) swami.
-WS28	Wy nėßmejoscho take źischetze Zinnenė wȧscź.
+WS26	Sslėsy nascheje Wåźe stoje tschi rydne Jabluzinki szėrenymi Jabluschkami.
+WS27	Nåmźoscho wy hyschcźi jadno Hokkognuschko na naß zakkasch, potom źomy (pojźomy) swami.
+WS28	Wy nėßmejoscho take źischetze Zinnenė wåscź.
 WS29	Nasche Gory neßu welgin hußo[k]kė, te wasche ßu wele huschė.
 WS30	Kak wele Punt Wjeschnize a kak wele Klėba zoscho wy mėsch.
 WS31	Ja wam nėrosmeju, wü mußyscho zoschku sjaune pojedasch.
 WS32	Nescźo Kußk bėleje Sepy samnȯ na mojom Bliźe namakali.
-WS33	Jogo Bratsch zo ßebe dwej redne, nowe Wȧźė wė waschom Gunė twarisch.
+WS33	Jogo Bratsch zo ßebe dwej redne, nowe Wåźė wė waschom Gunė twarisch.
 WS34	To Sslowo pschiźė jomu wot Hutschoby.
 WS35	To by pschauwe wot ṅogo.
 WS36	Zo ßesche tam sa Taschatzki gorece na <tom> te male Muri.

--- a/56458_Jänschwalde.csv
+++ b/56458_Jänschwalde.csv
@@ -16,7 +16,7 @@ WS05	Won jo psched stirich abo schestschich Tiźen humrel.
 WS06	Ten Pjaz bescho zu welgin topjoni, te Tikanze su spalone.
 WS07	Won je te jaja pschezej mimo Soli a Päpṙa.
 WS08	Te Nogi me bole, ja werim, aż som sebe je pschegnal.
-WS09	Ja som pschi tej żenskej bu̇l a som je groṅil, a wona gronascho, aż wona buźo jo jeje Źowze teke gronisch.
+WS09	Ja som pschi tej żenskej bůl a som je groṅil, a wona gronascho, aż wona buźo jo jeje Źowze teke gronisch.
 WS10	Ja nok jo sasej zinisch.
 WS11	Ja schi baschijom steju Schizu sa Huschi, ti Affa <(Nalpa)>.
 WS12	Żo pojżosch, deru stobu hisch?

--- a/56462_Babow.csv
+++ b/56462_Babow.csv
@@ -44,7 +44,7 @@ WS33	Jogo bratsch zo ßebe dwe rednej wjaźi we waschom kumne twarisch.
 WS34	To swowo jo jomu pschischwo wot hutschobi.
 WS35	To bescho pschawe wot waß.
 WS36	Zo ßejźe tam sa teschazki swercha, na tej murze.
-WS37	Te burȧ mejachu pesch wowow, a żewesch krow, a dwanasćzo wojzow, psched tu wjaß <sp> pschijadli, te ßu woni kscheli pschedasch.
+WS37	Te burå mejachu pesch wowow, a żewesch krow, a dwanasćzo wojzow, psched tu wjaß <sp> pschijadli, te ßu woni kscheli pschedasch.
 WS38	Te luźe ßu źinßa schickne na tom polu a ßeku.
 WS39	Ży jan, ten bruni pjaß nezini tebe niz.
 WS40	Ja ßom stimi luźimi tam ßlesi psches tu huku do źita jew.

--- a/56463_Papitz.csv
+++ b/56463_Papitz.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zyḿe leśe te suche hoṕenka přez ten wětř hokoło.
-WS02	Ned buźo se přestaś sněgowiś, pon buźo te ẃedro zasej rědnejše.
-WS03	Scyńaj hugle do Kaḿen, aby to mloko se jěsno wariło.
+WS01	W zyḿe leśe te suche hoṕenka přez ten wĕtř hokoło.
+WS02	Ned buźo se přestaś snĕgowiś, pon buźo te ẃedro zasej rĕdnejše.
+WS03	Scyńaj hugle do Kaḿen, aby to mloko se jĕsno wariło.
 WS04	Ten dobry stary cłoẃek jo se z tym końom na loźe přewalił a do teje zymneje wody panył.
 WS05	Wón jo před styrich abo šesćich tyźeńach humŕeł.
-WS06	Ten hogeń běšo ẃelgin śopły, te mazańce su spozy wše carne hopalone.
-WS07	Wón jě te jaja přece mimo soli a ṕeṕera.
-WS08	Te nogi mě ẃelgin bole, ja se myslim, až som se te nogi wotšurował.
-WS09	Ja som pla teje žeńskeje buł, a som jej jo gronił, a wona grońašo, wona kšěła teke jeje źowce jo groniś.
-WS10	Ja ńebudu jo wěcej cyniś.
-WS11	Ja śi deriju ned z teju měšawu za wušy, Ty nawpa!
+WS06	Ten hogeń bĕšo ẃelgin śopły, te mazańce su spozy wše carne hopalone.
+WS07	Wón jĕ te jaja přece mimo soli a ṕeṕera.
+WS08	Te nogi mĕ ẃelgin bole, ja se myslim, až som se te nogi wotšurował.
+WS09	Ja som pla teje žeńskeje buł, a som jej jo gronił, a wona grońašo, wona kšĕła teke jeje źowce jo groniś.
+WS10	Ja ńebudu jo wĕcej cyniś.
+WS11	Ja śi deriju ned z teju mĕšawu za wušy, Ty nawpa!
 WS12	Źo ty pojźoš, dejmy sobu hyś?
-WS13	Něto su śěžke casy.
+WS13	Nĕto su śĕžke casy.
 WS14	Mojo lube góle, wostań how spozy stojecy, te złe gusy śi zakuse.
-WS15	Ty sy źinsa nejžwěcej nahuknuł a sy posłušny był, ty smějoš jěsnej domoj hyś ako te druge.
+WS15	Ty sy źinsa nejžwĕcej nahuknuł a sy posłušny był, ty smĕjoš jĕsnej domoj hyś ako te druge.
 WS16	Ty ńejsy hyšći ẃeliki dosć, aby mogł flašu wina hupiś, ty derbiš perej hyšći třochu narosć a ẃetšy hordowaś.
 WS17	Źij, buź tak dobry a groń twojej sotřy, až dejała tu drastwu za wašu maś došyś a z berštu hucysćiś.
-WS18	Gaby ty jogo znał, pon by wšykno hynac přišło, a z nim lěpej było.
-WS19	Chto jo mi moju kipu z měsom hukřadnuł?
+WS18	Gaby ty jogo znał, pon by wšykno hynac přišło, a z nim lĕpej było.
+WS19	Chto jo mi moju kipu z mĕsom hukřadnuł?
 WS20	Wón cyńašo tak, ako by jogo k mośeńoju hobštelowali; ale woni su to sami cynili.
 WS21	Komu jo wón to nowe hulicowańko hulicował?
-WS22	To dejš se druch drěś, howac nam ńerozmejo.
+WS22	To dejš se druch drĕś, howac nam ńerozmejo.
 WS23	My smy mucne a łacne.
 WS24	Ako se cora wjacor domoj rośichmy, lažachu te druge juž w postolach a spachu twarźe.
-WS25	Źins nocy jo sněg lažecy wostał, žajtřa pak jo roztajał.
-WS26	Slězy našeje špy su tři jabłušcyny z cerẃenymi jabłukami.
+WS25	Źins nocy jo snĕg lažecy wostał, žajtřa pak jo roztajał.
+WS26	Slĕzy našeje špy su tři jabłušcyny z cerẃenymi jabłukami.
 WS27	Ńamožośo ga hyšće chylcycku na nas hobcakaś, pon pojźomy z wami.
 WS28	Ńebuźćo ga take źiśece.
 WS29	Naše gory ẃelgin husoke ńejsu, te waše su ẃele hušše.
-WS30	Ẃele punt jěšnicow a ẃele klěba cośo měś?
-WS31	Ja wam ńerozmeju, to dejśo lěpej druch poẃedaś.
-WS32	Ńejsćo ga kusk běłeje zejpy za ḿno na mojom bliźe namakali?
-WS33	Jogo bratř co sebe dwě rědnej nowej wjažy we wašej zagroźe natwariś.
+WS30	Ẃele punt jĕšnicow a ẃele klĕba cośo mĕś?
+WS31	Ja wam ńerozmeju, to dejśo lĕpej druch poẃedaś.
+WS32	Ńejsćo ga kusk bĕłeje zejpy za ḿno na mojom bliźe namakali?
+WS33	Jogo bratř co sebe dwĕ rĕdnej nowej wjažy we wašej zagroźe natwariś.
 WS34	To słowo hujźo jomu z hutřoby!
 WS35	To su přaẃe cynili.
 WS36	Kake tešacki tam zẃerchu na tej muŕcyce sejźe?
-WS37	Burjo běchu pěś wołow a źeẃeś krowow a dwanasćo wojckow předejs přiwjadli, woni kšěchu je předaś.
+WS37	Burjo bĕchu pĕś wołow a źeẃeś krowow a dwanasćo wojckow předejs přiwjadli, woni kšĕchu je předaś.
 WS38	Te luźe su źinsa wše na poli a syku.
 WS39	Źij jan, ten bruny pjas śi ńekusńo.
-WS40	Ja som z tymi luźimi tam slězy přez tu łuku do žyta jěł.
+WS40	Ja som z tymi luźimi tam slĕzy přez tu łuku do žyta jĕł.

--- a/56464_Briesen.csv
+++ b/56464_Briesen.csv
@@ -9,7 +9,7 @@ Transliterent: ''
 Anmerkungen: ''
 ...
 WS01	Symė lėtaju te ßuche łopėna we tom lufschė hokoło.
-WS02	Wono ße bużo ned hobschėstasch ßněg hysch, potom bużo to wedro saßej lėpsche.
+WS02	Wono ße bużo ned hobschėstasch ßnĕg hysch, potom bużo to wedro saßej lėpsche.
 WS03	Szyn hugłė do kaṁen, až to mloko ße chopio waṙisch.
 WS04	Ten dobry stary złowėk jo ße stym koṅom psches lod pschewalil, a do teje symneje wody padnul.
 WS05	Won jo pschėd styri abo schescż tyżeṅami humrėl.

--- a/56465_Striesow.csv
+++ b/56465_Striesow.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Symä lėtaju ßuche hopena wo lu̇fscḣe hoko(lo) (wo).
+WS01	Symä lėtaju ßuche hopena wo lůfscḣe hoko(lo) (wo).
 WS02	Wono bużo ße ned pschestascḣ ßṅeg hyscḣ, potom bużo lėpsche wedro.
 WS03	Szyṅ huglė do kamėn, aż to mlȯko ße jeßno chopijo wariscḣ.
 WS04	Ten dobry stary zlowėk jo stim koṅom pschės ten lȯd pscḣełamaw, a do tejė simneje wody panuw.

--- a/56467_Zahsow.csv
+++ b/56467_Zahsow.csv
@@ -14,9 +14,9 @@ WS03	Sziṅ huglė do kamen, aż to mloko ße baldim chapja warisch.
 WS04	Ten dobri stary zlowek jo stim koṅȯm do lȯdy pschėwamaw a do simneje wodi panul.
 WS05	Won jo pschėd styri abo schescż tyżėn humrel.
 WS06	Ten hogėṅ bescho parėzi, te tikaṅze ßu sposi zarne hordowali.
-WS07	Won je te jaja pschezei mimo ßoly a pėprȧ.
+WS07	Won je te jaja pschezei mimo ßoly a pėprå.
 WS08	Te nogi mė wėlgim bolė, ja wėrim, ja mam puchorė.
-WS09	Ja ßom pschȧ teje żȯnskeje bül, a ßom to jej groṅiw, a wona żȧscho, ja zu to mojej żȯwze groṅisch.
+WS09	Ja ßom pschå teje żȯnskeje bül, a ßom to jej groṅiw, a wona żåscho, ja zu to mojej żȯwze groṅisch.
 WS10	Ja jo ṅȯck tecke saßej ziṅisch.
 WS11	Ja schi deriju ned steju welikeju Żizu sa huschi, ti nawpa!
 WS12	Żo tü pojżosch, dejmü mü s’tobu hisch?
@@ -24,27 +24,27 @@ WS13	Wono ßu rijne Zaße!
 WS14	Mojo lube Golė, wostaṅ how sposi, te sle Gußi budu schi sakußisch.
 WS15	Tü ßü żinßa derė hucknul a poschluschni bül, tu dejsch jeßṅei domoj hisch, ako te drugė.
 WS16	Tü neißü hiscżi doscż weliki, janu Flaschu Wina hupisch, tü mußisch hiscżi kußk roscż a wetschi hordowasch.
-WS17	Żj, büż tak dobri, a groṅ twojej ßotschi, wona dei tu drastwu waschei motterze huschisch a derė hubėrschtowȧsch.
+WS17	Żj, büż tak dobri, a groṅ twojej ßotschi, wona dei tu drastwu waschei motterze huschisch a derė hubėrschtowåsch.
 WS18	Gabü tü jogo snal! ga bü wono hinazei pschischlo, a wono bü lėpej s’nim stojwo.
 WS19	Chto jo mė moj kȯrb s’tim mėßom hukschadnuw?
 WS20	Won ziṅascho, abü jogo nėcht na moschėnė stellȯwal; alė woṅi ßu jo ßami ziṅili.
 WS21	Komu jo won tu nowu historiju hulizowal?
 WS22	Wono ße mußi kschusche drėsch, howaz won nam ṅerosmejo.
 WS23	Mü ßmü muzne a wazne.
-WS24	Acko mü zora wȧzor naßlėtk pschiżochmü, bechu te druge już postoli a spichu.
+WS24	Acko mü zora wåzor naßlėtk pschiżochmü, bechu te druge już postoli a spichu.
 WS25	Ten ßṅeg jo tu noz pschi nas lażezi wostal, alė żinß żaitscha hotajal.
 WS26	Sa nascheju Ważu stoje tschy rėdne jabuschzini s’zerenimi jabukami.
-WS27	Możoscho ga chilku sa nami pozakȧsch - potom poiżomü s’wamy.
+WS27	Możoscho ga chilku sa nami pozakåsch - potom poiżomü s’wamy.
 WS28	Żischėze Graschė ßebė ṅedeischo prȯtk wȯsėsch.
 WS29	Nasche Gory ṅeißu welgim hußoke, te wasche ßu wėlė husche.
 WS30	Wėlė punt jeschṅize a welė klėba zoscho mėsch?
 WS31	Ja wam ṅerosmeju, wü mußischo zoschku k’schuschėi pojedasch.
 WS32	Ṅeiscżo kusk beweje sejpi sa mṅe na mojom bliże namakali?
-WS33	Jogo bratsch zo ßebe dwė rėdnei nowei Wȧżi wȯ waschom gumṅė twarisch.
+WS33	Jogo bratsch zo ßebe dwė rėdnei nowei Wåżi wȯ waschom gumṅė twarisch.
 WS34	To ßlowo pschiżo jomu s’hutschobi!
 WS35	To bėscho pschawė wot waß!
-WS36	Kakė tȧschky tam ßeiżė s’wercha na tej mury?
-WS37	Te burȧ mėjachu pėsch wȯwi a żėwėsch krowi a dwanascżo Woize prȯtku teje ßy - te k’schėchu wȯṅi pschėdȧsch.
+WS36	Kakė tåschky tam ßeiżė s’wercha na tej mury?
+WS37	Te burå mėjachu pėsch wȯwi a żėwėsch krowi a dwanascżo Woize prȯtku teje ßy - te k’schėchu wȯṅi pschėdåsch.
 WS38	Te lużė ßu ziṅßa schickne wȯnze na poli a ßeku.
-WS39	Ży jano, ten bruni pȧß schi ṅiz ṅezini.
+WS39	Ży jano, ten bruni påß schi ṅiz ṅezini.
 WS40	Ja ßom s’timi lużimi tam ßlesi pschės tu Huku do Żita jew.

--- a/56471_Merzdorf.csv
+++ b/56471_Merzdorf.csv
@@ -44,7 +44,7 @@ WS33	Jogo bratsch zo ßebe dwa rednej nowej chroma we waschogo guhna natwarisch.
 WS34	To ßlowo jo pschischwo wot hutschobi.
 WS35	To bėscho pschawė wot was.
 WS36	Kake taschazki sejże na tei murizi.
-WS37	Te burȧ ßu peschoch wow’ a żewesch krow’ a dwanascżo woizkow psched tu ßu pschijadli, te ßame ßu kschėli woni pschedasch.
+WS37	Te burå ßu peschoch wow’ a żewesch krow’ a dwanascżo woizkow psched tu ßu pschijadli, te ßame ßu kschėli woni pschedasch.
 WS38	Te luże ßu żinza schikne wȯnze na tom pȯlu a ßeku.
 WS39	Ży jan, ten bruni pjas tėbe niz nezini.
 WS40	Ja ßom stimi lużimi tam ßlesi psches huku do żitta sajėw.

--- a/56473_Döbbrick.csv
+++ b/56473_Döbbrick.csv
@@ -15,7 +15,7 @@ WS04	Ten dobry stary muž jo stym koṅom ße psches ten lȯd pschewamaw a jo do
 WS05	Won jo psched styri abo schescż tyžeṅami humrėw.
 WS06	Ten hȯgėṅ jo byw wėlgi parėzy, te tykaṅze ßu sposi zewe zarne spalȯne.
 WS07	Won je tė jaja mimo ßoli a pėpṙa.
-WS08	Tė nogi mė wėlgi bȯle ja wėrim až ßom je pschėgȧṅaw.
+WS08	Tė nogi mė wėlgi bȯle ja wėrim až ßom je pschėgåṅaw.
 WS09	Ja ßom pschi tej Žeṅßkej byw a ßom jej groniw, a wona groṅi, až zo jo jeje Žowze tėkė groṅisch.
 WS10	Ja jo ṅok tėkė wezej saßej zyṅisch.
 WS11	Ja klaßnu schi ned steju warėṅzu hokowo huschowu, ty naupa.
@@ -32,7 +32,7 @@ WS21	Komu jo won te nowė hulizowaṅe hulizowaw?
 WS22	My ße mußymy drėsch, howazej won nam nerosmėjo.
 WS23	My ßmy muzne a wazne.
 WS24	Ako my zora w’jazor saßej pschižochmy, lažachu tė druge pȯstoli a spachu twardo.
-WS25	Ten ßṅeg jo tu noz pschi naß lȧžezy westaw, ale žinß [žei] sajutscha jo wotajaw.
+WS25	Ten ßṅeg jo tu noz pschi naß låžezy westaw, ale žinß [žei] sajutscha jo wotajaw.
 WS26	Sa naschim domom stoje tschi jabukowe bomki s’zerėnymi jabukami.
 WS27	Ṅamȯžoscho wy jadno hokognusche na naß zakasch, petom pojžomy s’wami.
 WS28	Wy ṅedejscho tak žischėzė bysch.

--- a/56477_Grötsch.csv
+++ b/56477_Grötsch.csv
@@ -31,20 +31,20 @@ WS20	Wön zinascho tak, abü woni jogo na Mo<Mlo>schene hobstellowali; woni pak 
 WS21	Komu jo wön to nowe Tschojeṅe hulizowaw<l>?
 WS22	<(Wir)> Mü mußimi ße welgi<(in)> dresch, howazei wön nas nerosmejo.
 WS23	Mü ßmü muzne a wazne <(lazne)>.
-WS24	Ako mü zora Wȧzor naßletk pschiźechmü, ga laźachu te Druge <(jusch)> juź Postoli a bechu twardo wö Spaṅu.
+WS24	Ako mü zora Wåzor naßletk pschiźechmü, ga laźachu te Druge <(jusch)> juź Postoli a bechu twardo wö Spaṅu.
 WS25	Ten ßnėg jo tu Noz pschi nas wöstal<aw> laźezi, alė źinß Sajutscha jo won ße ßlisnul.
-WS26	Sa nascheju Wȧźu stoje tschi rėdne Jabu<blu>zinki szerėnimi Jabluschkami.
+WS26	Sa nascheju Wåźu stoje tschi rėdne Jabu<blu>zinki szerėnimi Jabluschkami.
 WS27	Ṅamoźoscho wü hiscźi jano Hokognusche na nas zakasch, pötom źomü mü swami.
 WS28	Wü nedeischo taki Dumzeig treibowasch.
 WS29	Nasche Gori neißu welgi hußoke, wasche ßu wėle husche.
 WS30	Kak wėle Punt Jeschnize a kak wėle Kleba zoscho wü mėsch?
 WS31	Ja was ṅerosmeju, wü mußischo zoschku lepei pojedasch.
 WS32	Ṅeiscźo wü źeden Kusk bewe<le>je Seipi samṅo na mojom Bliźė namakali?
-WS33	Jogo Bratsch zo ßebe dwė nowei Wȧźi wö waschom Gumńe twarisch.
+WS33	Jogo Bratsch zo ßebe dwė nowei Wåźi wö waschom Gumńe twarisch.
 WS34	To ßwo<lo>wo pschiźescho jomu wot Hutschobi.
 WS35	To bescho pschawe wot nich!
 WS36	Kake Taschazki tam ßeiźe na tei Muri?
-WS37	Te Burȧ ßu pesch Wöw<öl> a źewesch Krow a dwanascźo Woizkow psched Wȧs pschijadli, te kschechu wöni pschedasch.
+WS37	Te Burå ßu pesch Wöw<öl> a źewesch Krow a dwanascźo Woizkow psched Wås pschijadli, te kschechu wöni pschedasch.
 WS38	Te Luźe ßu źinßa schikne wönze na Poli <(na tom Polu)> a ßeku.
 WS39	Źi jano, ten bruni Pjas schi niz ṅeziṅi.
 WS40	Ja ßom stimi Luźimi tam ßlesi psches tu Huku <(Luku, Uku)> do Źita jew <(jel)>.

--- a/56478_Groß-Ossnig.csv
+++ b/56478_Groß-Ossnig.csv
@@ -43,7 +43,7 @@ WS32	Ṅejscżo wy žeden kusk bełeje sejpy sa mńo na mojom bliże namakali?
 WS33	Jogo bratſch zo ßebe dwé rédnej wjažy we waſchom gumńe twarisch.
 WS34	To ßłowo pschiże jomu wot hutschoby.
 WS35	To beſcho pschawé wot nich.
-WS36	Kake to taſchazki tam ßeiże sẇercha na tej murjy?
+WS36	Kake to taſchazki tam ßeiże sẃercha na tej murjy?
 WS37	Te burja bechu peschoch wołow a żewesch krow a dwanascżo wojzkow psched tu wjaß sporali, te kschechu woni pschedasch.
 WS38	Te luże ßu żinß ſchykne wonze na poli a ßekaju.
 WS39	Żi jano, ten bruny pjaß tebe niz nezyni.

--- a/56483_Greifenhayn.csv
+++ b/56483_Greifenhayn.csv
@@ -6,7 +6,7 @@ Bogentyp: NMD_1879/80
 Erhebung: ''
 Transliterationsprojekt: ''
 Transliterent: ''
-Anmerkungen: 'aus: Stone, Gerald (2003): Der erste Beitrag zur sorbischen Sprachgeographie. Aus dem Archiv des deutschen Sprachatlas. In Lětopis 50. Zeitschrift für sorbische Sprache, Geschichte und Kultur. Sonderherft. Bautzen: Domowina-Verlag. S. 77.'
+Anmerkungen: 'aus: Stone, Gerald (2003): Der erste Beitrag zur sorbischen Sprachgeographie. Aus dem Archiv des deutschen Sprachatlas. In Lĕtopis 50. Zeitschrift für sorbische Sprache, Geschichte und Kultur. Sonderherft. Bautzen: Domowina-Verlag. S. 77.'
 ...
 WS01	Symje huljetuju ssuche lopjena psches ljuft. 
 WS02	Ssnjeg ned pschestanio huletowasch, potom wjedro sassej ljepsche buźo. 

--- a/56492_Trebendorf.csv
+++ b/56492_Trebendorf.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	We zÿmě lětaja te suche lisče w lofćě wokoło.
-WS02	Ten sněg so zmolom čestanjo, potom bdže zas lěpše wědro.
-WS03	Ćin kole do kachlě, až to mloko skerě kopi so warić.
-WS04	Ton dobry stary muski je so zkonjom na lodžě pšełamał a do teje zymneje wody panuł.
+WS01	We zÿmĕ lĕtaja te suche lisče w lofćĕ wokoło.
+WS02	Ten snĕg so zmolom čestanjo, potom bdže zas lĕpše wĕdro.
+WS03	Ćin kole do kachlĕ, až to mloko skerĕ kopi so warić.
+WS04	Ton dobry stary muski je so zkonjom na lodžĕ pšełamał a do teje zymneje wody panuł.
 WS05	Won je psched štyrimi aby šesć tydženami wumreł.
-WS06	Ta hěca je była jara welika, te tykance su šak so spody cylě zesmudžili.
+WS06	Ta hĕca je była jara welika, te tykance su šak so spody cylĕ zesmudžili.
 WS07	Won jy te jaja bes soli a bes poprja.
-WS08	Te nogi me jara bolja, ja wěrim, až som sebi je přejšeł.
+WS08	Te nogi me jara bolja, ja wĕrim, až som sebi je přejšeł.
 WS09	Ja sym pola teje ženskeje był a som jo jej prajił, a wona jo prajiła, zo chce jo swojej džowzy tejž prajić.
-WS10	Ja tejž něcham to wjacy činić!
-WS11	Ja če ned zteju měšawu za wuši klěsnjom, ty nawpa!
+WS10	Ja tejž nĕcham to wjacy činić!
+WS11	Ja če ned zteju mĕšawu za wuši klĕsnjom, ty nawpa!
 WS12	Džo ty džoš, derimy my tejš sobu hić.
 WS13	To su hubjene časy.
-WS14	Moje lube džěčo, wostań jow delkach stejo, te złe husy če zakusaju.
+WS14	Moje lube džĕčo, wostań jow delkach stejo, te złe husy če zakusaju.
 WS15	Ty sy džensa najwjacy nawuknył, a sy pjekny był, ty moš predy domoj hić ako te druhe.
 WS16	Ty hišće nejsy weliki dosc, až by mogl flašu wina wupić, ty musyš hišće kusk rosć a wekši wordować.
-WS17	Dži, być tak dobry a praj twojej sostrě, wona deri tu drastu za wašu mać zešić a z byrštu wubyrštować.
-WS18	Dy by ty jog znał, tedy by to hinak přišło, a wono by lěpě za njogo było.
+WS17	Dži, być tak dobry a praj twojej sostrĕ, wona deri tu drastu za wašu mać zešić a z byrštu wubyrštować.
+WS18	Dy by ty jog znał, tedy by to hinak přišło, a wono by lĕpĕ za njogo było.
 WS19	Štu je mi moj korb z tym mjesom hukranył?
 WS20	Won ćineše tak, kaž bychu jogo na młočenje hobštellowali; woni pak su jo sami činili.
 WS21	Komu je won ton nowy podawk hulicowal?
-WS22	To musy wostrě wołać, howak nam nerozmejo.
+WS22	To musy wostrĕ wołać, howak nam nerozmejo.
 WS23	My smy mucne a laćne.
-WS24	Dyž smy my čora wećor curik přišli, da ležachu te druge hužom w postoli a běchu w twerdym spanju.
-WS25	Ton sněg je w nocy při nas lejžo wostał, džens rano pak je zaso wottajał.
+WS24	Dyž smy my čora wećor curik přišli, da ležachu te druge hužom w postoli a bĕchu w twerdym spanju.
+WS25	Ton snĕg je w nocy při nas lejžo wostał, džens rano pak je zaso wottajał.
 WS26	Za našim twarenjom stoja ci rjane jabłonje s čerwonymi jabłukami.
 WS27	Nemočo wy hišće wokomiknenje na nas čakać, da potom džomy zwami.
-WS28	Wy nedyrbiče tajke lozystwo čěrić.
+WS28	Wy nedyrbiče tajke lozystwo čĕrić.
 WS29	Naše Gory nejsu jara wósoke, te waše su wele wóše.
-WS30	Kak wele puntow woršty a kak wele klěba cojčo wy měć.
-WS31	Ja wam něrozmejom, wy dyričo kusk wostrejšo powedać.
-WS32	Nejsčo žeden kusk běłego mydla na mojom blidže namakali?
-WS33	Jog bratr co sebi dwě rjanej twarenji do wašej zarodže natwarić.
+WS30	Kak wele puntow woršty a kak wele klĕba cojčo wy mĕć.
+WS31	Ja wam nĕrozmejom, wy dyričo kusk wostrejšo powedać.
+WS32	Nejsčo žeden kusk bĕłego mydla na mojom blidže namakali?
+WS33	Jog bratr co sebi dwĕ rjanej twarenji do wašej zarodže natwarić.
 WS34	To słowo ćišło jomu wot wutroby.
 WS35	To jo było prawje wot nich.
 WS36	Co sedži tam za taški gorejka na tej murji?
-WS37	Te burja <su> běchu pěć wołow a džeweč krowow a dwanače wowckow pšed tu wěs čignali, te cychu pšedać.
-WS38	Te ludžo su džensa wšě wenkach na poli a syčeja.
-WS39	Dži jeno, ten bruny pěs či nic něcini.
-WS40	Ja som ztymi ludžimi tam zady pšes tu łuku do zito jěhł.
+WS37	Te burja <su> bĕchu pĕć wołow a džeweč krowow a dwanače wowckow pšed tu wĕs čignali, te cychu pšedać.
+WS38	Te ludžo su džensa wšĕ wenkach na poli a syčeja.
+WS39	Dži jeno, ten bruny pĕs či nic nĕcini.
+WS40	Ja som ztymi ludžimi tam zady pšes tu łuku do zito jĕhł.

--- a/56499_Bröthen.csv
+++ b/56499_Bröthen.csv
@@ -9,12 +9,12 @@ Transliterent: ''
 Anmerkungen: ''
 ...
 WS01	Wsymi lecža ßuche łopena lofcži.
-WS02	Nydom budže ßo sastacž ßnehowacz, potom budže wedro lěpsche.
+WS02	Nydom budže ßo sastacž ßnehowacz, potom budže wedro lĕpsche.
 WS03	Nametaj wuchlje do kachli, so ßo mloko sapoczne waricž.
 WS04	Tonlje dobry stary muž je ßo na lodži pschepanył a je do symneje wody panył.
-WS05	Won je psched stěri aby schescž nedželemi wumreł.
-WS06	Ton wŏhen bě jara wilki, te tykanzy ßu spody zyłe czorne pschepalene.
-WS07	Won jě jeja pschezy bes ßelje a poperja.
+WS05	Won je psched stĕri aby schescž nedželemi wumreł.
+WS06	Ton wŏhen bĕ jara wilki, te tykanzy ßu spody zyłe czorne pschepalene.
+WS07	Won jĕ jeja pschezy bes ßelje a poperja.
 WS08	Nohi me jary bola, ja cžuju, ßo ßym ßebi je wotcžischcžał.
 WS09	Ja ßym pschi tej Žoni był, a ßym jej prajił, a wona mi praji, so chze jo tež jeje džowzy prajicž.
 WS10	Ja jo tež nochzu saßo cžinicž!
@@ -25,7 +25,7 @@ WS14	Moje lube džecžo wostan jow delka stejo, te słe hußy cže sakuschu!
 WS15	Ty ßy dženßa najazy nawuknył, a ßy pekny był, ty mož skere dom hicž, hacž te tamne.
 WS16	Ty hischcže neßy wilki doscz, so moł bleschu wina wupicž, ty dyrbisch hischcže neschto pschiroscž a wjecži wordowacž.
 WS17	Dzi, bydcž tak dobry a praj twojej ßotzi, wona dyrbi tu drastu sa waschu mamu doschicz a ju se schcžetku wupuzowacž.
-WS18	Byli ty jeho snał! da by hinak pschischwo a snim by lěpe stejałe.
+WS18	Byli ty jeho snał! da by hinak pschischwo a snim by lĕpe stejałe.
 WS19	Schtu je mi moj korb smjaßom kranył?
 WS20	Won pak cžinesche, jako byschcže jeho kmocženenju wobschtelowali, wy pak scže jo ßami cžinili.
 WS21	Komu je won ton nowy podawk powedał?
@@ -33,18 +33,18 @@ WS22	Wotße ßo mußy łowacž, hewak nam nerosymi.
 WS23	My ßmy mucžne a ßmy lacžni.
 WS24	Jako cžera wecžor dom pschindžechmy, da tamni hischno ležachu a krucže spachu.
 WS25	Ssne je tu noz ležo wostał, a rano neje rostał.
-WS26	Sady naschej kějze steja tsi rjane jabucžinki scžerwenymi jabucžkami.
+WS26	Sady naschej kĕjze steja tsi rjane jabucžinki scžerwenymi jabucžkami.
 WS27	Nemoschcže hischcže chwilcžicžku pocžakacž, potom swami pondcžemy.
 WS28	Wy nedyrbicže tajke džecžastwo honicž.
 WS29	Nasche hory nejßu jary hußoke, wasche ßu welje husche.
 WS30	Kak welje puntow kobaßy a kak welje kleba zecže mecž?
 WS31	Ja wam nerosymju, wy dyrbicže wotschischo rycžecž.
-WS32	Nescže schadyn kusk běweho modła na mojim blidaschku samnje namkali?
-WS33	Jeho bratr chze ßebi dwě rjanej twareni we waschej sarodži twaricž.
+WS32	Nescže schadyn kusk bĕweho modła na mojim blidaschku samnje namkali?
+WS33	Jeho bratr chze ßebi dwĕ rjanej twareni we waschej sarodži twaricž.
 WS34	Te ßłowo pschindže jemu swutrobu?
-WS35	To běsche prowje wot was!
+WS35	To bĕsche prowje wot was!
 WS36	Kajke ptacžicžki ßedža tam na tej muricžki?
-WS37	Burja běchu pecž wołow a džewecž kruwow a dwanacž jechnjatow pschedwßy pschichnali, te chzychu woni pschedacž.
-WS38	Tě ludžo ßu dzenßa wschitzy na poli a wßykaja.
+WS37	Burja bĕchu pecž wołow a džewecž kruwow a dwanacž jechnjatow pschedwßy pschichnali, te chzychu woni pschedacž.
+WS38	Tĕ ludžo ßu dzenßa wschitzy na poli a wßykaja.
 WS39	Dži nur, ton bruny pßyk cži niz necžini.
 WS40	Ja ßym stymi ludżimi tam sady psches łuku do žita jeł.

--- a/56500_Nardt.csv
+++ b/56500_Nardt.csv
@@ -14,7 +14,7 @@ WS03	Tschin Kohlu do Kachli, so ßo te Mloko waricż kopino.
 WS04	Ton dobry stary Muż je seß tym Konjom ßo na lodże pschepanu a do symneje Wody panił.
 WS05	Won je sa schtyri aby sa schescż nedcżel wumreł.
 WS06	Ton Woh<j>ejn jo bu jara horzy, te Tikanze ßu spody ganz cżorne spalene.
-WS07	Won hjě te Jejka pschezo beß Sylje a Poperja.
+WS07	Won hjĕ te Jejka pschezo beß Sylje a Poperja.
 WS08	Te Nohi mi jara bola, ja ßo mußlu, so ßym ße je pschehanjawł.
 WS09	Ja ßym pschi te żone bu a ßym <jo> jej prajił, a wona prajesche, so chze też jeje dżowze prajicż.
 WS10	Ja jo necham saßo cżinicż.

--- a/56501_Bergen.csv
+++ b/56501_Bergen.csv
@@ -9,42 +9,42 @@ Transliterent: ''
 Anmerkungen: ''
 ...
 WS01	Wsymme ßuche liscze loftcze lecza.
-WS02	Wone glei pschestane ßně ßo hicz, potom budze wedró saß lěpsche.
+WS02	Wone glei pschestane ßnĕ ßo hicz, potom budze wedró saß lĕpsche.
 WS03	Cžin wuhlo do kachli, só mloko kopina ßo waricz.
 WS04	Ten (bo) dobry stary musch je ßo na lódzi pschewamaw a dó symneje wody panył.
 WS05	Wón jo psched schtyri abu nedzelemi samreł.
 WS06	Ten wohen bysche jara horzy; te tykanzy ßu ßó delka seßmudzili.
-WS07	Ten te jeka pschezy bes ßele a popera jě.
+WS07	Ten te jeka pschezy bes ßele a popera jĕ.
 WS08	(Te) Nóhi mi jary bóla; mi ßo sda, só ßym ßej je wobschurwaw.
 WS09	Ja ßym pschi tej źoni pobuł a jej wurychtwaw a wóna meńesche, só ze ßwojej źozy tejsch wurychtwacz.
 WS10	Ja jó necham jaz czinicz.
 WS11	Ja cze glei sdrejanej źyzu sawschy ßunu, ty wopiza.
 WS12	Dze dzesch, dyrbimy stobu hicz?
 WS13	Wone ßu hubenje czaßy.
-WS14	Moje lubje dzěczo, wostan hew deleko, te słó huße cze sakuschu.
-WS15	Ty ßy dzenß naj jazy wuknyw a ßy poßwuschny buł. Ty ßměsch predy domoj hicz hacz te druhe.
+WS14	Moje lubje dzĕczo, wostan hew deleko, te słó huße cze sakuschu.
+WS15	Ty ßy dzenß naj jazy wuknyw a ßy poßwuschny buł. Ty ßmĕsch predy domoj hicz hacz te druhe.
 WS16	Ty nejßy hischcze wilki dosz, só bu moł flaschu wina wupicz; ty dejsch haklej kónz pschiroscz a wetschi wordwacz.
-WS17	Dzi, bucz tak dobry a praj twojej ßotzi, wóna dej sa waschu mammu tu drastu hottowu seschycz a se schczětku wupozwacz.
-WS18	Bu jó sesnał, dha bu hinak pschischło a wono bu lěpje sa njo buło.
+WS17	Dzi, bucz tak dobry a praj twojej ßotzi, wóna dej sa waschu mammu tu drastu hottowu seschycz a se schczĕtku wupozwacz.
+WS18	Bu jó sesnał, dha bu hinak pschischło a wono bu lĕpje sa njo buło.
 WS19	Schtu jo mi moj korb <sjm> smjaßom krachnył?
 WS20	Wón czinesche, hakó buchu jó kmóczenju wobschtelwali; wóni pak ßu to ßami czinili.
 WS21	Kommu jó won tu nołu schichtu pojedał?
 WS22	Jedn dejsch wócze wołacz (wołacz) hewak wón naß nerósemi.
 WS23	Mu ßmu wódne a nam ze ßo picz.
 WS24	Dysch wczera zurück pschindzechmu, leźachu te druhe hiźom woźu a kopinachu spacz.
-WS25	Ssně jo tu nóz wu leźó wostał, ale dzenß rano jo rostał.
+WS25	Ssnĕ jo tu nóz wu leźó wostał, ale dzenß rano jo rostał.
 WS26	Poßledy naschó twarenja stója czi rjane jabucziny s czerwenymi jabukami.
 WS27	Nemóli kwilku na naß czakacz, potom swami dźemu.
-WS28	Njebucze tak dzěczaze.
+WS28	Njebucze tak dzĕczaze.
 WS29	Nasche hory nejßu wußoke, wasche ßu wusche.
-WS30	Ka wele puntow kołbaßy a ka wele klěba zecze měcz?
-WS31	Ja waß nerósemju, wó dejczě kuß bole wotcze pojedacz.
-WS32	Nejßze kruch běwo mudła na mojom blidźe sa mnje namakali?
-WS33	Jóhó bratr ze ßej naschej saródzi dwě rjanej twareni stajicz.
+WS30	Ka wele puntow kołbaßy a ka wele klĕba zecze mĕcz?
+WS31	Ja waß nerósemju, wó dejczĕ kuß bole wotcze pojedacz.
+WS32	Nejßze kruch bĕwo mudła na mojom blidźe sa mnje namakali?
+WS33	Jóhó bratr ze ßej naschej saródzi dwĕ rjanej twareni stajicz.
 WS34	To ßłowó jom wót wutroby pschindze.
-WS35	To bě praje wot waß.
+WS35	To bĕ praje wot waß.
 WS36	Kajke taschki tam na muri ßejdźa?
-WS37	Te burja běchu pecz wowow a dźewecz krowow a dwanacz jechnata psched weß pschinesli; te zychu woni pschedacz.
+WS37	Te burja bĕchu pecz wowow a dźewecz krowow a dwanacz jechnata psched weß pschinesli; te zychu woni pschedacz.
 WS38	Ludźe ßu dzenß schytke wonkó na poli a ßykaja.
 WS39	Dzi doch, ten bruny poß czi niz neczini.
 WS40	Ja ßym (tamle kónz) stymi ludzimi tam poßledy psches wuku do źyta ßo purał.

--- a/56507_Nochten.csv
+++ b/56507_Nochten.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	We Symje lětaja te ßuche Wopena we Loftcźi wokoło.
-WS02	Wone budźe ßo skoro sastacź Ssněh hicź, potom budźe Wjedro saßo lěpsche.
+WS01	We Symje lĕtaja te ßuche Wopena we Loftcźi wokoło.
+WS02	Wone budźe ßo skoro sastacź Ssnĕh hicź, potom budźe Wjedro saßo lĕpsche.
 WS03	Cźin Wuhlow do Kachlow, so ßo Mloko skoro wari.
 WS04	Tón dobry stary Muž je ßo se ßwojim Konjom <psches> na Lodźi psche<s>łamał, a do symneje Wody panyl.
-WS05	Wón je psched schtyrjemi aby schěscźemi Njedźelemi wumreł.
-WS06	Hěza běsche zu wulka, Tykanzy ßu schak spody zylje czorne spalene.
-WS07	Wón jě Jajka pschezo bjes Sselje a Poprja.
-WS08	Nohsy mi jara bolitej, ja ßej myßlu, so ßym jej ßebi pscheběžał.
+WS05	Wón je psched schtyrjemi aby schĕscźemi Njedźelemi wumreł.
+WS06	Hĕza bĕsche zu wulka, Tykanzy ßu schak spody zylje czorne spalene.
+WS07	Wón jĕ Jajka pschezo bjes Sselje a Poprja.
+WS08	Nohsy mi jara bolitej, ja ßej myßlu, so ßym jej ßebi pschebĕžał.
 WS09	Ja ßym pschi tej Žonje byl, a ßym jej to prajil, a wona prajesche, so ze to tejž ßwojej dźowzy prajicź.
 WS10	Ja to njecham jazy cźinicź.
-WS11	Ja cźe <dyru> gleich stej Měschału sa Wuschi dyru, ty Wopi<w>za!
+WS11	Ja cźe <dyru> gleich stej Mĕschału sa Wuschi dyru, ty Wopi<w>za!
 WS12	Dźe ty dźež, dyrbimy stobu hicź?
 WS13	Wone ßu hubene Cźaßy.
-WS14	Moje lube dźěcźo, wostań tu delekach stejo, te słe hußy cźe sakußaja.
-WS15	Ty ßy dźenßa najwjaz nawuknył, a ßy pěkny był, ty móžesch <prj> prjedy dom hicź, hacź cźi druhsy.
+WS14	Moje lube dźĕcźo, wostań tu delekach stejo, te słe hußy cźe sakußaja.
+WS15	Ty ßy dźenßa najwjaz nawuknył, a ßy pĕkny był, ty móžesch <prj> prjedy dom hicź, hacź cźi druhsy.
 WS16	Ty hischcźen njeßy wulki doscź, so by jenu Fleschu Wina wupicź mohł, ty dyrbisch hischcźen Lochcź naroscź a wjecźi wordowacź.
-WS17	Dźi, bycź tak dobry a praj twojej Ssotrje, so by tä Drasty sa waschu Macźer doschiła, a stej Běrschtu <wucźiscźiły> wucźiscźiła.
-WS18	Dy by ty jeho snał! da by hinak pschischło, a by lěpe snim stejało.
+WS17	Dźi, bycź tak dobry a praj twojej Ssotrje, so by tä Drasty sa waschu Macźer doschiła, a stej Bĕrschtu <wucźiscźiły> wucźiscźiła.
+WS18	Dy by ty jeho snał! da by hinak pschischło, a by lĕpe snim stejało.
 WS19	Schtó je mi moj Korbik stym Mjaßom kranył?
 WS20	Wón tak cźinjesche, jako bychu jeho k Mócźenju <wobschtellowali> najeli; woni pak to ßu ßami cźinili.
 WS21	Komu da je tu nowu historiju powjedal.
 WS22	Wone dyrbi ßo wótse wołacź, hewak wón nas njerosemi.
 WS23	My ßmy sprózni a nam ze ßo picź.
-WS24	Jako ßo cźera <dom> Wjecźor dom wrócźichmy, da žno běchu schitzy do Łoža schli, a běchu twjerdźen wußnyli.
-WS25	Tón Ssněh je tu Noz pola nas lejžo wostał, ale dźenßa rano je wottał.
+WS24	Jako ßo cźera <dom> Wjecźor dom wrócźichmy, da žno bĕchu schitzy do Łoža schli, a bĕchu twjerdźen wußnyli.
+WS25	Tón Ssnĕh je tu Noz pola nas lejžo wostał, ale dźenßa rano je wottał.
 WS26	Sady nascheho twarjenja steja tsi rjane Jablonki s cźerwjenolizkatymi Jabluschkami.
 WS27	Njemóžecźe hischcźen Kwilku na nas cźakacź, da dźemy swami.
-WS28	To ßo sa was njehodźi, tajke dźěcźaze Rajki cźinicź.
+WS28	To ßo sa was njehodźi, tajke dźĕcźaze Rajki cźinicź.
 WS29	Nasche Hory tak wóßoke njeßu, wasche ßu wjele wósche.
-WS30	Kak wjele Puntow Kolbaßy a kak wjele Klěba zecźe měcź.
+WS30	Kak wjele Puntow Kolbaßy a kak wjele Klĕba zecźe mĕcź.
 WS31	Ja wam njerosemju, wy dyrbicźe bólje <wós> wótsje rycźecź.
-WS32	Njescźe wy Kusk běłeho Módła sa mnje na mojim Blidźi namakali?
-WS33	<Wasch> Jeho Bratr ze ßebi dwě rjanej Kěži we waschej Sahrodźi natwaricź.
+WS32	Njescźe wy Kusk bĕłeho Módła sa mnje na mojim Blidźi namakali?
+WS33	<Wasch> Jeho Bratr ze ßebi dwĕ rjanej Kĕži we waschej Sahrodźi natwaricź.
 WS34	To Ssłowo pschindźe jemu wot Wutroby.
-WS35	To bě prawje wot was.
+WS35	To bĕ prawje wot was.
 WS36	Kajke tam ßejdźa Ptacźki na Murzy?
-WS37	Burjo mějachu pjecź Wołow a dźewjecź Kruwow a <dź> dwanacźe Wowzkow psched Wjeß pschiwjedli na Pschedan.
+WS37	Burjo mĕjachu pjecź Wołow a dźewjecź Kruwow a <dź> dwanacźe Wowzkow psched Wjeß pschiwjedli na Pschedan.
 WS38	Ludźo ßu dźenßa schitzy na Polu a ßycźeja.
 WS39	Dźi nož, tón bruny Peß cźi nicźo njecźini.
-WS40	Ja ßym sLudźimi tam sady psches tu Łuku po Žito jěł.
+WS40	Ja ßym sLudźimi tam sady psches tu Łuku po Žito jĕł.

--- a/56508_Haide.csv
+++ b/56508_Haide.csv
@@ -8,39 +8,39 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	We symě lětaja te ßuche lopěna psches ten loft wokolo.
-WS02	Wono ße dźěstano nět labrowacž, pon wordujo to ẃedro saßej lěpsche.
-WS03	Szyn wuglě do tych kachli, až to mloko baldy ße waridź schopně.
-WS04	Ten dobry stary muž jo stym końom zěž ten lod zělamal a do teje symneje wody walil.
-WS05	Won jo pschěs styrimi aby schesdź necžělami wumrěl.
-WS06	Ten wogěn jo byl zu parjacźy, te tykanze ßu da spoda zele zarne spalěne.
-WS07	Won jě te jaja zecźe bes ßoli a popza.
-WS08	Te nogy zujarě bolěja, ja wěrim, ja ßem je zegnal.
-WS09	Ja ßem dźi tej źěnscze byl a ßem je prajil, a wona prajila, wona ze jo tesch jejě dźowze prajisch.
+WS01	We symĕ lĕtaja te ßuche lopĕna psches ten loft wokolo.
+WS02	Wono ße dźĕstano nĕt labrowacž, pon wordujo to ẃedro saßej lĕpsche.
+WS03	Szyn wuglĕ do tych kachli, až to mloko baldy ße waridź schopnĕ.
+WS04	Ten dobry stary muž jo stym końom zĕž ten lod zĕlamal a do teje symneje wody walil.
+WS05	Won jo pschĕs styrimi aby schesdź necžĕlami wumrĕl.
+WS06	Ten wogĕn jo byl zu parjacźy, te tykanze ßu da spoda zele zarne spalĕne.
+WS07	Won jĕ te jaja zecźe bes ßoli a popza.
+WS08	Te nogy zujarĕ bolĕja, ja wĕrim, ja ßem je zegnal.
+WS09	Ja ßem dźi tej źĕnscze byl a ßem je prajil, a wona prajila, wona ze jo tesch jejĕ dźowze prajisch.
 WS10	Ja nocham jo tesch jazej saßej zynisch.
 WS11	Ja mausnom tebe net ßteju warenizu wokolo teju wuschowu, ty naupa.
-WS12	Dźě ga ty dźeß, derimy my ßobu stebu hẏcź?
-WS13	To ßu nědobre zaße.
-WS14	Mojo lube dscheczo, wostan wostan how deleka stojo, te sle guße sakußaja tebě nabogě.
-WS15	Ty ßy dźenßa nej lepej wuknul a ßy byl poschluschny, ty derisch perej domoj hićz ak te drugě.
-WS16	Ty hyschi neßy wěliki doscź, aby nednu flaschu wina wupitsch, ty mußisch pěre hyschcźi jeden konz naroscz a jatschy wordowasch.
-WS17	Dźi, bysch tak dobry a preij twojej schostrě, wona derila tu drastu sa jich Maczěrě gotowu seschicž a steju berstu zystu zynicž.
+WS12	Dźĕ ga ty dźeß, derimy my ßobu stebu hẏcź?
+WS13	To ßu nĕdobre zaße.
+WS14	Mojo lube dscheczo, wostan wostan how deleka stojo, te sle guße sakußaja tebĕ nabogĕ.
+WS15	Ty ßy dźenßa nej lepej wuknul a ßy byl poschluschny, ty derisch perej domoj hićz ak te drugĕ.
+WS16	Ty hyschi neßy wĕliki doscź, aby nednu flaschu wina wupitsch, ty mußisch pĕre hyschcźi jeden konz naroscz a jatschy wordowasch.
+WS17	Dźi, bysch tak dobry a preij twojej schostrĕ, wona derila tu drastu sa jich Maczĕrĕ gotowu seschicž a steju berstu zystu zynicž.
 WS18	Dyby ty jogo snal! téden by to hinaz pschischlo, a by to lepej wokolo nogo stojalo.
 WS19	Chto jo my moj kerb stym ḿaßom hukradnul?
 WS20	Won jo tak zynil, kajsch by woni jogo k mloźenoju hobstelowali, woni ßu jo ale ßami sźinyli.
 WS21	Komu jo won tu nowu schichtu hulizowal?
-WS22	Jaden mußy mozně wolacž, howacž won nam ńěrosmejě.
+WS22	Jaden mußy moznĕ wolacž, howacž won nam ńĕrosmejĕ.
 WS23	My ßmy muzne a mami laznoscź.
-WS24	Dysch ßmy my zora ẃazor dom pschischli, teden ßu te trugě postoli a ßu byli twardo we spańu.
-WS25	Ten ßněg jo tu noz pschi naß ležo wostal, alě dźinßa rano jo won wotajal.
-WS26	Zady naschěg twarěna stojeja tschi jablukowe bomy stemi zerwěnimi jablukami.
-WS27	Nemocze wy ischi jedno wokomikněne na naß zakacž, potom dschemi my ßobu swami.
-WS28	Wy nedericže take dźecžace waschně gnacž.
-WS29	Nasche gori nejschu jare hußoke, te wasche ßu wělě huße.
-WS30	Wělě puntow worschty a wělě chleba cecżě mecž?
-WS31	Ja nerosmějem waß, wy mußiczě kusk schorfně pojedacž.
-WS32	Nejscě wy žadyn kusk belejě sejpy samně na mojim blidcźě namakali?
-WS33	Jogo bratr ze ßebe dwě radne weži we wasché zarodže natwaricž.
+WS24	Dysch ßmy my zora ẃazor dom pschischli, teden ßu te trugĕ postoli a ßu byli twardo we spańu.
+WS25	Ten ßnĕg jo tu noz pschi naß ležo wostal, alĕ dźinßa rano jo won wotajal.
+WS26	Zady naschĕg twarĕna stojeja tschi jablukowe bomy stemi zerwĕnimi jablukami.
+WS27	Nemocze wy ischi jedno wokomiknĕne na naß zakacž, potom dschemi my ßobu swami.
+WS28	Wy nedericže take dźecžace waschnĕ gnacž.
+WS29	Nasche gori nejschu jare hußoke, te wasche ßu wĕlĕ huße.
+WS30	Wĕlĕ puntow worschty a wĕlĕ chleba cecżĕ mecž?
+WS31	Ja nerosmĕjem waß, wy mußiczĕ kusk schorfnĕ pojedacž.
+WS32	Nejscĕ wy žadyn kusk belejĕ sejpy samnĕ na mojim blidcźĕ namakali?
+WS33	Jogo bratr ze ßebe dwĕ radne weži we wasché zarodže natwaricž.
 WS34	To ßlowo přidže jomu wot wutroby.
 WS35	To bylo prawe wot nich.
 WS36	Zo ßedźeja tam sa p taschatki goreka na tej murce?

--- a/56509_Brandt.csv
+++ b/56509_Brandt.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	We symě lětaja te ßuche lopěna psches ten loft wokolo.
-WS02	Wono ße dźěstano net labrowacž, pon worduje to wedro saßej lěpsche.
-WS03	Szyn wuglě do tych kachli, až to mloko baldy ße waridź <dzě> schopne.
-WS04	Ten dobry stary muž jo stym końom zěź ten lod zělamal a do téje symneje wody walil.
-WS05	Won jo pschěs styrimi aby schesdź necžělami wumrěl.
-WS06	Ten wogěn jo byl zu parjatźy, te tykanze ßu da spode zele zarne spalěne.
-WS07	Won jě te jaja zecźe bes ßoli a popza.
-WS08	Te nogi zujarě bolěja, ja wěrim, ja ßem jě zegnal.
-WS09	Ja ßem dźi tej źěnscźe byl a ßem je prajil, a wona prajila, wona ze jo tesch jejě dźowze prajisch.
+WS01	We symĕ lĕtaja te ßuche lopĕna psches ten loft wokolo.
+WS02	Wono ße dźĕstano net labrowacž, pon worduje to wedro saßej lĕpsche.
+WS03	Szyn wuglĕ do tych kachli, až to mloko baldy ße waridź <dzĕ> schopne.
+WS04	Ten dobry stary muž jo stym końom zĕź ten lod zĕlamal a do téje symneje wody walil.
+WS05	Won jo pschĕs styrimi aby schesdź necžĕlami wumrĕl.
+WS06	Ten wogĕn jo byl zu parjatźy, te tykanze ßu da spode zele zarne spalĕne.
+WS07	Won jĕ te jaja zecźe bes ßoli a popza.
+WS08	Te nogi zujarĕ bolĕja, ja wĕrim, ja ßem jĕ zegnal.
+WS09	Ja ßem dźi tej źĕnscźe byl a ßem je prajil, a wona prajila, wona ze jo tesch jejĕ dźowze prajisch.
 WS10	Ja nocham jo tesch jazej saßej zynisch.
 WS11	Ja mausnom tebe net ßteju warenizu wokolo teju wuschowu, ty naupa!
-WS12	Dźě ga ty dźěß, derimy my ßobu stebu hẏcź?
-WS13	To ßu nědobre zaße.
-WS14	Mojo lube dschěczo, wostan how deleka stojo, te sle guße sakußaja tebě nabogě.
-WS15	Ty ßy dźenßa nej lepej wuknul a ßy byl poschluschnẏ, ty derisch perej domoj hićz ak te drugě.
-WS16	Ty hyschi neßy wěliki doscź, aby nednu flaschu wina wupitsch, ty mußisch pěre hẏschcźi jeden kónz naroscz a jakschy wordowasch.
-WS17	Dźi, bysch tak dobry a preij dwojej schostrě, wona derila tu drastu sa jich Maczěrě gotowu seschicž a steju berstu zẏstu zynicž.
+WS12	Dźĕ ga ty dźĕß, derimy my ßobu stebu hẏcź?
+WS13	To ßu nĕdobre zaße.
+WS14	Mojo lube dschĕczo, wostan how deleka stojo, te sle guße sakußaja tebĕ nabogĕ.
+WS15	Ty ßy dźenßa nej lepej wuknul a ßy byl poschluschnẏ, ty derisch perej domoj hićz ak te drugĕ.
+WS16	Ty hyschi neßy wĕliki doscź, aby nednu flaschu wina wupitsch, ty mußisch pĕre hẏschcźi jeden kónz naroscz a jakschy wordowasch.
+WS17	Dźi, bysch tak dobry a preij dwojej schostrĕ, wona derila tu drastu sa jich Maczĕrĕ gotowu seschicž a steju berstu zẏstu zynicž.
 WS18	Dyby ty jogo snal! téden by to hinaz pschischlo, a by to lepej wokolo ńogo stojalo.
 WS19	Chto jo my moj kerb stym ḿaßom hukradnul?
 WS20	Won jo tak zynil, kajsch by woni jogo k mloźenoju hobstelowal, woni ßu jo ale ßami sźinyli.
 WS21	Komu jo won tu nowu schichtu hulizowal?
-WS22	Jaden mußy mozně wolacž, howacž won nam ńěrosmejě.
+WS22	Jaden mußy moznĕ wolacž, howacž won nam ńĕrosmejĕ.
 WS23	My ßmy muzne a mami laźnoscź.
-WS24	Dysch ßmy my zora ẃazor dom pschischli, téden ßu te drugě postoli a ßu byli twardo we spańu.
-WS25	Ten ßněg jo tu noz pschi naß ležo wostal, alě dźinßa rano jo won wotajal.
-WS26	Zady nascheg twarěna stojeja tschi jablukowe bomy stymi zerwěnemi jablukami.
-WS27	Nemocze wy ischi jedno wokomikněne na naß zakacž, potom dschemi my ßobu swami.
-WS28	Wy nedericže táke dźecžace waschně gnacž.
-WS29	Nasche gori nejschu jara hußoke, te wasche ßu wělě wusche.
-WS30	Wělě puntow worschty a wělě chleba ceczě mecž?
-WS31	Ja nerosmějem waß, wy mußicže kusk schorfně pojědacž.
-WS32	Nejscě wy žadyn kusk belejě sejpy samně na mojim blidcźě namakali?
-WS33	Jogo bratr ze ßebe dwě rádne weži we wasché zarodže natwaricž.
+WS24	Dysch ßmy my zora ẃazor dom pschischli, téden ßu te drugĕ postoli a ßu byli twardo we spańu.
+WS25	Ten ßnĕg jo tu noz pschi naß ležo wostal, alĕ dźinßa rano jo won wotajal.
+WS26	Zady nascheg twarĕna stojeja tschi jablukowe bomy stymi zerwĕnemi jablukami.
+WS27	Nemocze wy ischi jedno wokomiknĕne na naß zakacž, potom dschemi my ßobu swami.
+WS28	Wy nedericže táke dźecžace waschnĕ gnacž.
+WS29	Nasche gori nejschu jara hußoke, te wasche ßu wĕlĕ wusche.
+WS30	Wĕlĕ puntow worschty a wĕlĕ chleba ceczĕ mecž?
+WS31	Ja nerosmĕjem waß, wy mußicže kusk schorfnĕ pojĕdacž.
+WS32	Nejscĕ wy žadyn kusk belejĕ sejpy samnĕ na mojim blidcźĕ namakali?
+WS33	Jogo bratr ze ßebe dwĕ rádne weži we wasché zarodže natwaricž.
 WS34	To ßlowo přidže jomu wot wutroby.
 WS35	To bẏlo prawe wot nich.
 WS36	Zo ßedźeja tam sa p taschatki goreka na tej murce?
-WS37	Te buŕa ßu pjacž wolow a džejacz krowow a dwanasce wowcko protk teje ßy třinaßli, te zechu woni pschědacž.
-WS38	Te ludže ßu džinßa schizkě wenkach na tym polu a ßezeja.
+WS37	Te buŕa ßu pjacž wolow a džejacz krowow a dwanasce wowcko protk teje ßy třinaßli, te zechu woni pschĕdacž.
+WS38	Te ludže ßu džinßa schizkĕ wenkach na tym polu a ßezeja.
 WS39	Dži no, ten bruni pés necẏni tebi niz.
 WS40	Ja ßem stymi ludžimi tam sady psches tu luku do žita jel.

--- a/56510_Ossling.csv
+++ b/56510_Ossling.csv
@@ -12,7 +12,7 @@ WS01	Wsymje ljetaja ßuche wopena wlofcże wokoło.
 WS02	Wono ßo pschesta ßnje hicż, njetk bdżo wedro saßo ljepsche.
 WS03	Cżiß Kholu do kachli, so ßo mlóko ßkoro waricż pocżnje.
 WS04	Tón stary dobry muż je ßo se ßwojim konjom psches lód pschepanył a do symnej wody panył.
-WS05	Wón je psched schtyri aby schjesz nedżelami wumrěł.
+WS05	Wón je psched schtyri aby schjesz nedżelami wumrĕł.
 WS06	Tón woheṅ bje jara horzy, te tykanzy ßu spody cżißcże cżorne spalene.
 WS07	Wón jy jeja pschezo bes ßele a bes pópera.
 WS08	Nohi mje jara bola, ja wjerju, ja ßym ßej je pschebejżał.

--- a/56511_56512_Sollschwitz.csv
+++ b/56511_56512_Sollschwitz.csv
@@ -8,21 +8,21 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje letaja suche łopjenja přez powětr.
-WS02	Sněh přestanje hnydom padač, potom so zaso wuwjedri <(N.B. richtig rein deutsch)> potom nastanje zaso rjeńše wjédro.
+WS01	W zymje letaja suche łopjenja přez powĕtr.
+WS02	Snĕh přestanje hnydom padač, potom so zaso wuwjedri <(N.B. richtig rein deutsch)> potom nastanje zaso rjeńše wjédro.
 WS03	Syp wuhlo do kachli, zo so mloko zawari.
 WS04	<(Ton)> Dobrÿ stary muž je so z konjom přez lod přewamał a do zemnje wody padnył.
 WS05	Wón je pŕed śtyrjomi abo śesćimi njedželemi zemrjeł <(wumrjeł / das Erste ist besser.)>
-WS06	Woheń bě přehorčy <(oder: přejara horcy, čopły, palaty)> tykancy su tohodla spodÿ cely čorńe wopalene.
-WS07	Wón jÿja <(o)> přecy bjez sele a popjeŕa jě!
-WS08	Nohi mje jara bola, mi so zda, zo sym sebi je přeběžał.
+WS06	Woheń bĕ přehorčy <(oder: přejara horcy, čopły, palaty)> tykancy su tohodla spodÿ cely čorńe wopalene.
+WS07	Wón jÿja <(o)> přecy bjez sele a popjeŕa jĕ!
+WS08	Nohi mje jara bola, mi so zda, zo sym sebi je přebĕžał.
 WS09	Sym po teje žonÿ pobył a jej to prajił, a wona praješe, zo chce to tež jeje dźowcy prajič.
 WS10	Ja njecham to tež ženje wjacy cžinić.
 WS11	Dyru tebje hnydom z mješałku za wuši, <(ty)> wopica!
 WS12	Hdźe dźeš, dyrbimy z tobu hič?
 WS13	Su hubjene časy!
 WS14	Moje luby dźečo, wostań tule delkach stojo, lóze husy tebje zakusaja.
-WS15	Ty sy dźens naj wjacy wuknył a tež posłušny był, směš prjedy domoj hič dyžli druzÿ.
+WS15	Ty sy dźens naj wjacy wuknył a tež posłušny był, smĕš prjedy domoj hič dyžli druzÿ.
 WS16	Nejsy hišče wulki dosč, zo mohł blešu wina wupič, dyrbiš hišče kónc wječi narosč.
 WS17	Dži budž tak dobrÿ a praj twojej sotře, zo dyrbi suknje za wašu mač dosič a je z ščetku wučesač.
 WS18	By ty joho znał! by zawešče wšo hinak přišło a lepje za njeho było.
@@ -40,11 +40,11 @@ WS29	Naše horÿ nejsu jara wÿsoke, wašÿ su wjele wyšše.
 WS30	Kak wjele puntow kołbasy a kelko kleba chceče meč?
 WS31	Ja wam njerozemju, dyrbiče wótrišo powjedač.
 WS32	Nejsče žadyn kusk bełeho modła na mojim blidže za mnje namakali?
-WS33	Jeho bratr chce sebi dwě rjanej nowy kheži we wažyj zarodže twarič <(oder: natwarič)>.
+WS33	Jeho bratr chce sebi dwĕ rjanej nowy kheži we wažyj zarodže twarič <(oder: natwarič)>.
 WS34	Te słowo přindže jemu wot wutrobu.
-WS35	To bě prawje wot was.
+WS35	To bĕ prawje wot was.
 WS36	Kajke ptački sedža tam na ty murcy?
-WS37	Burja bychu pječ wowow <(bokow)> džewječ krowow a dwanače wowckow před wjes přiwjedli, <ch>chcychu jě předač.
+WS37	Burja bychu pječ wowow <(bokow)> džewječ krowow a dwanače wowckow před wjes přiwjedli, <ch>chcychu jĕ předač.
 WS38	Ludžo su dzens wšitcy wonkach na polu a syku.
 WS39	Dzi jenož, bruny pos <(psek)> tebi ničo nješčini.
 WS40	Sym z tymi ludžimi tam zady přes wuku do žita jeł.

--- a/56513_Spohla.csv
+++ b/56513_Spohla.csv
@@ -9,42 +9,42 @@ Transliterent: ''
 Anmerkungen: ''
 ...
 WS01	Wsymi lecža ßuche łopenja lofcži.
-WS02	Nydom budże ßo sastacž ßněhowacž, potom budże wedro lěpsche.
+WS02	Nydom budże ßo sastacž ßnĕhowacž, potom budże wedro lĕpsche.
 WS03	Nametaj wuchlje do kachli, so ßo mloko sapocžne waricž.
 WS04	Tonlje dobry stary muž je ßo na lodżi pschewamał a je do symneje wody panył.
-WS05	Won je psched schtěri aby schěscž nedżelemi wumreł.
-WS06	Pěz bě pschepurena, te tykanzy ßu spody zyłe cžorne pschepalene.
-WS07	Won jě jeja pschezy bes ßelje a poperja.
+WS05	Won je psched schtĕri aby schĕscž nedżelemi wumreł.
+WS06	Pĕz bĕ pschepurena, te tykanzy ßu spody zyłe cžorne pschepalene.
+WS07	Won jĕ jeja pschezy bes ßelje a poperja.
 WS08	Nohi me jary bola, ja cžuju so ßym ßej je wotcżischcżał.
 WS09	Ja ßym pschi tej žoni był, a ßym jej prajił, a wona mi ßlubi, so chze też ßwojej dżowzy prajicż.
 WS10	Ja jo tež nochzu saßo cžinicž.
 WS11	Ja cże stej drejanej łžizu woko wuschi praßnu, ty wopiza!
 WS12	Dže dżesch, dyrbimy stobu hicž?
 WS13	Hubene cžaßy ßu!
-WS14	Moje lube džěcžo wostan jow delka stejo, te słe hußy kußaja.
-WS15	Ty ßy dżenßa najazy nawuknył, a ßy pěkny był, ty moż skerje dom hicž, hacž tamne.
+WS14	Moje lube džĕcžo wostan jow delka stejo, te słe hußy kußaja.
+WS15	Ty ßy dżenßa najazy nawuknył, a ßy pĕkny był, ty moż skerje dom hicž, hacž tamne.
 WS16	Ty hischcže neßy stary doscž, so mosch bleschu wina wupicž, ty dyrbisch łochcž pschiroscž.
 WS17	Dżi, bydcž tak dobry a praj twojej ßotsi, wona dyrbi tu drastu sa waschu mamu doschicž a je se scžetku je wumachacž.
-WS18	Byli ty jeho snał! da by hinak pschischwo a snim by lěpe stejała.
+WS18	Byli ty jeho snał! da by hinak pschischwo a snim by lĕpe stejała.
 WS19	Schtu je mi moj Kórb smjaßom kranył?
 WS20	Won tak cžinesche, jako byschcže jeho kmocženju wobschtelowali; wy pak scže jo ßami cżinili.
 WS21	Komu je won ton nowy podawk powedał?
 WS22	Wotße ßo mußy łowacž, hewak won nerosymi.
 WS23	My ßmy mucžne a ßmy lacžni.
 WS24	Jako cžera wecžor dom pschindżechmy, da tamni schno ležachu a krucže spachu.
-WS25	Ssně je tu noz ležo wostał, a rano neje rostał.
-WS26	Sady naschej kějži steja tsi rjane jabucžinki s cžerwenymi jabucžkami.
+WS25	Ssnĕ je tu noz ležo wostał, a rano neje rostał.
+WS26	Sady naschej kĕjži steja tsi rjane jabucžinki s cžerwenymi jabucžkami.
 WS27	Nemoschcže hischcže khwilcžicžku pocžakacž, potom swami pondżemy.
 WS28	Wy nedyrbicže tajku džecžazu rhu wescž.
 WS29	Nasche hore nejßu hußoke, wasche ßu welje husche.
-WS30	Kak welje punt kobaßy a kak welje klěba zecže měcž?
+WS30	Kak welje punt kobaßy a kak welje klĕba zecže mĕcž?
 WS31	Ja wam nerosemju, wy dyrbicže wotsischo rycžecž.
-WS32	Nescže schadyn kusk běweho módła na mojim blidaschku namakali?
-WS33	Jeho bratr chze ßebi dwě rjanej nowej twareni, we waschej sarodżi twaricž.
+WS32	Nescže schadyn kusk bĕweho módła na mojim blidaschku namakali?
+WS33	Jeho bratr chze ßebi dwĕ rjanej nowej twareni, we waschej sarodżi twaricž.
 WS34	Te ßłowo pschindże jemu swutrobu.
-WS35	To běsche praje wot waß!
+WS35	To bĕsche praje wot waß!
 WS36	Kajke ptacžicžki ßedża tam na tej muricžki?
-WS37	Burja běchu pecž wołow a dżewecž kruwow a dwanacže jechnjatow psched wßy pschichnali, te chzychu je pschedacž.
+WS37	Burja bĕchu pecž wołow a dżewecž kruwow a dwanacže jechnjatow psched wßy pschichnali, te chzychu je pschedacž.
 WS38	Ludżo ßu dżenßa wschitzy na poli a ßycžeja.
 WS39	Dżi nur, ton bruny pßycžk cži niz necžini.
-WS40	Ja ßym stymi ludżimi tam sady psches łuku do žita jěł.
+WS40	Ja ßym stymi ludżimi tam sady psches łuku do žita jĕł.

--- a/56514_Gross-Särchen.csv
+++ b/56514_Gross-Särchen.csv
@@ -9,42 +9,42 @@ Transliterent: ''
 Anmerkungen: ''
 ...
 WS01	W zymje lecźa ßuche łopjena w loftcźe.
-WS02	Zmolom pschestanje ßněh hicź, potom budźe wedro saßy lěpsche.
+WS02	Zmolom pschestanje ßnĕh hicź, potom budźe wedro saßy lĕpsche.
 WS03	Cžin wuhle do khachlow, so ßo mlóko bórsy sawari.
 WS04	Wbohi stary muž je ßo s konjom psches lód pschełamał a do symneje wody padnył.
 WS05	Wón je psched schtyrimi aby scheßcźimi njedźelemi wumrjeł.
-WS06	Hěza besche pschewulka, tykanzy ßu ßpody zyle cžorne seßmudźene.
-WS07	Wón jě jeja pschezy bjes ßele a popjerja.
-WS08	Nohi mje jara bola, myßlu ßebi, ßym ßebi je pscheběžał.
+WS06	Hĕza besche pschewulka, tykanzy ßu ßpody zyle cžorne seßmudźene.
+WS07	Wón jĕ jeja pschezy bjes ßele a popjerja.
+WS08	Nohi mje jara bola, myßlu ßebi, ßym ßebi je pschebĕžał.
 WS09	Ssym pola tej žony pobył a ßym jej to prajił, a wona rjekny, so chze to tež ßwojej dźowzy rjez.
 WS10	Njecham to ženje wjazy cźinicź.
 WS11	Na blaku cźe se łžizu wo wuschi morßnu, ty wopiza.
 WS12	Hdźe dźesch, dyrbimy s tobu hicź?
 WS13	Wone ßu hubjene cžaßy.
 WS14	Moje lube dźecžo wostań jow delkach stejo, słe hußy cźe sakußaje.
-WS15	Ty ßy dźenßa najlěpje wuknył a ßy pěkny był, ty móžesch prjedy domoj hicź hacž cźi drusy.
+WS15	Ty ßy dźenßa najlĕpje wuknył a ßy pĕkny był, ty móžesch prjedy domoj hicź hacž cźi drusy.
 WS16	Ty hischcźe wulki doscź njejßy, bleschu wina wupicź, ty dyrbisch prjedy naroßcź a wjetschi bycź.
 WS17	Dźi, bydź tak dobry a rjek twojej sotři, so by ßuknje sa waschu maczer doschije a se schcźetku wucžeßała.
-WS18	By ty jeho snał, dha by wscho hinak pschischło, a by lěpje snim stało.
+WS18	By ty jeho snał, dha by wscho hinak pschischło, a by lĕpje snim stało.
 WS19	Schtó je mi moj korb s mjaßom kradnył?
 WS20	Wón tak cźinjesche, jako bychmy jeho na młócźenje skazali; woni pak ßu to ßami cźinili.
 WS21	Komu je wón to nowe powjedanćźko wowjedał?
 WS22	Wótře dyrbi ßo wołacź, hewak nam njerosymi.
 WS23	My ßmy sprózni a lacžni.
-WS24	Jako wcźera wjecžor dom pschindźechmy, ležachu hižom cźi drusy we łožu a běchu nimalje wußli.
-WS25	Ssněh je pola naß ležo wostał, ale dźenßa rano rostał.
-WS26	Zady nascheje khěže steja tři rjane jabłucžki scžerwjenymi jabłucžkami.
+WS24	Jako wcźera wjecžor dom pschindźechmy, ležachu hižom cźi drusy we łožu a bĕchu nimalje wußli.
+WS25	Ssnĕh je pola naß ležo wostał, ale dźenßa rano rostał.
+WS26	Zady nascheje khĕže steja tři rjane jabłucžki scžerwjenymi jabłucžkami.
 WS27	Njemóžeczé wy hischcze na naß wocžaknycź, potom dźemy swami.
-WS28	Wy njeßměcźe tajke hłuposcźe cžinicź.
+WS28	Wy njeßmĕcźe tajke hłuposcźe cžinicź.
 WS29	Nasche hory njejßu jara wyßoke, wasche ßu wyschsche.
-WS30	Kak wjele puntow kołbaßy a kak wjele khlěba chzecźe měcź?
+WS30	Kak wjele puntow kołbaßy a kak wjele khlĕba chzecźe mĕcź?
 WS31	Njerosymju wam, dyrbicźe kußk wótřischo rycźež.
-WS32	Njescźe žadyn kußk běłeho mydła sa mnje na mojim blidźe namakali?
-WS33	Jeho bratr chze ßebi dwě rjanej khěži we waschej sahrodże twaricź.
+WS32	Njescźe žadyn kußk bĕłeho mydła sa mnje na mojim blidźe namakali?
+WS33	Jeho bratr chze ßebi dwĕ rjanej khĕži we waschej sahrodże twaricź.
 WS34	To ßłowo pschindźe jemu swutroby.
-WS35	To bě prawje wot nich.
+WS35	To bĕ prawje wot nich.
 WS36	Kajke ptacžatka ßedźa horkach na muricźzy.
-WS37	Burjo běchu pjecž wołow a dźewjecź kruwow a dwanacźe wowzkow psched wjeß pschiwjedli, te chzychu pschedacź.
+WS37	Burjo bĕchu pjecž wołow a dźewjecź kruwow a dwanacźe wowzkow psched wjeß pschiwjedli, te chzychu pschedacź.
 WS38	Ludźo ßu dźenßa wschitzy wonkach napoli a ßykaja.
 WS39	Dźi jenož, bruny poß cźi nicžo njecžini.
-WS40	Ssym s ludźimi tam sady psches łuku do žita jěł.
+WS40	Ssym s ludźimi tam sady psches łuku do žita jĕł.

--- a/56515_Wartha.csv
+++ b/56515_Wartha.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje suche wopjena w powětrje wokoło lětaja.
-WS02	Sněh so hnydom zastanje hić, potom so z wjedrom zaso polěpša.
+WS01	W zymje suche wopjena w powĕtrje wokoło lĕtaja.
+WS02	Snĕh so hnydom zastanje hić, potom so z wjedrom zaso polĕpša.
 WS03	Nakładź wuhla do khachli, zo by so mlóko skoro zawariło.
 WS04	Tutón dobry starc je so z konjom na lodźi přełamał a do zymnej’ wody padnył.
 WS05	Wón je před štyrjomi abo šesćimy njedźelemi wumrjeł.
-WS06	Woheń běše pře nahły, tykancy hdźě su spody cyle čorne spalene.
-WS07	Wón jeja stajnje bjez sele a pópjera jě.
+WS06	Woheń bĕše pře nahły, tykancy hdźĕ su spody cyle čorne spalene.
+WS07	Wón jeja stajnje bjez sele a pópjera jĕ.
 WS08	Nohi mje jara bola; ja mam strach, zo sym sebi je šćišćał.
-WS09	Ja sym po tej žony pobył a jej to prajił, a wona měnješe, zo budźe jo tež swojej dźowcy rjec.
+WS09	Ja sym po tej žony pobył a jej to prajił, a wona mĕnješe, zo budźe jo tež swojej dźowcy rjec.
 WS10	Ja pak jo tež nochcu wospjet činić.
 WS11	Ja će hnydom ze łžicu za <l> hłuši prasnu, ty wopica!
 WS12	Hdźe dźeš, dyrbimy z tobu hić?
 WS13	Časy su hubjeny.
-WS14	Moje lube dźěćo, wostań tu stejo, te lózy husy će zakusaja.
-WS15	Ty sy dźeńsa najwjacy wuknył a sy pěkny był, ty směš prjedy w domoj hić hač druzy.
+WS14	Moje lube dźĕćo, wostań tu stejo, te lózy husy će zakusaja.
+WS15	Ty sy dźeńsa najwjacy wuknył a sy pĕkny był, ty smĕš prjedy w domoj hić hač druzy.
 WS16	Ty hišće njejsy wulki dosć, blešu wina wupić, ty dyrbiš prjedy hišće kónc narosć a wjetši zbyć.
 WS17	Budź tak dobry a dźi twojej sotři prajić, zo by wona tu drastu za wašu mać zešiła a ze sćeću wučisćiła.
-WS18	Budźiše ty jeho znał, dha by jo hinak přišło a z nim by so lěpje měło.
+WS18	Budźiše ty jeho znał, dha by jo hinak přišło a z nim by so lĕpje mĕło.
 WS19	Štó je mi mój korb z mjasom kradnył?
 WS20	Wón so zdaše, jako byšće wy jeho skazał, zo by móćił; wy pak sće jo sam činił.
 WS21	Komu je wón tu nowu stawiznu powjedał?
 WS22	Jedyn ma wótře wować, hinak wón nas njerozemi.
 WS23	My smy sprócni a lačni.
 WS24	Wčera wječor wróćo přišedši, ći druzy hižom we łožach lejžachu a twjerdźe spachu.
-WS25	Pola nas bě sněh w tutej nocy lejžo wostał, ale dźeńs z ranja je roztał.
+WS25	Pola nas bĕ snĕh w tutej nocy lejžo wostał, ale dźeńs z ranja je roztał.
 WS26	Zady našeho statoka steja tři rjane jabłučinki z čerwjenjemi jabłučkami.
 WS27	Njemóh-li wy hišće wokomik na nas dočakać, potom my z wami dźemy.
-WS28	Wy so njedyrbiće z tajkimi dźěćatstwami nasadźować.
+WS28	Wy so njedyrbiće z tajkimi dźĕćatstwami nasadźować.
 WS29	Naše hory njejsu jara wysoke, waše su wjele wyšše.
-WS30	Kak wjele puntow kołbasy a kak wjele khlěba zechceće?
-WS31	Ja wam njerozymju, wy dyrbiće kusk wótřišo rěčeć.
-WS32	Njejsće žadyn kusk běłeho mydła za mnje na mojim blidźe namykali?
-WS33	Jeho bratr chce sebi rjanej nowej khěži we wašej zahrodźe natwarić.
+WS30	Kak wjele puntow kołbasy a kak wjele khlĕba zechceće?
+WS31	Ja wam njerozymju, wy dyrbiće kusk wótřišo rĕčeć.
+WS32	Njejsće žadyn kusk bĕłeho mydła za mnje na mojim blidźe namykali?
+WS33	Jeho bratr chce sebi rjanej nowej khĕži we wašej zahrodźe natwarić.
 WS34	To słowo jemu z wutroby přińdźe.
 WS35	Jow byšće wy z prawom.
 WS36	Kajke ptački dha horkach na muričcy sejdźa?
-WS37	Burjo běchu pjeć wołow a dźewjeć kruw a dwanaće wowckow před wjes zaćěrili, je předać.
+WS37	Burjo bĕchu pjeć wołow a dźewjeć kruw a dwanaće wowckow před wjes zaćĕrili, je předać.
 WS38	Dźeńsa su wšitcy ludźo na poli a syku.
 WS39	Dźi jeno, tón bruny pos tebi ničo nječini!
-WS40	Ja sym z tymi ludźimi tam zady přez łuku do rožki jěł. <(wiederholtes Fahren = jězdźił!).>
+WS40	Ja sym z tymi ludźimi tam zady přez łuku do rožki jĕł. <(wiederholtes Fahren = jĕzdźił!).>

--- a/56516_Steinitz.csv
+++ b/56516_Steinitz.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	We Symi te suche Wopena psches Lóft wokoło ljětaju.
-WS02	Wono ßo nydom pschestane Ssnjě hicź, potom budźe ljěpsche Wjedro.
+WS01	We Symi te suche Wopena psches Lóft wokoło ljĕtaju.
+WS02	Wono ßo nydom pschestane Ssnjĕ hicź, potom budźe ljĕpsche Wjedro.
 WS03	Nacźin Wuhle to Kachlow, so ßo to Mlóko skoro waricź pócźne.
 WS04	Ton dobry stary Muž je ßo s Konjom psches Lót pschełamał a do tej symnje Wody panył.
 WS05	Wo je psched schtyri abo schjescź Tydcźenjami wumreł.
 WS06	Ton Wohen bje zu horczy, to Tykanzy ßu spody zyłe cźorne palene.
-WS07	Wo te Jeja pschezo bes Ssele a Poperja jě.
-WS08	Te Nohi me jara bola, ja wěrju ja ßym ßebi je pscheběżał.
+WS07	Wo te Jeja pschezo bes Ssele a Poperja jĕ.
+WS08	Te Nohi me jara bola, ja wĕrju ja ßym ßebi je pschebĕżał.
 WS09	Ja ßym pola teje Zony był a ßym ji prajił, a wana prajesche, wona cźe jo ßłojej džowży tejsch prajicź.
 WS10	Ja tejsch jo necham wjaży ßaßo cžinicź!
 WS11	Ja tebe nydom swarnej Łżiżu wokoło Wuschow nabiju, ty Wopiża!
 WS12	Dże ty dżesch, dyrbimy stobu hicź?
 WS13	Wono ßu hubene Cžaßy.
 WS14	Moje lube dźeczo wostan tudy delkach stejo, te lóse Hußy tebe sakußaja.
-WS15	Ty ßy dżenscha najbóle wuknył a ßy pěkny był, ty ßmesch predy domoj hicź hacź te tamne.
+WS15	Ty ßy dżenscha najbóle wuknył a ßy pĕkny był, ty ßmesch predy domoj hicź hacź te tamne.
 WS16	Ty hischcźe neßy wulki docź, so by mół Bleschu Wina wupicź, ty dyrbisch predy hischcźe Kónz roscź a wjetschi wordowacź.
 WS17	Dźi, bycź tak dobry a praj twojej Ssotsi, wona dyrbi te Klejdy sa waschu Macż hotowe seschicź a se Schcźetku cźiste scźinicź.
-WS18	Běsche jeho snał, potom by jo hinak pschischło, a wono by lěpe wokoło neho stejało.
+WS18	Bĕsche jeho snał, potom by jo hinak pschischło, a wono by lĕpe wokoło neho stejało.
 WS19	Schtu je mi moj Korb stym Mjaßom kranuł.
 WS20	Won tak cźinesche, jako bychu woni jeho kmłócżenu wobschtelowali, woni pak ßu jo ßami cźinili.
 WS21	Komu je wón tu nowu Powesz powedał?
 WS22	Jedyn dyrbi wótse wołacż, hewak nam won nerosymi.
 WS23	My ßmy spróźne, a nam cźe ßo picž.
-WS24	Jako my cžera Wecžor rócžo pschindźechmy, da hicżom te tamne Łożu ležachu a běchu twerdom Spanju.
-WS25	Ton Ssně je tule Nócź ležo wostał, ale dżenßa Rano je ßo won seschkreł.
-WS26	Sady naschej Khěźu steja tsi rjane Jabłucźinki scźerwenymi Jabłudżkami.
+WS24	Jako my cžera Wecžor rócžo pschindźechmy, da hicżom te tamne Łożu ležachu a bĕchu twerdom Spanju.
+WS25	Ton Ssnĕ je tule Nócź ležo wostał, ale dżenßa Rano je ßo won seschkreł.
+WS26	Sady naschej Khĕźu steja tsi rjane Jabłucźinki scźerwenymi Jabłudżkami.
 WS27	Nemożecźe wy Wokomiknencźko na naß cźakacź, potom my swami dźemy.
 WS28	Wy nedyrbicźe tajke Dźecźatstła nahcź.
 WS29	Nasche Hory njeßu jara wyßoke, te wasche ßu wele wysche.
-WS30	Kak wele Puntow Kołbaßy a kak wele Klěba zecźe wy měcź.
+WS30	Kak wele Puntow Kołbaßy a kak wele Klĕba zecźe wy mĕcź.
 WS31	Ja wam nerosymju, wy dyrbicźe kusk wotsischo powedacź.
-WS32	Nejscźe wy żadyn Kruch běło Modła samne na mojim Blidże namkali.
-WS33	Jeho Bratr ze ßebi dwi rjanej nowej Khěźi we waschej Sarodźi twaricź.
+WS32	Nejscźe wy żadyn Kruch bĕło Modła samne na mojim Blidże namkali.
+WS33	Jeho Bratr ze ßebi dwi rjanej nowej Khĕźi we waschej Sarodźi twaricź.
 WS34	To Sswoło jemu wot Wutroby pschindźesche.
-WS35	To běsche prawje wot waß.
+WS35	To bĕsche prawje wot waß.
 WS36	Schto tam do Ptacźatkow horkach na tej Muricźzy ßejdza?
-WS37	Te Burja běchu pecź Wołow a dźewecź Kruwoł a dwanacźe Wołzkow psched Weß pschiwedli a zychu je pschedacź.
+WS37	Te Burja bĕchu pecź Wołow a dźewecź Kruwoł a dwanacźe Wołzkow psched Weß pschiwedli a zychu je pschedacź.
 WS38	Te Ludźo ßu dźenßa schitzy wonkach a ßycźeja.
 WS39	Dźi jenoź, ton bruny Poß tebi nicźo neczini.
-WS40	Ja ßym stymi Ludzimi tam sady psches tu Wuku do Zita jěł.
+WS40	Ja ßym stymi Ludzimi tam sady psches tu Wuku do Zita jĕł.

--- a/56517_Klitten.csv
+++ b/56517_Klitten.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymi leća suche łopjena w powětre.
-WS02	Hnydom zastanje sněh sypać, potom budźe wedro lěpše.
+WS01	W zymi leća suche łopjena w powĕtre.
+WS02	Hnydom zastanje snĕh sypać, potom budźe wedro lĕpše.
 WS03	Čin wule do Khachlow, zo so mloko započnje warić.
 WS04	Stary dobry muš je so sKonjom přez lód přełamał a je do zymneje wody panył.
-WS05	Wón je před štyri abo šěsc njedźel zemrěł.
-WS06	Wohen běše přećopły, tykancy su drje delka cyle čorne napalene.
-WS07	Wón jě jeja přeco bjez sele a popěra.
-WS08	Nohi mje jara bola, mi so zda, je sym sebi je přeběšał.
+WS05	Wón je před štyri abo šĕsc njedźel zemrĕł.
+WS06	Wohen bĕše přećopły, tykancy su drje delka cyle čorne napalene.
+WS07	Wón jĕ jeja přeco bjez sele a popĕra.
+WS08	Nohi mje jara bola, mi so zda, je sym sebi je přebĕšał.
 WS09	Ja sym při tej žoni pobył, a sym jej prajił, a wona praješe, zo chce tež swojej dźowczy prajić.
 WS10	Ja njecham tež to wjacy činić.
 WS11	Ja biju će hnydom z łžicu wokoło wuši, ty wopica.
 WS12	Hdźe ty dźeš, dyrbimy z tobu hić?
 WS13	Su hubjene časy.
-WS14	Moje lube dźěćo, wostań tuhdy delka stejo, złe husy tebe zakusaja.
-WS15	Ty sy dźensa najwjacy wuknył a sy posłušny był; ty směš prjedy domoj hić, hač ći druzy.
+WS14	Moje lube dźĕćo, wostań tuhdy delka stejo, złe husy tebe zakusaja.
+WS15	Ty sy dźensa najwjacy wuknył a sy posłušny był; ty smĕš prjedy domoj hić, hač ći druzy.
 WS16	Ty hišće njejsy wulki dosć, zo blešu wina wupiješ; ty dyrbiš hišće rosć a wjetši so činić.
-WS17	Dźi, budź tak dobry a praj twojej sotři, zo dyrbi drastu za wašu mać hotowu šić a ze šćětku čistu činić.
-WS18	Běšeš ty jo znał; dha by hinak přišło, a lěpje by wo nim stało.
+WS17	Dźi, budź tak dobry a praj twojej sotři, zo dyrbi drastu za wašu mać hotowu šić a ze šćĕtku čistu činić.
+WS18	Bĕšeš ty jo znał; dha by hinak přišło, a lĕpje by wo nim stało.
 WS19	Štó je mi mój korb z mjasom kranył?
 WS20	Wón čineše tak, kak bychu jeho k móćenju zkazali; woni su pak to sami činili.
 WS21	Komu je nowe powjedančko prajił?
 WS22	Dyrbi so wótře wołać, hewak nas njedorozymi.
 WS23	Smy sprócni a mamy lačnosć.
 WS24	Jako wčera wječor wróćo přińdźechmy, ležachu ći druzy hižom we łožu a spachu twjerdźe.
-WS25	Sněh je tutu nóc pola nas ležo wostał, ale dźensa rano je tał.
-WS26	Zady našeje khěžy steja tři rjane jabłukowe štomički z čeŕwjenimi jabłukami.
+WS25	Snĕh je tutu nóc pola nas ležo wostał, ale dźensa rano je tał.
+WS26	Zady našeje khĕžy steja tři rjane jabłukowe štomički z čeŕwjenimi jabłukami.
 WS27	Njemóžeće hišće wokomiknjenčko na nas čakać, potom dźemy sobu z wami.
-WS28	Wy njesměće tajke dźećatstwa ćinić.
+WS28	Wy njesmĕće tajke dźećatstwa ćinić.
 WS29	Naše hory njejsu jara wysoke, waše su wyšše.
-WS30	Kak wjele puntow kołbasy a kak wjele khlěba chceće měć.
+WS30	Kak wjele puntow kołbasy a kak wjele khlĕba chceće mĕć.
 WS31	Ja was njerozymju, dyrbiće kusk wótřišo ryčeć.
-WS32	Njejsće kusk běłeho mydła za mnje na mojim blidźe namykali?
-WS33	Jeho bratr chce sebi dwě rjanej, nowej khěži w wašej zahrodźi twarić.
+WS32	Njejsće kusk bĕłeho mydła za mnje na mojim blidźe namykali?
+WS33	Jeho bratr chce sebi dwĕ rjanej, nowej khĕži w wašej zahrodźi twarić.
 WS34	To słowo je jemu z wutroby přišło.
-WS35	To běše prawje wot nich.
+WS35	To bĕše prawje wot nich.
 WS36	Kajcy tam sedźa ptačatka horkach na muri?
-WS37	Burja běchu pječ wowow, a dźeweć kruwow a dwanaće wowckow před wjes přinjesli, kotrychš chcychu předać.
+WS37	Burja bĕchu pječ wowow, a dźeweć kruwow a dwanaće wowckow před wjes přinjesli, kotrychš chcychu předać.
 WS38	Ludźo su dźensa wšitcy wonkach na poli a žneja.
 WS39	Dźi tola, bruny pos tebi ničo nječini.
-WS40	Ja sym z tymi ludźimi tam sady přez łuku do rožki jěł.
+WS40	Ja sym z tymi ludźimi tam sady přez łuku do rožki jĕł.

--- a/56518_Räckelwitz.csv
+++ b/56518_Räckelwitz.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje lěta suche lisćo w lofće wokoł.
-WS02	Přestanje bórzy sně hić, potom budźe wjedro zasy rjeńše.
+WS01	W zymje lĕta suche lisćo w lofće wokoł.
+WS02	Přestanje bórzy snĕ hić, potom budźe wjedro zasy rjeńše.
 WS03	Syp wuhla do khachli, zo by so mloko skoro zawariło.
 WS04	Dobry stary muž je so z konjom na lodźe pšepadnył a do teje zymneje wody panył.
 WS05	Wón je před štyrjomi abo šesćimi njedźlami wumrjeł.
-WS06	Woheń bě pře-horcy, tykancy su dźěn spody cyle čorne spalene.
-WS07	Wón jě jeja přecy bjez sele a popjera.
+WS06	Woheń bĕ pře-horcy, tykancy su dźĕn spody cyle čorne spalene.
+WS07	Wón jĕ jeja přecy bjez sele a popjera.
 WS08	Nozy mje jara bolitej, ja sej myslu, ja sym sej jej wotstupał.
 WS09	Ja sym pola tej žony pobył a sym jej to prajił, a wona praješe, zo chce to tež swojej dźowcy prajić.
 WS10	Ja njecham je tež wjacy zasy činić!
 WS11	Ja dyru Tebje bórzy z mješałku wokoł wuši, Ty wopica!
 WS12	Hdźe dźeš, dyrbimy z Tobu hić?
 WS13	Wone su hubjene časy!
-WS14	Moje lube dźěćo, wostań tu deleka stejo, te lóze husy zakusaja Tebje.
-WS15	Ty sy dźensa najwjacy nawuknył a sy pěkny był, Ty směš zaže domoj hić dyžli ći druzy.
+WS14	Moje lube dźĕćo, wostań tu deleka stejo, te lóze husy zakusaja Tebje.
+WS15	Ty sy dźensa najwjacy nawuknył a sy pĕkny był, Ty smĕš zaže domoj hić dyžli ći druzy.
 WS16	Ty njejsy hišće wulki dosć, zo by blešu wina wupił, Ty dyrbiš prjedy hišće kónc narosć a wječi wordwać.
-WS17	Dźi, budź tak dobry a praj Twojej sotře, wona dyrbi tu drastu za wašu mać hotowu zešić a ze šćětku čistu sćinić.
-WS18	Hdy bě Ty joho znał! dha bě to hinak přišło, a wone by lěpje z nim stało.
+WS17	Dźi, budź tak dobry a praj Twojej sotře, wona dyrbi tu drastu za wašu mać hotowu zešić a ze šćĕtku čistu sćinić.
+WS18	Hdy bĕ Ty joho znał! dha bĕ to hinak přišło, a wone by lĕpje z nim stało.
 WS19	Štó je mi mój korb z mjasom pokradnył?
 WS20	Wón činješe tak, hako bychu joho na móćenjo zkazali; woni su to pak sami sčinili.
 WS21	Komu je wón tu nowu stawiznu powjedał?
 WS22	Jedyn dyrbi wotře wować, hewak nas wón njerozemi.
 WS23	Mó smy mučni a nam chce so pić.
 WS24	Hdyš mó wčera wječor so wróćichmy, ležachu ći druzy hižo we wožu a spachu kruće.
-WS25	Sně je tule nóc pola nas ležo wostał, ale dźens rano je rostał.
+WS25	Snĕ je tule nóc pola nas ležo wostał, ale dźens rano je rostał.
 WS26	Zady našoho domu steja tři rjane jabłučinki z čerwjenymi jabłučkami.
 WS27	Njemóžeće hišće wokomiknjeńčko na nas čakać, potym dźemy z wami.
-WS28	Wy njesměće tajke dźěćace wěcy činić.
+WS28	Wy njesmĕće tajke dźĕćace wĕcy činić.
 WS29	Naše hory njejsu jara wysoke, waše su wjele wyšše.
-WS30	Kak wjele puntow kołbasy a kak wjele khlěba chcejće měć?
+WS30	Kak wjele puntow kołbasy a kak wjele khlĕba chcejće mĕć?
 WS31	Ja njerozemju was, wy dyrbiće trochu wotřišo ryčeć.
-WS32	Njejsće žadyn kusk běłeho mydła za mnje na mojim blidźe namkali?
-WS33	Joho bratr chce sebi dwě rjanej nowej khěži we wašej zahrodźe twarić.
+WS32	Njejsće žadyn kusk bĕłeho mydła za mnje na mojim blidźe namkali?
+WS33	Joho bratr chce sebi dwĕ rjanej nowej khĕži we wašej zahrodźe twarić.
 WS34	Te swoło přindźe jomu wot wutroby.
-WS35	To bě prawje wot nich.
+WS35	To bĕ prawje wot nich.
 WS36	Kajke sejdźa tu ptačatka horjeka na muŕcy?
-WS37	Burja běchu pjeć wołow a dźěwjeć kruwow a dwanaće wowckow přede wsu přiwjedli, te chcychu woni předać.
+WS37	Burja bĕchu pjeć wołow a dźĕwjeć kruwow a dwanaće wowckow přede wsu přiwjedli, te chcychu woni předać.
 WS38	Ludźo su dźensa wšicy wonka na polu a syku.
 WS39	Dźi jenož, tón bruny pos nječini Tebi ničo.
-WS40	Ja sym z tymi ludźimi tam zady po wucy do žita jěł.
+WS40	Ja sym z tymi ludźimi tam zady po wucy do žita jĕł.

--- a/56519_Ralbitz.csv
+++ b/56519_Ralbitz.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje leći suche lišćo wo powětre wokowo.
-WS02	Bórzy so přestanje sněh hić, potom budźe zasy lěpše wjedro.
+WS01	W zymje leći suche lišćo wo powĕtre wokowo.
+WS02	Bórzy so přestanje snĕh hić, potom budźe zasy lĕpše wjedro.
 WS03	Připowož kachlach wuhlo, zo bó so mloko bórzy počało warić.
 WS04	Dobry stary muž jo so z konjom nà lodźe přepadnył a do zymneje wody padnył.
 WS05	Wón jo před štyrjomi abo šesćimi nedźelami wumrjeł.
-WS06	Woheń bě přejara horcy, tykancy su dźěn nad dnje cyle čorne spalene.
-WS07	Wón jeja přecy bjez sele a popjerja jě.
+WS06	Woheń bĕ přejara horcy, tykancy su dźĕn nad dnje cyle čorne spalene.
+WS07	Wón jeja přecy bjez sele a popjerja jĕ.
 WS08	Nozy mje jara bolitej, móslu sebi, zo sym jej přebežał.
 WS09	Ja sym pola tej žony bół a sym jej to prajił, a wona praji, zo chce to tež jeje dźowcy prajić.
 WS10	Ja je tež wjacy činić njecham.
 WS11	Ja će zmolom ze žicu za wuši dyru, ty wopica.
 WS12	Hdźe ty dźójž, dyrbimó z tobu hić?
 WS13	Su hubjene časy!
-WS14	Lube dźěćo, wostań deleka stejo, lóze husy će zakusaja.
-WS15	Ty sy dźens najwjacy nawuknył a sy pěkny bół, ty móžeš prjedy dom hić hać ći druzy.
+WS14	Lube dźĕćo, wostań deleka stejo, lóze husy će zakusaja.
+WS15	Ty sy dźens najwjacy nawuknył a sy pĕkny bół, ty móžeš prjedy dom hić hać ći druzy.
 WS16	Ty šće nejsy wilki dosć, zo bó blešu wina wupił, dyrbiš šće kónc narosć, zo bó wječi bół.
-WS17	Dźi, bóć tak dobry a praj twojej sotře, zo dyrbi tu drastu za wašu mać došić a ze šćětku čistu činić.
-WS18	Hdy bó joho ty znał! hda bó to hinak přišło a wone bó lěpje znim stało.
+WS17	Dźi, bóć tak dobry a praj twojej sotře, zo dyrbi tu drastu za wašu mać došić a ze šćĕtku čistu činić.
+WS18	Hdy bó joho ty znał! hda bó to hinak přišło a wone bó lĕpje znim stało.
 WS19	Štóha jo mi mój korb z mjasom kranył?
 WS20	Wón tak činješe, kaž bóchu sebi joho na móćenjo skazali; woni pak su to sami činili.
 WS21	Komu jo wón tu nowu stawiznu pówjedał?
 WS22	Dyrbimó wótce wować, hewak nas wón njerozemi.
 WS23	Mó smó mućne a nam chce so pić.
 WS24	Hdyž mó čora wječor zasy dom přindźechmó, ležachu ći druzy hižom wožu a spachu krutće.
-WS25	Sněh jo tule nóc pola nas ležo wostał, ale dźensa rano jo roztał.
-WS26	Zady našej khejže stoja tři rjane jabłučiny z čěrwjenymi jabłućkami.
+WS25	Snĕh jo tule nóc pola nas ležo wostał, ale dźensa rano jo roztał.
+WS26	Zady našej khejže stoja tři rjane jabłučiny z čĕrwjenymi jabłućkami.
 WS27	Njemóžeće hišće jedyn mały wokomik na nas čakać, potom dźomó z wami.
-WS28	Wó njedyrbiće tajke dźěćace wěcy hnać.
+WS28	Wó njedyrbiće tajke dźĕćace wĕcy hnać.
 WS29	Naše hory nejsu jara wósoke, waše su wjele wóše.
-WS30	Ka wjele puntow kołbasy a ka wjele khlěba chcejće wó měć?
+WS30	Ka wjele puntow kołbasy a ka wjele khlĕba chcejće wó mĕć?
 WS31	Ja wam njerozemju, dyrbiće kusk wótřišo pówjedać.
-WS32	Nejsće wó žadyn kusk běwoho módła na mojim blidźe namakali?
+WS32	Nejsće wó žadyn kusk bĕwoho módła na mojim blidźe namakali?
 WS33	Joho bratr chce sebi dwej rjanej nowej kheži wo wašej zahrodźe natwarić.
 WS34	Te swoło přindźe jomu wot wutrobu!
-WS35	To bě prawje wot nas!
+WS35	To bĕ prawje wot nas!
 WS36	Što ha to do taćkow na murcy sejdźa?
 WS37	Burja su pjeć wowow a dźewjeć kruwow a dwanaće wowckow před tej wsy přiwjedli, tele chcejdźa přehdać.
 WS38	Te ludźo su dźensa wšitcy wonka na polu a syku.
-WS39	Dźi jenoj, tón bruny psěk tebi ničo nječini.
-WS40	Ja sym z tymi ludźimi tamle zady přez wuku do žita jěł.
+WS39	Dźi jenoj, tón bruny psĕk tebi ničo nječini.
+WS40	Ja sym z tymi ludźimi tamle zady přez wuku do žita jĕł.

--- a/56520_Luppa.csv
+++ b/56520_Luppa.csv
@@ -8,13 +8,13 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W symje suche łopjena we powětre letaja.
-WS02	Hnydom so sneha hić přestanje, potom so wjedro polěpši.
+WS01	W symje suche łopjena we powĕtre letaja.
+WS02	Hnydom so sneha hić přestanje, potom so wjedro polĕpši.
 WS03	Sčin wuhla do kachli, zo so mlóko skoro zawari.
 WS04	Wbohi stary muž je so zkonjom na lodźe přełamał a do zymneje wody padnył.
 WS05	Je před štyri aby šesć njedźelemi wumrjeł.
-WS06	Woheń bě přesylny; tykancy su so spody cyłe zesmudźiłe.
-WS07	Jě jeja bez sele a popjera.
+WS06	Woheń bĕ přesylny; tykancy su so spody cyłe zesmudźiłe.
+WS07	Jĕ jeja bez sele a popjera.
 WS08	Mje nohi jara bola, zda so mi, zo sym sebi je přeteptał.
 WS09	Sym pola žony pobył a jej to prajił; a wona praješe, zo chce to tež swojej dźowcy rjec.
 WS10	Njecham to tež wjacy činić.
@@ -22,29 +22,29 @@ WS11	Spraskam će hnydom z kuchinskej łžicu za wuši, ty wopica.
 WS12	Hdźe dźeš, mamy z tobu hić?
 WS13	Su złe časy.
 WS14	Lube dźečo wostan deleka steja; złe husy će zakusaja.
-WS15	Ty sy dźenca najwjacy nawuknył a sy pěkny był; směṡ prjedy druhich domoj hić.
+WS15	Ty sy dźenca najwjacy nawuknył a sy pĕkny był; smĕṡ prjedy druhich domoj hić.
 WS16	Njejsy hisće dosć wulki, so by blešu wina wupił, dyrbiš prjedy hišće kusk narosć a wjetši być.
 WS17	Dźi, bydź tak dobry a praj swojej sotře, zo by drastu za mać zešiła a ze sčedku wurjedźiła.
-WS18	Hdy bě jeho znał; dha budźiše hinak přišło a stobu lepje stało.
+WS18	Hdy bĕ jeho znał; dha budźiše hinak přišło a stobu lepje stało.
 WS19	Štó je mi moj korb z mjasom kradnył.
 WS20	Činješe, hako bychu jemu na młoćenje kazali byli; ale su pak to sami činili.
 WS21	Komu je nowu stawiznu powjedał?
 WS22	Dyrbiš wotře wołać, hewak nam njerozemi.
 WS23	Smy mučni a chce so nam pić.
 WS24	Hdyž wčera wječor wročo prindzechmy, lezachu druzy hižom we łožu a spachu kruće.
-WS25	Sněh je pola nas w nocy ležo wostał, ale dźensa rano roztał.
+WS25	Snĕh je pola nas w nocy ležo wostał, ale dźensa rano roztał.
 WS26	Zady našoho domu steja tři rjane jabłonćini, z čerwjenym jabłuškami.
 WS27	Njemožeće hišce wokomiknjeńčko na nas drčakać, potom z wami pondźemy.
-WS28	Tajke tryski činic njesměće.
+WS28	Tajke tryski činic njesmĕće.
 WS29	Naše hory jara wysoke njejsu, waše su wyšše.
-WS30	Kak wjele puntow kołbasy a kak wjele khlěba schceće měc?
+WS30	Kak wjele puntow kołbasy a kak wjele khlĕba schceće mĕc?
 WS31	Njerozemju wam dyrbiće trochu wótŕišo ryčeč.
-WS32	Njejsće žady kusk běłeho mydła za mnje na mojim blidźe namakali?
-WS33	Jeho bratr chce sebi dwě rjanej nowej kheži we wašej zahrodźe twarić.
+WS32	Njejsće žady kusk bĕłeho mydła za mnje na mojim blidźe namakali?
+WS33	Jeho bratr chce sebi dwĕ rjanej nowej kheži we wašej zahrodźe twarić.
 WS34	Słowo jemu wot wutrobu přindźe.
 WS35	To beše wot nich prawje.
 WS36	Kajke to ptačatka horjeka na muričcy sedźa?
-WS37	Burjo běchu pjeć wołow a dźewjeć kruwow a dwanaće wowćkow před wjes přiwedli, te chcychu předać.
+WS37	Burjo bĕchu pjeć wołow a dźewjeć kruwow a dwanaće wowćkow před wjes přiwedli, te chcychu předać.
 WS38	Ludźo su dźensa wšitcy wonka na polu a syku.
 WS39	Dźi jeno bruny pos tebi ničo njesćini.
-WS40	Sym z ludźimi tam zady přez łuku do žita jěł.
+WS40	Sym z ludźimi tam zady přez łuku do žita jĕł.

--- a/56521_Sdier.csv
+++ b/56521_Sdier.csv
@@ -9,42 +9,42 @@ Transliterent: ''
 Anmerkungen: ''
 ...
 WS01	We zymi leča suche wopjena w lofći wokoło.
-WS02	Wone přestanje so bórzy sněh hić, potom je wjedro zasy rjeńše.
+WS02	Wone přestanje so bórzy snĕh hić, potom je wjedro zasy rjeńše.
 WS03	Připowoš kólje do kachli, zo by so mloko bórzy wariło.
 WS04	Stary dobry muš je so z konjom přez lód přepanył a do zymnej wody panył.
 WS05	Wón je před štyrjomi abo šesćimi njedźelemi wumrjeł.
-WS06	Wohjen bě přejara sylny; tykancy su spody čorne spalene.
-WS07	Wón jě jeja přecy bjez selje a popjera.
+WS06	Wohjen bĕ přejara sylny; tykancy su spody čorne spalene.
+WS07	Wón jĕ jeja přecy bjez selje a popjera.
 WS08	Nohi mje jara bola, myslu sej, zo sym sej je wotčisćał.
 WS09	Ja sym pola žony był, a sym jej prajił, a wona wotmołwi, so chce tež swojej dźowcy prajić.
 WS10	Ja njecham to tež wjacy činić.
 WS11	Ja će dyru ze žicu woko wuši, ty wopica!
 WS12	Hdźje dźejš, dyrbimy stobu hić.
 WS13	Su hubjene časy!
-WS14	Moje lubo dźěćo, wostajn tule delka stejo, lóse husy će zakusaja.
-WS15	Ty sy dźeńs najwjacy wuknył a pěkny był, ty móžeš prjedy domoj hić, hač druzy.
+WS14	Moje lubo dźĕćo, wostajn tule delka stejo, lóse husy će zakusaja.
+WS15	Ty sy dźeńs najwjacy wuknył a pĕkny był, ty móžeš prjedy domoj hić, hač druzy.
 WS16	Ty šće nejsy wulki dosć, zo by blješu wina wupił, ty šće dyrbiš kruch rosć a wjeći być.
-WS17	Dźi, być tak dobry a praj twojej sotře, zo by mojej maćerne drasty zešiwa a je z sćětku čisćiwa.
-WS18	Hdy by ty jého znał! potom by to hinak było, a z nim tejž lěpje stało.
+WS17	Dźi, być tak dobry a praj twojej sotře, zo by mojej maćerne drasty zešiwa a je z sćĕtku čisćiwa.
+WS18	Hdy by ty jého znał! potom by to hinak było, a z nim tejž lĕpje stało.
 WS19	Štó je mi mój korb z mjasom kranył.
 WS20	Wón tak činješe, hako bychu jeho na moćenjo sej najeli; woni pak su to sami sčinili.
 WS21	Komu je wón tu nowu stawiznu powjedał.
 WS22	Jedyn dyrbi wótse wołać, hewak wón nam njerozemi.
 WS23	My smy sprocni a nam chce so pić.
-WS24	Hdyž my wčera wospět přindźechmy, lejžachu ći druzy žno łožu a spachu kruče.
-WS25	Sněh je dźens nocy pola nas lejžo wostał, ale dźens rano je zasy rostał.
+WS24	Hdyž my wčera wospĕt přindźechmy, lejžachu ći druzy žno łožu a spachu kruče.
+WS25	Snĕh je dźens nocy pola nas lejžo wostał, ale dźens rano je zasy rostał.
 WS26	Zady našo twarjenja steja tři rjane jabłočinki z čerwjenymi jabłukami.
 WS27	Njemóžeće wo łokomik wočaknyć, potom dźemy my tež sobu.
-WS28	Wo njesměće tak dźěćace činić.
+WS28	Wo njesmĕće tak dźĕćace činić.
 WS29	Naše hory nejsu tak wysoke, waše su wyšje.
-WS30	Kak wjele puntow kołbasy a kak wjele khlěba chceće wy měć.
+WS30	Kak wjele puntow kołbasy a kak wjele khlĕba chceće wy mĕć.
 WS31	Ja was njerozymju, wy dyrbiće kusk wótsišo ryčeć.
-WS32	Nejsće wy kusk běło módła za mnje na mojim blidźe namakali?
-WS33	Jeho bratr chce dwě rjanej nowoj khejži we wašej zarodźe twarić.
+WS32	Nejsće wy kusk bĕło módła za mnje na mojim blidźe namakali?
+WS33	Jeho bratr chce dwĕ rjanej nowoj khejži we wašej zarodźe twarić.
 WS34	Tele słowo přindźeše jemu wot wutrobu.
 WS35	
 WS36	Kajke ptački sejdźa tam horka na muri.
-WS37	Burja běchu pjeć wołow a dźewjeć kruwow a dwanaće wowckow před wjes pšinali; k pšedaću.
+WS37	Burja bĕchu pjeć wołow a dźewjeć kruwow a dwanaće wowckow před wjes pšinali; k pšedaću.
 WS38	Dźeńs su wšitcy ludźo na polu a sećeja.
 WS39	Dźi jenož, bruny pos ći ničo n<j>ečini.
-WS40	Ja sym stymi ludźimi tam zady do žita jěł.
+WS40	Ja sym stymi ludźimi tam zady do žita jĕł.

--- a/56522_Klix.csv
+++ b/56522_Klix.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje lěta suche lisče wokoło.
+WS01	W zymje lĕta suche lisče wokoło.
 WS02	Snje bórzy přestanje, potom budźe wedro zaso rjane.
 WS03	Nakładž wuhla do kachlow, zo so mlóko zawari.
 WS04	Ton bohi stary je so na lodże z konjom přepadnył a do zymnej wody padnył.
 WS05	Wón je před štyrjomi aby šesčimi njedżelemi wumrjeł.
-WS06	Pěc bje přepyrena, tykancy su spody wšě smudžene.
-WS07	Wón jeja přeco bjeż selje a póperja jě.
+WS06	Pĕc bje přepyrena, tykancy su spody wšĕ smudžene.
+WS07	Wón jeja přeco bjeż selje a póperja jĕ.
 WS08	Nohi mje jara bola, najskeršo sym sebi je zrybował.
 WS09	Ja sym pola teje žony pobył a sym jej prajił, a wona slubi, zo chce jo tez swojej džowcy prajič.
 WS10	Ja to wjacy ćinič nochcu.
-WS11	Ja će z měšawu za wuši smyknu, wopica.
-WS12	Hdže džeš? směmy sobu přindż?
+WS11	Ja će z mĕšawu za wuši smyknu, wopica.
+WS12	Hdže džeš? smĕmy sobu přindż?
 WS13	Su hubjene ćasy.
-WS14	Lube džěćo, wostan delkach, te złe husy ce zkusaja.
-WS15	Ty sy džensa najpěknišo wuknył a posłušny był, ty směš predy druhich domoj hić.
+WS14	Lube džĕćo, wostan delkach, te złe husy ce zkusaja.
+WS15	Ty sy džensa najpĕknišo wuknył a posłušny był, ty smĕš predy druhich domoj hić.
 WS16	Ty hišce nejsy wulki dosć, zo by móhł blešu wina znesč, ty dyrbiš hišće kónc přirosć.
-WS17	Dži, zčin mi k woli a rjek sotři, zo chcyła te drasćenje za wašu mać došič a ze ščěču wućesać.
-WS18	Hdy by jeho znał, hda by hinak [z nim stało] přišło a lěpe znim stało.
+WS17	Dži, zčin mi k woli a rjek sotři, zo chcyła te drasćenje za wašu mać došič a ze ščĕču wućesać.
+WS18	Hdy by jeho znał, hda by hinak [z nim stało] přišło a lĕpe znim stało.
 WS19	Štu je mój korb z mjasom kradnył?
 WS20	Wón ćineše, jako bychu jeho na młoćenje skazali [by na młoćenje skazany był] woni su jo pak sami sčinili.
 WS21	Komu je wón ton nowy podałk powjedał?
 WS22	Wołajmy wótře, hjewak nam njezrozÿmi.
 WS23	My smy mućni a laćni.
 WS24	Jako so wčera wječor wróčichmy, ležachu ći druzy hižom w łožach a spachu twjerdže.
-WS25	W nocy bě sně pola nas ležo wostał, ale na ranje je rostał.
+WS25	W nocy bĕ snĕ pola nas ležo wostał, ale na ranje je rostał.
 WS26	Před poslencu steja tři zróstne jabłočinki z čerwjenymi jablóćkami.
 WS27	Njemóžeće hišće khwilku wočakać? Potom džemy sobu.
-WS28	Wy njesměce tajke pryslje hnać.
+WS28	Wy njesmĕce tajke pryslje hnać.
 WS29	Naše horÿ nejsu jara wysoke, waše su wjele wyšše.
-WS30	Wjele kołbasy a khlěba chceče měč?
+WS30	Wjele kołbasy a khlĕba chceče mĕč?
 WS31	Ja wan njerozymju, ryčče trochu wótřišo.
 WS32	Nejsće mój kusk mydła na blidži pytnyli?
-WS33	Jeho bratr chce sebi dwě nowej khěži <w> na wašej zahrodźe twarić.
+WS33	Jeho bratr chce sebi dwĕ nowej khĕži <w> na wašej zahrodźe twarić.
 WS34	To słowo přindže jemu wot wutroby!
-WS35	To bě prawje wot njeho!
-WS36	<To bě prawje wot njeho!> Što su to za ptački tam horkach na muričcy?
+WS35	To bĕ prawje wot njeho!
+WS36	<To bĕ prawje wot njeho!> Što su to za ptački tam horkach na muričcy?
 WS37	Či burja <mejachu> bjechu pječ wołow a džeweč kruwow a dwanačen wowocow před wjes prihnali a chcychu je předać.
 WS38	Ludžo su dżensa wšitcy na polje a syku tam.
 WS39	Přeco dzi, tón bruny psyk či ničo nječini.
-WS40	Ja sym stymi ludžimi tam zady po łukach do žita jěł.
+WS40	Ja sym stymi ludžimi tam zady po łukach do žita jĕł.

--- a/56523_Guttau.csv
+++ b/56523_Guttau.csv
@@ -8,21 +8,21 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Zymi suche lisće lofći wokoło lěta.
-WS02	Sněh dołho wjac njepońdźe, potom budźe rjeńše wjedro.
+WS01	Zymi suche lisće lofći wokoło lĕta.
+WS02	Snĕh dołho wjac njepońdźe, potom budźe rjeńše wjedro.
 WS03	Namjetaj wuhle do khachlow, zo so mloko borzy zawari.
 WS04	Wbohi stary muž je so na lodźi z konjom přepadnył a do zymnej wody padnył.
-WS05	Wón je před štěrimi aby šesćimi njedźelemi zemrjeł.
-WS06	Wohén bě přez měru žahwy, tykancy su smudźene.
-WS07	Jeja wón přecy bjez sele a pópjera jě.
+WS05	Wón je před štĕrimi aby šesćimi njedźelemi zemrjeł.
+WS06	Wohén bĕ přez mĕru žahwy, tykancy su smudźene.
+WS07	Jeja wón přecy bjez sele a pópjera jĕ.
 WS08	Mje jara nohi bola, najskeršo sym sebi je wotčišćał.
 WS09	Ja sym pola žony był a sym jej prajił, a wona chcyše to tež swojej dźowcy prajić.
 WS10	Njecham to tež wjacy činić.
-WS11	Ja će z měšawku prasnu, ty wopica.
+WS11	Ja će z mĕšawku prasnu, ty wopica.
 WS12	Hdźe dźeš, dyrbimy sobu hić.
 WS13	Su złe časy = Maš złe časy.
-WS14	Moje lube dźěćo, wostań delkach, złe husy će zakusaja.
-WS15	Ty sy dźensa najwjacy nawuknył a sy pěkny był, směš prjedy tamnych domoj hić.
+WS14	Moje lube dźĕćo, wostań delkach, złe husy će zakusaja.
+WS15	Ty sy dźensa najwjacy nawuknył a sy pĕkny był, smĕš prjedy tamnych domoj hić.
 WS16	Ty hišće njejsy wulki dosć, zo by mohł blešu wina wupić, kruch wjetši narosć.
 WS17	Dźi a budź tak dobry a praj sotři, zo by maćeri drasty zešiła a wučesała.
 WS18	Budźiše jeho znał, dha by hinak a lepje z njem stało.
@@ -32,19 +32,19 @@ WS21	Komu je nowinku powjedał?
 WS22	Dyrbimy na njeho wować, hewak nam njezrozymi.
 WS23	(My smy) Sprócni a laćni smy.
 WS24	Jako so wčera wroćichmy, leźa ći druzy a spachu twjeŕdźe.
-WS25	Wnocy pola nas sněh ležo wosta, ale na ranje rosta.
-WS26	Zady našej khěže tři rjane jabłočinki steja, z čerwjenymi jabłočkami.
+WS25	Wnocy pola nas snĕh ležo wosta, ale na ranje rosta.
+WS26	Zady našej khĕže tři rjane jabłočinki steja, z čerwjenymi jabłočkami.
 WS27	Njemožeće kwilku čakać, potom z wami póńdźemy.
 WS28	Njećerće tajke pryzle.
 WS29	Naše hory njejsu wysoke, waše su wjele wysowše.
-WS30	Kak wjele puntow kołbasy a khlěba?
+WS30	Kak wjele puntow kołbasy a khlĕba?
 WS31	Ja wam njerozemju, ryčće trochu wotřišo.
-WS32	Njejsće žadyn kusk běłeho mydła za mnje na mojim blidźi namkali.
-WS33	Jeho bratr chce sebi dwě rjanej nowej khěži wašej zahrodźi natwarić.
+WS32	Njejsće žadyn kusk bĕłeho mydła za mnje na mojim blidźi namkali.
+WS33	Jeho bratr chce sebi dwĕ rjanej nowej khĕži wašej zahrodźi natwarić.
 WS34	To słowo jemu z wutroby přińdźe.
-WS35	To bě wot nich prawje.
+WS35	To bĕ wot nich prawje.
 WS36	Kajke ptaćatko <sedźé> sedźi na muričcy?
-WS37	Burjo běchu pjeć wołow a dźewjeć kruwow a dwanaće wowckow přede wsu na předań stajili.
+WS37	Burjo bĕchu pjeć wołow a dźewjeć kruwow a dwanaće wowckow přede wsu na předań stajili.
 WS38	Dźensa su wšitcy ludźo na poli na syčenju.
 WS39	Dźi jenož, bruny pos ći ničo nječini.
-WS40	Ja sym z ludźimi tam zady přez łuku do žita jěł.
+WS40	Ja sym z ludźimi tam zady přez łuku do žita jĕł.

--- a/56524_Kuckau.csv
+++ b/56524_Kuckau.csv
@@ -8,13 +8,13 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Wo zymje lěta suche liscżo po wetrě woko.
-WS02	Wony pschěsta skoro sṅje hicż, potym polěpschi so wědro.
-WS03	Cżěs kholje do kachlow, zo buh so mloko skoro zawariwo.
-WS04	Tón pěkny stary muż jo ze swojim koṅjom pschez lod so pschepadnyw ha do zymnei wody padnył.
-WS05	Won jo psched schterjomi haby schescźomi ṅjedźilami wumrěł.
-WS06	Woheṅ bě jara horcy, tykancy so spody cyle cźorny <so> spaljene.
-WS07	Won pschecy jeja je bjez selě ha popěra.
+WS01	Wo zymje lĕta suche liscżo po wetrĕ woko.
+WS02	Wony pschĕsta skoro sṅje hicż, potym polĕpschi so wĕdro.
+WS03	Cżĕs kholje do kachlow, zo buh so mloko skoro zawariwo.
+WS04	Tón pĕkny stary muż jo ze swojim koṅjom pschez lod so pschepadnyw ha do zymnei wody padnył.
+WS05	Won jo psched schterjomi haby schescźomi ṅjedźilami wumrĕł.
+WS06	Woheṅ bĕ jara horcy, tykancy so spody cyle cźorny <so> spaljene.
+WS07	Won pschecy jeja je bjez selĕ ha popĕra.
 WS08	Nohi mje jara bola, ja sei moslu, zo sym sei je sreibwaw.
 WS09	Ja sym pa’ tei żony pobył ha sym to ji prajił ha wona prajesche, zo chce to też swojei dżowcy prajicż.
 WS10	Ja to ṅjecham żeni jacy cźiṅicź!
@@ -22,29 +22,29 @@ WS11	Ja dyru cźe ṅjedom ze żicu woko wuschow, ty wopica!
 WS12	Dże ty dżeisch, derbimo mo smo też sobu hicź?
 WS13	Wony su hubeṅje cźasy.
 WS14	Moje lubo dźecźo, wostan jow deleka stejo, hewak cźe te zwy husy zakusaja.
-WS15	Ty sy dźenca najacy nawuknył ha sy pschistoiṅje so zadźerźał, ty moźesch prědy domoj hicź, hacź cźi druzy.
+WS15	Ty sy dźenca najacy nawuknył ha sy pschistoiṅje so zadźerźał, ty moźesch prĕdy domoj hicź, hacź cźi druzy.
 WS16	Ty neisy hischcźe wilki doscź, zo bó mohł bljeschu wina wupicź, ty dyrbisch schcźe kruch naroscź ha wetschi wordwacź.
-WS17	Dźi, bocź tak dobry ha praj twojei sotcě, zo bo wona te drasty za waschu macź hotowy zeschiła ha je ze <scht> schcźetku cźisty wucźesawa.
-WS18	Bjy ty joho znał! potyn bo so ta wěc hinak cźiniła; ha wony buh lěpe znim stawo.
+WS17	Dźi, bocź tak dobry ha praj twojei sotcĕ, zo bo wona te drasty za waschu macź hotowy zeschiła ha je ze <scht> schcźetku cźisty wucźesawa.
+WS18	Bjy ty joho znał! potyn bo so ta wĕc hinak cźiniła; ha wony buh lĕpe znim stawo.
 WS19	Schto jo mi moi korb zmjasom kranył?
 WS20	Won tak cźinjesche, hako bochu joho kmocźeṅju wobschtelwali; woni pak su to sami cźinili.
-WS21	Komu jo won tu nowu wěc pojedał?
+WS21	Komu jo won tu nowu wĕc pojedał?
 WS22	Jedyn dyrbi chczewoi wschiju wowacź, hewak won nas njezrozemi.
 WS23	Mo smo mucźni ha nam chcze so picź.
-WS24	Dysch mo cźera wěcźor so domoj wrocźichmo, leiżachu cźi druzy żno wo wożu ha spachu krucźe.
+WS24	Dysch mo cźera wĕcźor so domoj wrocźichmo, leiżachu cźi druzy żno wo wożu ha spachu krucźe.
 WS25	Sṅei jo tulei noc pa nas leižo wostał, tola dźenc rano jo rostał.
 WS26	Zady naschoho domskoho steja tsi rjany jabłucźiny ze cźerwenymi jabucźkami.
 WS27	Njemoźecźe wo schcźe mawy kus na nas <d> cźakacź, potom dźemo mo zwami.
 WS28	Wo njedyrbicźe taike dźecźacy wuposcze nacź.
-WS29	Nasche hory neisu jary wosokě, te wasche su wele wosche.
-WS30	Ka wele puntow kobasy ha ka wele klěba chczeicźe wo měćz?
+WS29	Nasche hory neisu jary wosokĕ, te wasche su wele wosche.
+WS30	Ka wele puntow kobasy ha ka wele klĕba chczeicźe wo mĕćz?
 WS31	Ja was ṅjezrozemju, wy dyrbicźe kusk wotsischo recźecź.
-WS32	Neiscźe wo kusk běwoho modła za mṅje na mojim blidźe nankali?
+WS32	Neiscźe wo kusk bĕwoho modła za mṅje na mojim blidźe nankali?
 WS33	Joho brat chce sebi dwei nowoi keiźi wo waschei zahrodźe natwaricź.
 WS34	Te słowo pschindźe jomu zwutroby.
 WS35	To bjy praje wot was!
-WS36	Kaike ptacźki seidźa tam horěka na murcy?
-WS37	Burja běchu pjecź wowow ha dzewecź kruwow ha dwanacźe wowcow psched wes pschiwedli, kotresch chcechu woni pschedacź.
+WS36	Kaike ptacźki seidźa tam horĕka na murcy?
+WS37	Burja bĕchu pjecź wowow ha dzewecź kruwow ha dwanacźe wowcow psched wes pschiwedli, kotresch chcechu woni pschedacź.
 WS38	Ludźo su dźenca wschitc<z>e wonka na polu ha syku.
 WS39	Dźi noi, ton bruny psyk cźi nicźo ṅjecźini.
 WS40	Ja sym stymi ludźimi tam zady pschez wuku do žita zajeł.

--- a/56525_Crostwitz.csv
+++ b/56525_Crostwitz.csv
@@ -8,13 +8,13 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje lětaja te suche wopjeschka w lofcže woko.
-WS02	Sněh bdže zmolom hicž pschestacž, potom změjemo zas lěpsche wjedro.
-WS03	Pschiwož wulo do něscźe, zo bó so mlóko skoro wariwo.
+WS01	W zymje lĕtaja te suche wopjeschka w lofcže woko.
+WS02	Snĕh bdže zmolom hicž pschestacž, potom zmĕjemo zas lĕpsche wjedro.
+WS03	Pschiwož wulo do nĕscźe, zo bó so mlóko skoro wariwo.
 WS04	Tón bohi stary muž jo so z konjom na lodže pschepanył a do teje zymneje wody panył.
-WS05	Wón jo psched schtyrjomi abo schěscžimi njedžlemi wumrěł.
-WS06	Pěc bě jara horca, tykancy su spody cžiscže cžorne zesmudžene.
-WS07	Wón jeja wěcžnje bjez sele a popjerja jě.
+WS05	Wón jo psched schtyrjomi abo schĕscžimi njedžlemi wumrĕł.
+WS06	Pĕc bĕ jara horca, tykancy su spody cžiscže cžorne zesmudžene.
+WS07	Wón jeja wĕcžnje bjez sele a popjerja jĕ.
 WS08	Nohi mje jara bola, ja so bóju, zo sym sej je wotstupił.
 WS09	Ja sym pola teje žony pobył a sym ji to prajił, a wona prajesche, zo chce je tež swojej džowcy prajicž.
 WS10	Ja tež to wjacy cžinicž njecham.
@@ -22,29 +22,29 @@ WS11	Ja cže glaj zmutylcźku za wuschi dyru, ty wopica.
 WS12	Džeha džesch, dyrbimy sobu hicž?
 WS13	Wone su hubjene cžasy!
 WS14	Moje lubo džecźo, wostań tu delka stejo, te zwo husy cźe zakusaja.
-WS15	Ty sy džens najwjacy wuknył a pěkny bół. Ty móžesch prjedy domoj hicź, hacź cźi druzy.
+WS15	Ty sy džens najwjacy wuknył a pĕkny bół. Ty móžesch prjedy domoj hicź, hacź cźi druzy.
 WS16	Ty hischcźe wilki doscź nejsy, zo bó bleschu wina wupicź moł, ty dyrbisch schcźe kusk roscź a wjecži wordwacź.
-WS17	Dži, bódž tak dobry a praj twojej sotse, zo dyrbi tu drastu za waschu macź hotowu zeschicź a ze schcźětku wurjedźicź.
-WS18	Hdy bě joho znał, dha bě to hinak pschischło, a wone bó lěpje znim stawo.
+WS17	Dži, bódž tak dobry a praj twojej sotse, zo dyrbi tu drastu za waschu macź hotowu zeschicź a ze schcźĕtku wurjedźicź.
+WS18	Hdy bĕ joho znał, dha bĕ to hinak pschischło, a wone bó lĕpje znim stawo.
 WS19	Schtó jo mi mój korb ztym mjasom kranył?
 WS20	Wón tak cžinjesche, hako bóchu jomu na mócźenjo kazali; woni pak su je sami cžinili.
 WS21	Komu jo wón tu nowinu pójedał?
 WS22	Jedyn dyrbi wótse wowacž, hewjak wón njeswyschi.
 WS23	Mó smó mucžni a nam chce so picž.
-WS24	Hacž mó cžera wjecžor zas pschindžechmó, dha běchu cźi druzy do woža a spachu.
-WS25	Sněh jo tule nóc pa nas ležo wostał, ale džens rano zas roztał.
-WS26	Zady naschoh twarjenja steja tsi rjane jabłocžinki z cžěrwjenymi jabucžkami.
+WS24	Hacž mó cžera wjecžor zas pschindžechmó, dha bĕchu cźi druzy do woža a spachu.
+WS25	Snĕh jo tule nóc pa nas ležo wostał, ale džens rano zas roztał.
+WS26	Zady naschoh twarjenja steja tsi rjane jabłocžinki z cžĕrwjenymi jabucžkami.
 WS27	Njechacže hschcže khwilku wocžaknycž, mó potom sobu džemó.
-WS28	Wó njesměcže tak džecźace bódž.
+WS28	Wó njesmĕcže tak džecźace bódž.
 WS29	Nasche hory njejsu jara wysoke, wasche su wjele wósche.
-WS30	Kak wjele puntow kołbasy a kak wjele khlěba chcecźe měcź?
+WS30	Kak wjele puntow kołbasy a kak wjele khlĕba chcecźe mĕcź?
 WS31	Ja wam njerozemju, wó dyrbicže trochu wótsischo rycžecź.
-WS32	Nejscźe žadyn kusk běwoh módła wote mnje na mojim blidže namkali?
-WS33	Mój bratr chce sebi dwě rjanej nowej twarjeni waschej zahrodže natwaricź.
+WS32	Nejscźe žadyn kusk bĕwoh módła wote mnje na mojim blidže namkali?
+WS33	Mój bratr chce sebi dwĕ rjanej nowej twarjeni waschej zahrodže natwaricź.
 WS34	Te słowo pschindže jomu wot wutrobu.
-WS35	To bě prawje wot was.
+WS35	To bĕ prawje wot was.
 WS36	Kajke tam ptacžki horka na murcy sedža?
-WS37	Cźi burja běchu pjecź wołow a džewjecź kruwow a dwanacźe wowckow ke wsy pschiwjedli, kiž chcychu pschedacź.
-WS38	Ludžo su džens schě wonka na polu a syku.
+WS37	Cźi burja bĕchu pjecź wołow a džewjecź kruwow a dwanacźe wowckow ke wsy pschiwjedli, kiž chcychu pschedacź.
+WS38	Ludžo su džens schĕ wonka na polu a syku.
 WS39	Dži jenoj, bruny psyk cźi nicžo cžinicź njeńdže.
-WS40	Ja sym z tymi ludžimi tam zady pschez łuku do žita jěł.
+WS40	Ja sym z tymi ludžimi tam zady pschez łuku do žita jĕł.

--- a/56526_Coblenz.csv
+++ b/56526_Coblenz.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje lětaja suche łopjena přez powětr wokoło.
-WS02	Sněh so nydom přestanje hić, potom je wjedro zaso lěpše.
+WS01	W zymje lĕtaja suche łopjena přez powĕtr wokoło.
+WS02	Snĕh so nydom přestanje hić, potom je wjedro zaso lĕpše.
 WS03	Sčin wuhlje do khachlow, zo so mlóko bórzy warić započnje.
 WS04	Dušny stary muž je so z konjom přez lód přełamał a do zymneje wody panył.
 WS05	Wón je před štyri aby peč njedželemi wumreł.
-WS06	Woheń <je> bě přejara horcy, tykancy dže su spody čisće čorne spalene.
-WS07	Wón jeja přeco bjez sele a póperja jě.
-WS08	Nohi mje jara bola, mi so zda, zo sym je přeběžał.
+WS06	Woheń <je> bĕ přejara horcy, tykancy dže su spody čisće čorne spalene.
+WS07	Wón jeja přeco bjez sele a póperja jĕ.
+WS08	Nohi mje jara bola, mi so zda, zo sym je přebĕžał.
 WS09	Pola teje žony sym pobył a jej to prajił, a wona praješe, zo chce to jejnej džówcy tež rec.
 WS10	To pak tež njecham zaso činić!
 WS11	Nydom će z mutelu <z mutelu> za wuši biju, wopica.
 WS12	Hdže džeš, dyrbimi z tobu hić?
 WS13	Wono su hubjene časy!
-WS14	Lube dźěćo, wostań tule delkach stejo, złe husy će zakusaja.
-WS15	Ty sy džensa najwjacy nawuknył a pěkny był, móžeš prjedy domoj hić, hač druzy.
+WS14	Lube dźĕćo, wostań tule delkach stejo, złe husy će zakusaja.
+WS15	Ty sy džensa najwjacy nawuknył a pĕkny był, móžeš prjedy domoj hić, hač druzy.
 WS16	Hišće wulki dosć njejsy, zo by blešu wina wupił, dyrbiš hisće kónc nasrosć a nabyć.
-WS17	Dži, <byc> bydž tak dobry a praj twojej sotře, zo dyrbi drastu za wašu mać došić a ze šćětku wuredžić.
-WS18	By jeho znał! Wšitko by potom hinak přišło a lěpje by <znim> z nim stało.
+WS17	Dži, <byc> bydž tak dobry a praj twojej sotře, zo dyrbi drastu za wašu mać došić a ze šćĕtku wuredžić.
+WS18	By jeho znał! Wšitko by potom hinak přišło a lĕpje by <znim> z nim stało.
 WS19	Štó je mi mój korb mjasa kranył?
 WS20	Wón činješe, jako bychu woni jeho kmócenju zkazali, woni pak su jo sami činili.
 WS21	Komu je tón nowy podawk powjedał?
 WS22	Wono dyrbi so wótře wołać, hewak naz njezrozymi.
 WS23	Smy sprócni a <lačnosć> lačni.
-WS24	Jako wćera wećór róćo přindžechmy, ležachu druzy hižom w łožu a běchu w twerdym spanju.
-WS25	Sněh je tu nóc pola nas ležo wostał, ale džensa rano je roztał.
-WS26	Zady našeje khěže steja tři rjane jabłućinki z čerwjenymi jabłućkami.
+WS24	Jako wćera wećór róćo přindžechmy, ležachu druzy hižom w łožu a bĕchu w twerdym spanju.
+WS25	Snĕh je tu nóc pola nas ležo wostał, ale džensa rano je roztał.
+WS26	Zady našeje khĕže steja tři rjane jabłućinki z čerwjenymi jabłućkami.
 WS27	Njemóžeće hisče wokomiknjeńćko na naz dočakać, potom sobu džemy.
-WS28	Tajke džěčastwa njesméće čěrić.
+WS28	Tajke džĕčastwa njesméće čĕrić.
 WS29	Naše hory njejsu jara wysoke, waše su wjele wyše.
-WS30	Kak wjele puntow kołbasy a kak wjele khlěba chceće měć?
+WS30	Kak wjele puntow kołbasy a kak wjele khlĕba chceće mĕć?
 WS31	Njerozymju wam, dyrbiće wótřišo ryćeć.
-WS32	Njejsće kusk běłeho módła za mnje na blidže namakali?
-WS33	Jeho bratr chce sebi dwě rjanej nowej khěži w wašej zahrodže natwarić.
+WS32	Njejsće kusk bĕłeho módła za mnje na blidže namakali?
+WS33	Jeho bratr chce sebi dwĕ rjanej nowej khĕži w wašej zahrodže natwarić.
 WS34	To słowo přindže jemu z wutroby!
-WS35	To bě prawje wot nich.
+WS35	To bĕ prawje wot nich.
 WS36	<Kal> Kajke ptaćatka sedža tu horjekach na muričcy?
-WS37	Burjo běchu pjeć wołow a džeweć kruwow a dwanaće wowckow předewsu přinjesli, te chcychu předać.
+WS37	Burjo bĕchu pjeć wołow a džeweć kruwow a dwanaće wowckow předewsu přinjesli, te chcychu předać.
 WS38	Ludžo su wšitcy wonkach na poli a syčeja.
 WS39	Dži jenož, ćorny pos ci ničo njećini.
-WS40	Tamle zady sym <s> z tymi ludžimi prez <w> łuku do žita jěł.
+WS40	Tamle zady sym <s> z tymi ludžimi prez <w> łuku do žita jĕł.

--- a/56527_Grosswelka.csv
+++ b/56527_Grosswelka.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje lětaja suche łopjena w lofće wokoło.
-WS02	Wono zastanje hnydom sněh hić, potom budźe lěpše wjedro.
+WS01	W zymje lĕtaja suche łopjena w lofće wokoło.
+WS02	Wono zastanje hnydom snĕh hić, potom budźe lĕpše wjedro.
 WS03	Čiń wuhlo do khachlow, zo so mloko póčnje warić.
 WS04	Tón dobry stary muž je so z konjom na lodźe přepanył a do zymneje wody panył.
-WS05	Wón je před štyrimi abo šěsćimi njedźelemi wumrjeł.
-WS06	Horcota běše pře wulka, teho dla běchu tykancy delkach cyle spaleny.
-WS07	Wón jeja přeco bjez sele a popjera jě.
+WS05	Wón je před štyrimi abo šĕsćimi njedźelemi wumrjeł.
+WS06	Horcota bĕše pře wulka, teho dla bĕchu tykancy delkach cyle spaleny.
+WS07	Wón jeja přeco bjez sele a popjera jĕ.
 WS08	Nohi mje jara bola, ja sebi myslu, zo sym sebi je wobodrjeł.
 WS09	Ja sym pola teje žony był, a sym jej to prajił, a wona rjekny, zo chce to tež swojej dźowcy prajić.
 WS10	Ja to tež wjacy zaso ćinić njecham.
 WS11	Ja će hnydom z mutylu za wuši prasnu ty wopica.
 WS12	Hdźe dźeš? Dyrbimy z tobu hić?
 WS13	Časy su hubjene.
-WS14	Moje lube dźěćo, wostań delkach stejo, te hrosne husy móhłe tebje zakusać.
+WS14	Moje lube dźĕćo, wostań delkach stejo, te hrosne husy móhłe tebje zakusać.
 WS15	Ty sy dzensa najwjacy nawuknył a sy dušny był, ty móžeš prjedy domoj hić hač ći druzy.
 WS16	Ty hišće njejsy wulki dosć, zo by mohł blešu wina wupić, ty hišće dyrbiš kruch rosć.
-WS17	Dźi, budź tak dobry a praj twojej sotře, zo dyrbi tu drastu za wašu maćeŕ hotowu zešić a ze šćětku wurjedźić.
-WS18	Budźiši ty jeho znał, dha budźiše to hinik přišło a by <lj> lěpje z nim stało.
+WS17	Dźi, budź tak dobry a praj twojej sotře, zo dyrbi tu drastu za wašu maćeŕ hotowu zešić a ze šćĕtku wurjedźić.
+WS18	Budźiši ty jeho znał, dha budźiše to hinik přišło a by <lj> lĕpje z nim stało.
 WS19	Štó je mi mój korb z mjasom kranył?
 WS20	Wón tak činješe, jako bychu jeho k móćenju skazali, woni su pak to sami sčinili.
 WS21	Komu je wón tu nowu powjesć powjedał?
 WS22	Dyrbi so <b> wótře wołać, hewak won <w>nas njerozymi.
 WS23	My smy sprócni a lačni.
 WS24	Jako wčera wječor domoj přińdźechmy, ležachu wšitcy druzy hižom w łožu a spachu.
-WS25	Sněh je zańdźenu noc pola nas ležo wostał, ale dźensa rano je zaso wotešoł.
-WS26	Zady našeje khěže steja tři rjany jabłunćinki z čerwjenymi jabłučkami.
+WS25	Snĕh je zańdźenu noc pola nas ležo wostał, ale dźensa rano je zaso wotešoł.
+WS26	Zady našeje khĕže steja tři rjany jabłunćinki z čerwjenymi jabłučkami.
 WS27	Njemohli hišće khwilku na nas wočaknyć? My dźemy potom z wami.
-WS28	Wy njedyrbiće tajke dźěćinstwa hnać.
+WS28	Wy njedyrbiće tajke dźĕćinstwa hnać.
 WS29	Naše hory njejsu <tak> jara wosoke, waše su wyšše.
-WS30	Kak wjele puntow kołbasy a khlěba chceće měć.
+WS30	Kak wjele puntow kołbasy a khlĕba chceće mĕć.
 WS31	Ja was njerozymju, wo dyrbiće wotřišo ryčeć.
-WS32	Njejsće kusk běłeho mydła za mnje na blidźe mamakali?
-WS33	Jeho bratr chce sebi dwě rjanej nowej khěži w wašej zahrodźe natwarić.
+WS32	Njejsće kusk bĕłeho mydła za mnje na blidźe mamakali?
+WS33	Jeho bratr chce sebi dwĕ rjanej nowej khĕži w wašej zahrodźe natwarić.
 WS34	To słowo jemu wot wutroby přińdźe.
-WS35	To běše prawje wot was.
+WS35	To bĕše prawje wot was.
 WS36	Kajke tam małe ptački horkach na tej muričcy sedźa.
-WS37	Burjo běchu pjeć wołow, dźewjeć kruwow a dwanaće wowckow před wjes přiwjedli, te chcychu woni předać.
-WS38	Ludźo su dźensa wšitcy wonkach na poli a žněja.
+WS37	Burjo bĕchu pjeć wołow, dźewjeć kruwow a dwanaće wowckow před wjes přiwjedli, te chcychu woni předać.
+WS38	Ludźo su dźensa wšitcy wonkach na poli a žnĕja.
 WS39	Dźi jenož, bruny pos tebi ničo nječini.
-WS40	Ja sym z tymi ludźimi tam zezady přez łuku do žita jěł.
+WS40	Ja sym z tymi ludźimi tam zezady přez łuku do žita jĕł.

--- a/56528_Radibor.csv
+++ b/56528_Radibor.csv
@@ -8,13 +8,13 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje suche łopjena we powětre letaja.
-WS02	Hnydom so sněha hić přestanje, potom so wjedro polěpši.
+WS01	W zymje suche łopjena we powĕtre letaja.
+WS02	Hnydom so snĕha hić přestanje, potom so wjedro polĕpši.
 WS03	Sčin wuhla do kachli, zo so mloko skoro zawari.
 WS04	Wbohi stary muž je so z konjom na lodźe přełamał a do zymneje wody padnył.
-WS05	Je před styri aby šěsć njedźelemi wumrjeł.
-WS06	Woheń bě přesylny; tykancy su so spody cyle zesmudźiłe.
-WS07	Jě jeja přecy bjez sele a popjerja.
+WS05	Je před styri aby šĕsć njedźelemi wumrjeł.
+WS06	Woheń bĕ přesylny; tykancy su so spody cyle zesmudźiłe.
+WS07	Jĕ jeja přecy bjez sele a popjerja.
 WS08	Mje nohi jara bola, zda so mi, zo sym sebi je přeteptał.
 WS09	Sym pola žony pobył a jej to prajił; a wona praješe, zo chce to tež swojej dźowcy rjec.
 WS10	Njecham tež to wjacy činić.
@@ -22,29 +22,29 @@ WS11	Spraskam će hnydom z kuchinskej łžicu za wuši, ty wopica.
 WS12	Hdźe dźeš, mamy stobu hić?
 WS13	Su złe časy.
 WS14	Lube dźećo, wostań deleka stejo; zle husy će zakusaja.
-WS15	Ty sy dźensa najwjacy nawuknył a sy pěkny był; směš predy druhich domoj hić.
+WS15	Ty sy dźensa najwjacy nawuknył a sy pĕkny był; smĕš predy druhich domoj hić.
 WS16	Njejsy hišće dosć wulki, zo by blešu wina wupił; dyrbiš predy hišce kusk narosć a wjetši być.
 WS17	Dźi, budź tak dobry a praj swojej sotře, zo by drastu za mač zešiła a ze šćeću wurjedźiła.
-WS18	Hdy bě joho znał; dha budźiše hinak přišło a z tobu lěpje stało.
+WS18	Hdy bĕ joho znał; dha budźiše hinak přišło a z tobu lĕpje stało.
 WS19	Što je mi moj kóš z mjasom kradnył?
-WS20	Činješe, hako běchu jomu na młóćenjo kazali byli; ale woni su to sami činili.
+WS20	Činješe, hako bĕchu jomu na młóćenjo kazali byli; ale woni su to sami činili.
 WS21	Što je nowu stawiznu powjedał?
 WS22	Dyrbiš wotře wować, hewak nam njerozemi.
 WS23	Smy mučni a chce so nam pić.
 WS24	Hdyž wčera wječor wroćo přindźechmy, ležachu druzy hižon we łožo a spachu kruće.
-WS25	Sněh je pola nas w nocy ležo wostał, ale dźensa rano roztał.
+WS25	Snĕh je pola nas w nocy ležo wostał, ale dźensa rano roztał.
 WS26	Zady našoho domu steja tři rjane jabłońki z čerwjenymi jabłučkami.
 WS27	Njemóžeće hišce wokomiknjeńčko na nas dočakać, potom zwami pondźemy.
-WS28	Tajke tryski činić njesměće!
+WS28	Tajke tryski činić njesmĕće!
 WS29	Naše hory jara wysoke njejsu, waše su wyšše.
-WS30	Kak wjele puntow kołbasy a kak wjele khleba chceće měć?
+WS30	Kak wjele puntow kołbasy a kak wjele khleba chceće mĕć?
 WS31	Njerozemju wam, dyrbiš trochu wotřišo ryčec.
-WS32	Njejsće žadyn kusk běłoho mydła za mnje na mojim blidźe namakali?
-WS33	Joho bratr chce sebi dwej rjanej nowej khěži na wašej zahrodźe twarić.
+WS32	Njejsće žadyn kusk bĕłoho mydła za mnje na mojim blidźe namakali?
+WS33	Joho bratr chce sebi dwej rjanej nowej khĕži na wašej zahrodźe twarić.
 WS34	Słowo jomu wot wutroby přindźe.
-WS35	To běše wot nich prawje.
+WS35	To bĕše wot nich prawje.
 WS36	Kajke to ptačatka horjeka na muričcy sedźa?
-WS37	Burjo běchu pjeć wołow a dźewjeć kruwow a dwanaće wowckow před wjes přiwedli, te chcychu předać.
+WS37	Burjo bĕchu pjeć wołow a dźewjeć kruwow a dwanaće wowckow před wjes přiwedli, te chcychu předać.
 WS38	Ludźo su dźensa wšitcy wonka na polu a syku.
 WS39	Dźi jeno, bruny pos tebi ničo njesćini.
-WS40	Sym z ludźimi tam zady přez łuku do žita jěł.
+WS40	Sym z ludźimi tam zady přez łuku do žita jĕł.

--- a/56530_Baschütz.csv
+++ b/56530_Baschütz.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje suche lisće w powětře wokoło lětaja.
-WS02	Wono so hnydom zastanje sněh hić, potom bdźe rjeńše wjedro.
+WS01	W zymje suche lisće w powĕtře wokoło lĕtaja.
+WS02	Wono so hnydom zastanje snĕh hić, potom bdźe rjeńše wjedro.
 WS03	Přikładź wuhle do khachlow, zo so mloko bórzy warić započnje.
 WS04	Wbohi stary muž je so z konjom přez lód přepadnył a do zymnej wody padnył.
 WS05	Won je před štyrjomi aby šesćimi njedźelemi wumrjeł.
-WS06	Woheń bě přećopły, tykancy su spody <ce> cyle spalene.
-WS07	Wón jeja přeco bjez sele a popjerja jě.
-WS08	Nohi mje jara bola; ja sym sej je najskerje přeběžał.
+WS06	Woheń bĕ přećopły, tykancy su spody <ce> cyle spalene.
+WS07	Wón jeja přeco bjez sele a popjerja jĕ.
+WS08	Nohi mje jara bola; ja sym sej je najskerje přebĕžał.
 WS09	Ja sym pola tej žony był a jej to prajił, a wona praješe, zo chce wona to tež swojej dźowcy rjec.
 WS10	Ja tež to ženje wjacy činić nochcu.
 WS11	Ja će [hn] nydom ze łžicu za wuši prasnu, ty wopica!
 WS12	Hdźe dha ty dźeš, dyrbimy my z tobu sobu hić?
 WS13	Wone su złe časy.
-WS14	Moje lube dźěćo, wostań tu delkach stejo, złe husy će zakusaja.
-WS15	Ty sy dźens najwjacy wuknył a sy pěkny był, ty směš prjedy domoj hić, hač tamni.
+WS14	Moje lube dźĕćo, wostań tu delkach stejo, złe husy će zakusaja.
+WS15	Ty sy dźens najwjacy wuknył a sy pĕkny był, ty smĕš prjedy domoj hić, hač tamni.
 WS16	Ty hšće njejsy wulki dosć, zo by mohł blešu wina wupić; ty dyrbiš najprjedy kruch wjetši narosć.
-WS17	Dźi, bydź tak dobry a praj twojej sotři, zo dyrbi wona drastu za wašu maćeŕ došić a ze šćěću wučesać.
-WS18	Hdy by ty jeho znał! dha by wšo hinak přišło a znim by lěpje stało.
+WS17	Dźi, bydź tak dobry a praj twojej sotři, zo dyrbi wona drastu za wašu maćeŕ došić a ze šćĕću wučesać.
+WS18	Hdy by ty jeho znał! dha by wšo hinak přišło a znim by lĕpje stało.
 WS19	Štó je ći mój korb z mjasom kranył?
 WS20	Wón tak činješe, kaž byšće wy jeho na móćenje zkazali; woni pak su to sami činili.
 WS21	Komu je wón tón nowy podałk powjedał?
 WS22	Jedn dyrbi wótře <wować> wować, hewak nas wón njerozymi.
 WS23	My smy sprócni a lačni.
-WS24	Sněh je tu nóc po nas ležo wostał, dźens rano pak je wón roztał.
-WS25	Zahdy našej khěže tři rjane jabłučinki z čerwjenymi jabłukami steja.
+WS24	Snĕh je tu nóc po nas ležo wostał, dźens rano pak je wón roztał.
+WS25	Zahdy našej khĕže tři rjane jabłučinki z čerwjenymi jabłukami steja.
 WS26	Hdyž mi wčera wječor zasy přińdźechmy, tamni w łožu ležo twjerdźe spachu.
 WS27	Njemóžeće <y> wy hšće wokomik wočakać, my potom zwami sobu dźemy.
-WS28	Wy njesmjeće tajke dźěćace hłuposće činić.
+WS28	Wy njesmjeće tajke dźĕćace hłuposće činić.
 WS29	Naše hory njejsu jary wysoke, waše su wjele wyšše.
-WS30	Kak wjele puntow kołbasy a kak wjele khlěba chceće wy měć?
+WS30	Kak wjele puntow kołbasy a kak wjele khlĕba chceće wy mĕć?
 WS31	Ja wam njerozymju, wy dyrbiće kusk wótřišo ryčeć.
-WS32	Njejsće wy žadyn kusk běłeho mydła za mnje na mojim blidźi namkali?
-WS33	Jeho bratr chce sej dwě rjanej nowej khěži we wašej zahrodźi twarić.
+WS32	Njejsće wy žadyn kusk bĕłeho mydła za mnje na mojim blidźi namkali?
+WS33	Jeho bratr chce sej dwĕ rjanej nowej khĕži we wašej zahrodźi twarić.
 WS34	Te słowo jemu wot wutroby přińdźe.
-WS35	To bě prawje wot was.
+WS35	To bĕ prawje wot was.
 WS36	Kajke dha tam na tej muričcy ptački sedźa?
-WS37	Burjo běchu pjeć wołow a dźewjeć kruwow a dwanaće wowckow před wjes přinjesli, te chcychu woni předać.
+WS37	Burjo bĕchu pjeć wołow a dźewjeć kruwow a dwanaće wowckow před wjes přinjesli, te chcychu woni předać.
 WS38	Ludźo dźens wšitcy na poli syčeja.
 WS39	Dźi jenož, ton bruny pos ći ničo nječini.
-WS40	Ja sym z tymi ludźimi tam zady přez łuku do žita jěł.
+WS40	Ja sym z tymi ludźimi tam zady přez łuku do žita jĕł.

--- a/56533_Kotitz.csv
+++ b/56533_Kotitz.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Wzymi lětaja suchje wobjena we lofći <(oder: we powětre)> wokoło.
-WS02	Bórzy poztane sně padač a wjedro so polěpšuje.
+WS01	Wzymi lĕtaja suchje wobjena we lofći <(oder: we powĕtre)> wokoło.
+WS02	Bórzy poztane snĕ padač a wjedro so polĕpšuje.
 WS03	Sčin kohlje do khachlow, zo by so mloko zkoro zwariło.
 WS04	Tamny ztary dobry muž je so z konjom na lodči přepanył a do zymnej wody panył.
-WS05	Tón hižom je pjeć aby šěsć njedźel zemrjěty.
-WS06	Woheń bě pře jara čopły, tykance su delkach cyle čorny spalene.
-WS07	Tón jě jeja bjeze selě a popjera.
+WS05	Tón hižom je pjeć aby šĕsć njedźel zemrjĕty.
+WS06	Woheń bĕ pře jara čopły, tykance su delkach cyle čorny spalene.
+WS07	Tón jĕ jeja bjeze selĕ a popjera.
 WS08	Nohi mje jara bolja, mi so zta, zo sym so překhwatał.
 WS09	Ja sym při tej žonÿ pobył a sym jej prajił a samsna dźeše, zo chce swojej dźowcy prajić.
 WS10	Ja pak to tola njecham ženi wjacy činič.
-WS11	Ja će na blaku změšału za wuši dyrhu, ty wobica.
+WS11	Ja će na blaku zmĕšału za wuši dyrhu, ty wobica.
 WS12	Dźe dźeš, dyrbimy my sobu hič?
 WS13	To su hubjene časy.
-WS14	Lube dźěčo, wostan delkach ztejo, słe husy će hewak zakusaja.
-WS15	Ty sy dźensa najwjacy nawuknył a sy posłyšny był, tehodla směješ ty predy tamnych domoj hič.
-WS16	Ty hišćen njesy wulki dosc, zo by mół blešu wina wupič, ty dyrbiš najpródcy kruch narosć a masku selě zjěsć.
+WS14	Lube dźĕčo, wostan delkach ztejo, słe husy će hewak zakusaja.
+WS15	Ty sy dźensa najwjacy nawuknył a sy posłyšny był, tehodla smĕješ ty predy tamnych domoj hič.
+WS16	Ty hišćen njesy wulki dosc, zo by mół blešu wina wupič, ty dyrbiš najpródcy kruch narosć a masku selĕ zjĕsć.
 WS17	Dzi, bydź tak dobry a praj twojej sotři, zo by wona drastu za wašu mač zešiła a čisče wučesała.
-WS18	By ty jeho znał! dha by wšo hinak <stało> přišło a wo jeho by lěbje ztawo.
+WS18	By ty jeho znał! dha by wšo hinak <stało> přišło a wo jeho by lĕbje ztawo.
 WS19	Štó je mi mój korb z mjezom kradnył?
-WS20	Wón tak čineše, kak bychu jeho kmóćenju měč chyli; ći pak su to sami činili.
+WS20	Wón tak čineše, kak bychu jeho kmóćenju mĕč chyli; ći pak su to sami činili.
 WS21	Komu je wón tu nowu powjesć wupowjedał?
 WS22	Wone dyrbi so wotře wołać, hewak wón ničo njerosemi.
 WS23	My smy mučni a lačni.
 WS24	Jako my čera wječor zazo přindźechmy, ležachu tamni w łožach, a zpachu twjerdźe.
-WS25	Sně dźensa w nocy pola nas lejžo wosta, ale na ranje rozezta.
-WS26	Zezady našeje khěže zteja tři rjane jabukowe štomiki z čerwjenymi jabłučkami.
+WS25	Snĕ dźensa w nocy pola nas lejžo wosta, ale na ranje rozezta.
+WS26	Zezady našeje khĕže zteja tři rjane jabukowe štomiki z čerwjenymi jabłučkami.
 WS27	Njemóžeče wy hišćen wokomik na nas čakać, potom my z wami dźemy.
-WS28	Wy njesměće tajke dźěčastwa hrać.
+WS28	Wy njesmĕće tajke dźĕčastwa hrać.
 WS29	Naše hory njesu jara wysoke, waše su wjele woše.
-WS30	Kak wjele puntow kołbasy a kak wjele khlěba chcejće wy měć.
+WS30	Kak wjele puntow kołbasy a kak wjele khlĕba chcejće wy mĕć.
 WS31	Ja was njerozemju, wy dyrbiće kusk wotŕišo ryčeć.
-WS32	Njesće wy žadyn kusk běłeho módła na mojim blidźi za mnje namakali.
-WS33	Jeho bratr chce sebi dwě nowej khěži we wašej zahrodźi natwarić.
+WS32	Njesće wy žadyn kusk bĕłeho módła na mojim blidźi za mnje namakali.
+WS33	Jeho bratr chce sebi dwĕ nowej khĕži we wašej zahrodźi natwarić.
 WS34	Te słowa jemu z wutroby přindźechu.
 WS35	To by prawje wot nich.
 WS36	Kajke su to ptački horka na muričky.
-WS37	Burjo běchu pjeć wołow a dźeweć kruwow a dwanaćen wowcow přede wsy wuwjedli, te chcychu předać.
-WS38	Dźensa su ludźo wšě na poli a syku.
+WS37	Burjo bĕchu pjeć wołow a dźeweć kruwow a dwanaćen wowcow přede wsy wuwjedli, te chcychu předać.
+WS38	Dźensa su ludźo wšĕ na poli a syku.
 WS39	Dzij jenož, brune pos ci ničo nječini.
-WS40	Ja sym z tamymi ludźimi tam zady přez wuku do rožky jěł.
+WS40	Ja sym z tamymi ludźimi tam zady přez wuku do rožky jĕł.

--- a/56534_Rachlau.csv
+++ b/56534_Rachlau.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymi suche lisće w powětře wokoło lětaja.
-WS02	Wone so hnydom zastanje sněh hić, potom bdźe zaso lěpše wjedro.
+WS01	W zymi suche lisće w powĕtře wokoło lĕtaja.
+WS02	Wone so hnydom zastanje snĕh hić, potom bdźe zaso lĕpše wjedro.
 WS03	Sčin wuhle do khachlow, zo so mloko bórzy započnje warić.
 WS04	Wbohi stary muž je so z konjom přez lód přepadnył a do zymnej wody padnył.
-WS05	Wón je před štyrjomi aby šesćimi njedźelemi wumrěł.
-WS06	Woheń bě přećopły, tykancy su so spody ćisće zpaliłe.
+WS05	Wón je před štyrjomi aby šesćimi njedźelemi wumrĕł.
+WS06	Woheń bĕ přećopły, tykancy su so spody ćisće zpaliłe.
 WS07	Wón jeja přecy bjez poperja a selje jy.
-WS08	Nohi mje jary bola, mi so zda, zo sym sej je čisće přeběhał.
+WS08	Nohi mje jary bola, mi so zda, zo sym sej je čisće přebĕhał.
 WS09	Ja sym pola tej’ žony był a sym jej to prajił, a wona rjekny, zo chce to tež swojej dźowcy prajić.
 WS10	Ja to njecham zasy činić!
 WS11	Ja će hnydom ze łžicu za wuši prasnu, ty wopica!
 WS12	Hdźe dha ty dźeš, dyrbimy my z tobu hić?
 WS13	Wone su hubjene časy!
-WS14	Wostań jow delkach stejo, moje lube dźěćo, złe husy će zakusaja.
-WS15	Ty sy dźensa najwjacy nawuknył a sy pěkny był, ty móžeš prjedy tamnych domoj hić.
+WS14	Wostań jow delkach stejo, moje lube dźĕćo, złe husy će zakusaja.
+WS15	Ty sy dźensa najwjacy nawuknył a sy pĕkny był, ty móžeš prjedy tamnych domoj hić.
 WS16	Ty hšće njejsy wulki dosć, zo by mohł blešu wina wupić, ty hšće dyrbiš kusk wjetši narosć.
-WS17	Dźi, bydź tak dobry a praj twojej sotře, zo dyrbi wona tu drastu za wašu maćer došić a ze šćěću wurjedźić.
-WS18	By ty jeho znał! dha by wšo hinak přišło a znim by lěpje stejało.
+WS17	Dźi, bydź tak dobry a praj twojej sotře, zo dyrbi wona tu drastu za wašu maćer došić a ze šćĕću wurjedźić.
+WS18	By ty jeho znał! dha by wšo hinak přišło a znim by lĕpje stejało.
 WS19	Štó je mi moj korb z mjasom kranył?
 WS20	Wón tak činješe, kaž bychu joh’ woni na móćenje zkazali; woni pak su to sami činili.
 WS21	Komu je wón tu nowu powjesć powjedał?
 WS22	Jedyn dyrbi wótře wować, hewak nam wón njerozymi.
 WS23	My smy sprócni a lačni.
 WS24	Hdyž my wčera wječor zasy přińdźechmy, dha tamni žno w łožu ležachu a twjerdźe spachu.
-WS25	Sněh je w nocy pola nas ležo wostał, ale dźens rano je won roztał.
-WS26	Zahdy našej khěže tři rjane jabłučinki z čerwjenymi jabłučkami steja.
+WS25	Snĕh je w nocy pola nas ležo wostał, ale dźens rano je won roztał.
+WS26	Zahdy našej khĕže tři rjane jabłučinki z čerwjenymi jabłučkami steja.
 WS27	Njemóhli hšće wy wokomik na nas čakać, potom my z wami dźemy.
-WS28	Wy njesmjeće tajke dźěćace lózystwa činić.
+WS28	Wy njesmjeće tajke dźĕćace lózystwa činić.
 WS29	Naše hory njejsu jary wysoke, waše su wjele wyšše.
-WS30	Kak wjele puntow kołbasy a kak wjele khlěba chceće (wy) měć?
+WS30	Kak wjele puntow kołbasy a kak wjele khlĕba chceće (wy) mĕć?
 WS31	Ja wam njerozymju, wy dyrbiće trochu wótřišo ryčeć.
-WS32	Njesće wy žadyn kusk běłeho mydła za mnje na mojim blidźe namykali?
-WS33	Jeho bratr chce sej dwě rjanej nowej khěži we wašej zahrodźi natwarić.
+WS32	Njesće wy žadyn kusk bĕłeho mydła za mnje na mojim blidźe namykali?
+WS33	Jeho bratr chce sej dwĕ rjanej nowej khĕži we wašej zahrodźi natwarić.
 WS34	To słowo jemu wot wutroby přińdźe.
-WS35	<Bě> To bě prawje wot was!
+WS35	<Bĕ> To bĕ prawje wot was!
 WS36	Kajke dha tam na muričcy ptački sedźa?
-WS37	Burjo běchu pjeć wołow a dźewjeć kruwow a dwanaće wowckow před wjes prinahli, te chcychu woni předać.
+WS37	Burjo bĕchu pjeć wołow a dźewjeć kruwow a dwanaće wowckow před wjes prinahli, te chcychu woni předać.
 WS38	Ludźo su dźens wšicy wonkach na polu a <syć> syku.
 WS39	Dźi jenož, bruny pos ći ničo nječini.
 WS40	Ja sym z tymi ludźimi tam zady přez łuku do žita jył.

--- a/56535_Hochkirch.csv
+++ b/56535_Hochkirch.csv
@@ -8,11 +8,11 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zymje suche lisćo w powětřje wokoło lěta.
+WS01	W zymje suche lisćo w powĕtřje wokoło lĕta.
 WS02	
 WS03	
 WS04	Bohi <dušny> stary muž je so z konjom na lodźe přepa[d]nył a do zymneje wody panył.
-WS05	Wón je před štyri abo šěsć njedźelemi wumrjeł.
+WS05	Wón je před štyri abo šĕsć njedźelemi wumrjeł.
 WS06	
 WS07	
 WS08	
@@ -24,7 +24,7 @@ WS13	Su hubjene časy.
 WS14	
 WS15	
 WS16	
-WS17	Dźi, budź tak dobry a praj Twojej sotře, zo by drastu za wašu maćer došiła a ze šćěću wučesała.
+WS17	Dźi, budź tak dobry a praj Twojej sotře, zo by drastu za wašu maćer došiła a ze šćĕću wučesała.
 WS18	
 WS19	Štu je mój korb z mjasom pokranył?
 WS20	
@@ -32,14 +32,14 @@ WS21
 WS22	Dyrbimy wo<w>łać, hewak nam njerozymi.
 WS23	
 WS24	
-WS25	Sně je tule nóc pola nas ležo wostał, ale dźensa rano je roztał.
+WS25	Snĕ je tule nóc pola nas ležo wostał, ale dźensa rano je roztał.
 WS26	Zady našeho doma steja tři jabłońki z čerwjenymi jabłočkami.
 WS27	
 WS28	
 WS29	Naše hory njejsu wysoke, waše su wjele wyšše.
 WS30	
 WS31	
-WS32	Njejsće kusk běłeho mydła za mnje na mojim blidźe namakali?
+WS32	Njejsće kusk bĕłeho mydła za mnje na mojim blidźe namakali?
 WS33	
 WS34	Słowo jemu z wutroby přindźe!
 WS35	

--- a/56536_Breitendorf.csv
+++ b/56536_Breitendorf.csv
@@ -8,34 +8,34 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	We zymi ljetaja te suche ljizčiki we powjětri wokoło.
+WS01	We zymi ljetaja te suche ljizčiki we powjĕtri wokoło.
 WS02	Budže so pšestać sné hić, potom budže to wjedro zaso lepže.
-WS03	Zčin wulhě do kachli, so to hmloko so počně warič.
+WS03	Zčin wulhĕ do kachli, so to hmloko so počnĕ warič.
 WS04	Ton bohi stary muš je stymi konimi na loči so pšepanył a do teje zymneje wody panył.
-WS05	Won je pšet štěrimi aby šězč njedželemi wumrěł.
-WS06	Ton wohěn bje wulki, te tykancy su so zpody cyłe wopalili.
-WS07	Ton jě te jeja pše bjez selje a popěrja.
+WS05	Won je pšet štĕrimi aby šĕzč njedželemi wumrĕł.
+WS06	Ton wohĕn bje wulki, te tykancy su so zpody cyłe wopalili.
+WS07	Ton jĕ te jeja pše bjez selje a popĕrja.
 WS08	Te nohi mje jara bol<j>a, mi so sta, so sym sej je wotčišćał.
 WS09	Ja sym pši tej šoni był a sym jej prajił, a wona praješe, so ce jo swojej čowcy prajič.
 WS10	Ja jo tejž jac nochcu činić.
-WS11	Ja če stej měšelu za wuši dyru, ty wopica!
+WS11	Ja če stej mĕšelu za wuši dyru, ty wopica!
 WS12	Če ty cejš, dyrbimy my stobu hić?
 WS13	To su hubjene časy!
-WS14	Moje lube dźěćo, wostán delka stejo, te słe husy če sakusaja.
-WS15	Ty sy ćenc najwjacy nawuknył a sy pěkny był, ty smež predy dom hič hač te druhe.
+WS14	Moje lube dźĕćo, wostán delka stejo, te słe husy če sakusaja.
+WS15	Ty sy ćenc najwjacy nawuknył a sy pĕkny był, ty smež predy dom hič hač te druhe.
 WS16	Ty hišće nejsy wulki dosč, so moł blešu wina wupić, ty hišće maš konćk narosč a weči byč.
 WS17	Dži, byč tak dobry a praj twojej sotri, wona dyrbi te kleedy za wašu mač sešić a sčetku čiste zčinič.
-WS18	Dy by jeho znał! da by hinak pšišło, a wono by ljebje sa něho stawo.
+WS18	Dy by jeho znał! da by hinak pšišło, a wono by ljebje sa nĕho stawo.
 WS19	Što je mi moj kórb /das ó mehr wie u/ zmjasom kranył.
 WS20	Wón čineše tak, kajš by jo wy kmočenju wopštelwali, woni pak su jo sami činili.
-WS21	Komu je won tu nowu powězč powědał.
+WS21	Komu je won tu nowu powĕzč powĕdał.
 WS22	Wón dyrbi jedyn wotce wołač, hewak nam njerozymi.
 WS23	My smy mučni a nam ce so pič.
 WS24	Jako my čera wječor dom pžinčechmy, da lešachu ći druzy hišom wošu a spachu twerče.
-WS25	Tón sně je tu nóc pola naz lešo wostał, ale čenc rano je rostał.
-WS26	Zady našeje kějše steja ci rjane jabučinki zčerwenymi jabučkami.
+WS25	Tón snĕ je tu nóc pola naz lešo wostał, ale čenc rano je rostał.
+WS26	Zady našeje kĕjše steja ci rjane jabučinki zčerwenymi jabučkami.
 WS27	Njemošeče hišče wokomiknenje na naz počakać, potom cemy my zwami sobu.
-WS28	Wy njezměče tajke džěčastwa čěrič.
+WS28	Wy njezmĕče tajke džĕčastwa čĕrič.
 WS29	Naše hory nejsu hósoke, waše su welje hwuše.
 WS30	Kak welje puntow kołbasy a kak welje klėba ceče wy mječ?
 WS31	Ja wam njerozymju, wy dyrbiče kuzk wocišo ryčeć.

--- a/56776_Tupadel.csv
+++ b/56776_Tupadel.csv
@@ -16,7 +16,7 @@ WS05	On jä przed schtärzäma aboi szesc Niedzielami umarli.
 WS06	Tän Oidźin beel za goirąci, tä Kuchȧ są na spotku czȧsto czȯrne spȯloni.
 WS07	On jee tä jaja wjädno bez Solȧ ȧ Piȧprzȧ.
 WS08	Tė nodźi mjȧ bardzo boilǫ, jo wierzę, jȯ je so mom przȧmachconi.
-WS09	Jȯ beel u tü Bialćźi ȧ jȯ ju̇ rzek, a ona rzeikla, ona też to chcȧ Swojÿ cȯrce rzeic.
+WS09	Jȯ beel u tü Bialćźi ȧ jȯ jů rzek, a ona rzeikla, ona też to chcȧ Swojÿ cȯrce rzeic.
 WS10	Jö też to niȧchcę wjci robic.
 WS11	Jö cȧbie zarȯs tą Korschkwią trzasnę za Uchoi, tȧ Mȯlpa!
 WS12	Dzȧsź tȧ jidziesz, mȯmȧ mȧ jidz ztobȯ?
@@ -32,7 +32,7 @@ WS21	Kȯmusz uon tä nowi Geschichta mȯ rospoiwiȯdȯni?
 WS22	To muszy glosno wrzäszcec, boi te uon niedzie nom rozmiȯl.
 WS23	Mȧ jesmä meedäch ȧ nom się chcie pjic.
 WS24	Jak mä wczörȯ Wieczór naźód przäszlä, tee ty jini lȧżelȧ w Loszku, ȧ mocnu spalä.
-WS25	Tän Snieg jė ti Nocȧ unas leżącä uostöni, ale dzis Poiränu̇ uon jö rostopiali.
+WS25	Tän Snieg jė ti Nocȧ unas leżącä uostöni, ale dzis Poiränů uon jö rostopiali.
 WS26	Za naszämi Chȧczami stoją trzä piękni Jablónczi z czärzwionȧmi Jabluśźkami.
 WS27	A nämóżeta wa jisź jedno Woikoimärknäni za nami dośżdac, tee mä jidzemä zwama.
 WS28	Wa niedarwöta taćźywoi Dziecienstwa driwoiwac.

--- a/56776_Tupadel.csv
+++ b/56776_Tupadel.csv
@@ -8,43 +8,43 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zȧmie lȯtają tȧ sȧchi Lȧstȧ w Poiwietrzim.
+WS01	W zåmie lȯtają tå såchi Låstå w Poiwietrzim.
 WS02	To zarȯs przestonie Snieg kurzec, tee to mdźie zóss lepszȯ Poigoida.
-WS03	Wloźȧ Węglȯf w ten Pieck, co to Mlekoi wnät zacznie wrzóc.
-WS04	Ten dobrẏ stȯrẏ Clop je ztïm Koinię przez Lot wlȯmiony ȧ wtę zȧmną Wojdę wpadly.
+WS03	Wloźå Węglȯf w ten Pieck, co to Mlekoi wnät zacznie wrzóc.
+WS04	Ten dobrẏ stȯrẏ Clop je ztïm Koinię przez Lot wlȯmiony å wtę zåmną Wojdę wpadly.
 WS05	On jä przed schtärzäma aboi szesc Niedzielami umarli.
-WS06	Tän Oidźin beel za goirąci, tä Kuchȧ są na spotku czȧsto czȯrne spȯloni.
-WS07	On jee tä jaja wjädno bez Solȧ ȧ Piȧprzȧ.
-WS08	Tė nodźi mjȧ bardzo boilǫ, jo wierzę, jȯ je so mom przȧmachconi.
-WS09	Jȯ beel u tü Bialćźi ȧ jȯ jů rzek, a ona rzeikla, ona też to chcȧ Swojÿ cȯrce rzeic.
-WS10	Jö też to niȧchcę wjci robic.
-WS11	Jö cȧbie zarȯs tą Korschkwią trzasnę za Uchoi, tȧ Mȯlpa!
-WS12	Dzȧsź tȧ jidziesz, mȯmȧ mȧ jidz ztobȯ?
-WS13	To są lȧchi Czasȧ!
-WS14	Mojȧ kochani Dziäckoi, oistanÿ tu nadole stojące, tė zli Gęsą cȧbie ujȧdzą.
-WS15	Tȧ sę dzis nöwjici nauiczil ä jes beel poislȧszni, tȧ móześź rȧchli Dödom jidz jak ti jiźisz.
-WS16	Tä jisz niejes dosc wieldżi jednę Budlę Wjina dowäpicȯ, Tä muśźiśź jsż nöprzȯd sztȧk urosc a wjkszy bȧdz.
-WS17	Biȯ, będzȧ tak dobri a rzeczȧ twuji Sestrze, uona mö tȧ Ruchna do waji Matćźÿ fardich uiśźäc a wȧszczotkoiwac.
-WS18	Żebä tȧ jȧuo miól znónu, te to bei bȧlo jinaczi przäszli, ȧ to bȧ poidlug niewuo lȧpji stojalo.
+WS06	Tän Oidźin beel za goirąci, tä Kuchå są na spotku czåsto czȯrne spȯloni.
+WS07	On jee tä jaja wjädno bez Solå å Piåprzå.
+WS08	Tė nodźi mjå bardzo boilǫ, jo wierzę, jȯ je so mom przåmachconi.
+WS09	Jȯ beel u tü Bialćźi å jȯ jů rzek, a ona rzeikla, ona też to chcå Swojÿ cȯrce rzeic.
+WS10	Jö też to niåchcę wjci robic.
+WS11	Jö cåbie zarȯs tą Korschkwią trzasnę za Uchoi, tå Mȯlpa!
+WS12	Dzåsź tå jidziesz, mȯmå må jidz ztobȯ?
+WS13	To są låchi Czaså!
+WS14	Mojå kochani Dziäckoi, oistanÿ tu nadole stojące, tė zli Gęsą cåbie ujådzą.
+WS15	Tå sę dzis nöwjici nauiczil ä jes beel poislåszni, tå móześź råchli Dödom jidz jak ti jiźisz.
+WS16	Tä jisz niejes dosc wieldżi jednę Budlę Wjina dowäpicȯ, Tä muśźiśź jsż nöprzȯd sztåk urosc a wjkszy bådz.
+WS17	Biȯ, będzå tak dobri a rzeczå twuji Sestrze, uona mö tå Ruchna do waji Matćźÿ fardich uiśźäc a wåszczotkoiwac.
+WS18	Żebä tå jåuo miól znónu, te to bei bålo jinaczi przäszli, å to bå poidlug niewuo låpji stojalo.
 WS19	Chtäsz mie mó moj Koisz z Mięsę ukradly?
 WS20	Uon tak robjil, jak bä wa uo mielä do draszowaniȯ uebsȯlowȯny, uoni ale to sami zrobjilä.
 WS21	Kȯmusz uon tä nowi Geschichta mȯ rospoiwiȯdȯni?
 WS22	To muszy glosno wrzäszcec, boi te uon niedzie nom rozmiȯl.
-WS23	Mȧ jesmä meedäch ȧ nom się chcie pjic.
-WS24	Jak mä wczörȯ Wieczór naźód przäszlä, tee ty jini lȧżelȧ w Loszku, ȧ mocnu spalä.
-WS25	Tän Snieg jė ti Nocȧ unas leżącä uostöni, ale dzis Poiränů uon jö rostopiali.
-WS26	Za naszämi Chȧczami stoją trzä piękni Jablónczi z czärzwionȧmi Jabluśźkami.
+WS23	Må jesmä meedäch å nom się chcie pjic.
+WS24	Jak mä wczörȯ Wieczór naźód przäszlä, tee ty jini låżelå w Loszku, å mocnu spalä.
+WS25	Tän Snieg jė ti Nocå unas leżącä uostöni, ale dzis Poiränů uon jö rostopiali.
+WS26	Za naszämi Chåczami stoją trzä piękni Jablónczi z czärzwionåmi Jabluśźkami.
 WS27	A nämóżeta wa jisź jedno Woikoimärknäni za nami dośżdac, tee mä jidzemä zwama.
 WS28	Wa niedarwöta taćźywoi Dziecienstwa driwoiwac.
 WS29	Naszä Górä ńiesą bardzo wäsoćźi, tä waji są wielä wäsźi.
 WS30	Wieláśź Puütof Köbösä a wieläśź Chleba wa chciala miec?
 WS31	Jä wama nieerosmieję, wa muszita pärźinkę glosny gadac.
-WS32	Nimjalala wa żȯdniwoi kǫsinka biȯlėwoi Mȧdla dlo mie na mujim stole?
+WS32	Nimjalala wa żȯdniwoi kǫsinka biȯlėwoi Mådla dlo mie na mujim stole?
 WS33	Jeuȯ Brat chcä sobie dwie pięknäch Cháćźy we wajm Woigrodzä budowac.
 WS34	To Slowoi mu uod Serca przäszlo.
-WS35	To bälo sprawiedlȧwie uod was!
+WS35	To bälo sprawiedlåwie uod was!
 WS36	Cäsz tam sädzą za Ptöśźćźi u gorä na tim Murkü?
-WS37	Te Gburżä mielä pÿńc Woilof ä dzewinc Krof ä dwanösce Woiwieczk przed Wies przägnȯni, tä uoni chcielȧ przeidac.
-WS38	Ti lädze są dzis wszätce butän na Poilȧ ä säką.
+WS37	Te Gburżä mielä pÿńc Woilof ä dzewinc Krof ä dwanösce Woiwieczk przed Wies przägnȯni, tä uoni chcielå przeidac.
+WS38	Ti lädze są dzis wszätce butän na Poilå ä säką.
 WS39	Biole, tän bruni Pies tobie nic niezroby.
 WS40	Jö jäm stämi Lädzami tam <unont> prze tä Ląćźi w Zboiźy jachöl.

--- a/56777_Strellin.csv
+++ b/56777_Strellin.csv
@@ -24,7 +24,7 @@ WS13	To so leche tschase.
 WS14	Moe kochane dzeʒko ostani tu nadolle bo te sli ganse ʒebje urzo.
 WS15	Te jes dzisö so nowjiʒi nauʒil a bil jes grzecʒnÿ te możes rehli jitz dȯdom jak ti insche.
 WS16	Te jesch nejest docʒ wjelki co ti bi budlé wjina wipjil ti muschis jis rocʒ co ti bédzech wjekschi.
-WS17	Bedze tak dobri bjö a rzȧtze swoje sestrsä zä onna ma te ruchna waji matki uschitʒ i schzotko wyschzotkowac.
+WS17	Bedze tak dobri bjö a rzåtze swoje sestrsä zä onna ma te ruchna waji matki uschitʒ i schzotko wyschzotkowac.
 WS18	Zebi ti go snal te tobi prsislo jenaki te tobi jenaki bilo.
 WS19	Ktes mie ukrat moj kosch smjése.
 WS20	Onn tak zrobjil jak bi onne mjeli go opstelowani do draschowana, onne to zrobjili sami.

--- a/56781_Klein-Dommatau.csv
+++ b/56781_Klein-Dommatau.csv
@@ -20,9 +20,9 @@ WS09	Joł był u ty bialki a rzek ji to, a łona rzekla, łona chca to téż swo
 WS10	Joł niechcań to też wici robic!
 WS11	Joł trzasnań ce zarołs tą korszkwią za łuszy, te mołlpa!
 WS12	Gdzesz te idzesz, mąme me z tobą idz?
-WS13	To są lěchi czasy!
+WS13	To są lĕchi czasy!
 WS14	Moje kochane dzecko, łostani tu w dole stojące, te zlé gęsi cę do smierci urżą.
-WS15	Te dzisej nowicej sę uczyl i byl grzeczny, te możesz rěchli do dom idz jak ty inni.
+WS15	Te dzisej nowicej sę uczyl i byl grzeczny, te możesz rĕchli do dom idz jak ty inni.
 WS16	Te nie jes jesz dosc wielgi, coby te jednań budlań wina wepil, te musis nołprzód jesz sztek rosc i wikszy bec.
 WS17	Bioł, bądze tak dobry a rzecze twoi sestrze, ona miala klejdy do waj matki fartig uszyc a je bersztą czesty zrobic.
 WS18	Kieby te go znołl! toby belo inaczéj przeszly, toby z nim inaczéj stojalo.
@@ -33,14 +33,14 @@ WS22	Musimy glosno wrzescec, bo łon nóm nie roumieje.
 WS23	Me jesmy médech a chce nóm sę pic.
 WS24	Jakme wczoroł wieczór nazołd przeszle, leżele té inszi ju w lóżku a spali mocno.
 WS25	Sniég té nocy łostołl u nas leżące, ale dzis poréne łón stajołl.
-WS26	Slołde za naszą checzą stoją trze pěszny jablonki z czerwionemi jabluszkami.
+WS26	Slołde za naszą checzą stoją trze pĕszny jablonki z czerwionemi jabluszkami.
 WS27	Nie możeta wa jesz jedno okomergnienie na nas dożdac, to me idzeme z wama.
 WS28	Wa niedarwótła takiego dzecinstwa prowadzic.
 WS29	Nasze gore nie są tak baro wesokie, waj są wiele weższy.
 WS30	Wieleż puńtów worsztów a wieleż chléba chceta wa miec?
 WS31	Joł wama nie rozumiejań, wa musita perżnań glŏsnij gadac.
 WS32	Nie mołta wa ni żołdnego szteczka biołlego medla dloł mie na mojim stole nalazła.
-WS33	Jego brat chce sobie dwa pěszny nŏwy budinki we swoijim ogrodze budowac.
+WS33	Jego brat chce sobie dwa pĕszny nŏwy budinki we swoijim ogrodze budowac.
 WS34	To slołe przeszlo jému od serca!
 WS35	To belo prawie od nich!
 WS36	Cész tán sedzą za ptołszki u góre na murku?

--- a/56781_Klein-Dommatau.csv
+++ b/56781_Klein-Dommatau.csv
@@ -38,9 +38,9 @@ WS27	Nie możeta wa jesz jedno okomergnienie na nas dożdac, to me idzeme z wama
 WS28	Wa niedarwótła takiego dzecinstwa prowadzic.
 WS29	Nasze gore nie są tak baro wesokie, waj są wiele weższy.
 WS30	Wieleż puńtów worsztów a wieleż chléba chceta wa miec?
-WS31	Joł wama nie rozumiejań, wa musita perżnań glǒsnij gadac.
+WS31	Joł wama nie rozumiejań, wa musita perżnań glŏsnij gadac.
 WS32	Nie mołta wa ni żołdnego szteczka biołlego medla dloł mie na mojim stole nalazła.
-WS33	Jego brat chce sobie dwa pěszny nǒwy budinki we swoijim ogrodze budowac.
+WS33	Jego brat chce sobie dwa pěszny nŏwy budinki we swoijim ogrodze budowac.
 WS34	To slołe przeszlo jému od serca!
 WS35	To belo prawie od nich!
 WS36	Cész tán sedzą za ptołszki u góre na murku?

--- a/56792_Poblotz.csv
+++ b/56792_Poblotz.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	Wsěmjė lěcung sěchê lěstě prżês lěft.
+WS01	Wsĕmjė lĕcung sĕchê lĕstĕ prżês lĕft.
 WS02	To wnêt łoprżestonie snieżec, taj ta płogoda sę lepszo wstonie.
 WS03	Wrżece wangle w ten piec, cie te mleko sę sacznie gotiewac.
 WS04	Ten dobry chłop je stim kłoniem przes lot padłaj a w te semnong łodę wpadłuj.

--- a/56812_Smolsin.csv
+++ b/56812_Smolsin.csv
@@ -9,9 +9,9 @@ Transliterent: ''
 Anmerkungen: ''
 ...
 WS01	W semie lejcą seche leste prses left.
-WS02	To oprzestanie zara sniég padać te bądzie lepszǒ pogoda.
+WS02	To oprzestanie zara sniég padać te bądzie lepszŏ pogoda.
 WS03	Kładz wpieck węgle, co to mleko się sacznie gotowac.
-WS04	Ten dobri stari chłop je z konię przez lód salomany i w tę zemną odę wpǒd.
+WS04	Ten dobri stari chłop je z konię przez lód salomany i w tę zemną odę wpŏd.
 WS05	On je przed sztere dbo przed szesc niedziel umarły.
 WS06	Tėn ogien beł za ciepły, te kuche są w dole czesto czȯrne zrobione.
 WS07	On je te jaja wiedno bes sole a bes pieprzu.

--- a/56818_Gowidlino.csv
+++ b/56818_Gowidlino.csv
@@ -8,7 +8,7 @@ Transliterationsprojekt: ''
 Transliterent: ''
 Anmerkungen: ''
 ...
-WS01	W zemie lȧcȯ sȧchy Loste bez lȧft.
+WS01	W zemie låcȯ såchy Loste bez låft.
 WS02	To zaras oprzestanie sniek padac, le bandze pogoda snowo lepsza.
 WS03	Wrzuc wangle w piec, co bi sa mlėko zaczyło gotowac.
 WS04	Ten dobri stary chȯb jest s kȯniem bez lót pozerwane i w potl zomni woda.
@@ -28,7 +28,7 @@ WS17	Idz, bands tak dobri i mów twoje sostri, ona ma ty rupiece dlo twoji matka
 WS18	Zebys te go poznał tebi to inaczy bo pszysły i to bo o nim bo lepsze stojało.
 WS19	Kto mie moja Kosz z miasem ukrad.
 WS20	On tak robjł, jakobi oni go do draszowania miele obsztelowani, oni to ale nie sami robile.
-WS21	Komu on tȧ nowó history powiedzał?
+WS21	Komu on tå nowó history powiedzał?
 WS22	Me musimi głosno wrzeszczyc bo oni nas nie rozmiół.
 WS23	Me jesme ustanie a nóm sa chce pic.
 WS24	Jak me w czora wieczór nazat przysły, to te drugi już lezyly wószku i byłi usnanti.
@@ -39,12 +39,12 @@ WS28	Wa nie muszyta takie dziecinstwo pandzic.
 WS29	Nasze góre nie są bardzo wesokj, wasze są wyszy.
 WS30	Wiele funti worszte i wiele chlėb chceta miec.
 WS31	Nie rozumie wam, musita kosink głosni mowic.
-WS32	Nie mata wa stek biały mȧdło dla mie na stole nalesony.
+WS32	Nie mata wa stek biały mådło dla mie na stole nalesony.
 WS33	Jego brat sa chce dwa piankne budinczy w waszem ogrod budowac.
 WS34	Słowo mu przyszedł z serca.
 WS35	To bo recht od was.
 WS36	Co tam siedzo za ptaszki na murze.
 WS37	Gburze miele pianc Włełe i dzewianc Krów i dwanastce owieczczy pred wies przinosły, oni ti chcely pszedac.
-WS38	Ludza są dzies buten na pole i sȧko.
+WS38	Ludza są dzies buten na pole i såko.
 WS39	Jidz, ten bruny piés ciebie niec nie zrobie.
 WS40	Ja był tam z ladzami wtyle bes wonki w zbozy jechooni.

--- a/56821_Borzestowo.csv
+++ b/56821_Borzestowo.csv
@@ -9,7 +9,7 @@ Transliterent: ''
 Anmerkungen: ''
 ...
 WS01	Wzamie lezom te sachi Lasta s wiatrem.
-WS02	ħe łeprzestanie Snieg padac to bęndzie lepschó pegeda.
+WS02	he łeprzestanie Snieg padac to bęndzie lepschó pegeda.
 WS03	Ta Wangle muschi w pieck włozec, co to mlekue się zagueteje.
 WS04	Ten dobri stari Chłop przepot s kueniem bez lot w tę zemnom łedę.
 WS05	łon je prez stera abue siesc Niedziel umarłi.

--- a/56821_Borzestowo.csv
+++ b/56821_Borzestowo.csv
@@ -47,4 +47,4 @@ WS36	Co tam sedzom za ptosci na tim murku.
 WS37	Ti Gbusrche mele pięnc łełow dzewięnc krow i dwanöscie łewc przed wies przeprowadzoni i chcele je przedac.
 WS38	Ti Ledze som dzis wzeschce na puelu i sekom.
 WS39	Bele ten bruni pies tobie nic nie zrobi.
-WS40	Jő jachoł stimi Ledzmi tam wtele bez łonczi w zbueze.
+WS40	Jö jachoł stimi Ledzmi tam wtele bez łonczi w zbueze.

--- a/56826_Klukowahutta.csv
+++ b/56826_Klukowahutta.csv
@@ -29,7 +29,7 @@ WS18	Nimok ti bi goboznac te bito biło jnaci prziszo i lepi wkoł neg stoiec.
 WS19	Kto nie ieden Kosz z Miamsem ukrad?
 WS20	On ucinił to kedi oni jego do drasz owa [brzim uszali] oni allá onó to samy ucinili.
 WS21	Komu on ma iednę Christorię bowiedzec.
-WS22	Mi muszi mi głosno wrzesz [ęec] bo tedi nih tego něrozmi.
+WS22	Mi muszi mi głosno wrzesz [ęec] bo tedi nih tego nĕrozmi.
 WS23	Mi iesmi głodni i pragnemi.
 WS24	Kedi mi w czora dodom prziszli, tedrugi bili w oszku i spali.
 WS25	Snieg porano prziszed i jutro się rostopił.

--- a/57321_Prawdzisken.csv
+++ b/57321_Prawdzisken.csv
@@ -24,7 +24,7 @@ WS13	Lichie czazy so!
 WS14	Mniełe Dżedzie, ustan nisko tu, bo gęnszy cie zakonzo.
 WS15	Ty nagęnczie sie ucuieś dzichay i dobry bieś, mozes i pręnzcy do domu iśc nis te druge.
 WS16	Ty iesće neiest wielgg dosc butelke wjina wipic, ti musis iesce cokolwik rośnąc i węzi bic.
-WS17	Bo̢ć taki dobri, jic i mow twoi Schostrze aby ugaua odzene przed Matki wasy i scotko cisto robjitc.
+WS17	Bǫć taki dobri, jic i mow twoi Schostrze aby ugaua odzene przed Matki wasy i scotko cisto robjitc.
 WS18	Mokes ty iego snatć tedy bi to przisło ienacey, i mogło lepie o niego stoic.
 WS19	Chto mie moj kos smęsem ukrat?
 WS20	On srobjuł tak bi iego do młocenia obstalowali, i oni ale to sani srobili.

--- a/57397_Holländerei-Grabia-Grabie.csv
+++ b/57397_Holländerei-Grabia-Grabie.csv
@@ -22,7 +22,7 @@ WS11	jo bie ciebie zaras stumodgoctowaniatyszkom za uho ty głupi
 WS12	gdzie ty idziesz moma my tysz ztbą iści?
 WS13	jest zły czas! teros sum niedobre casy.
 WS14	Muj kohany Dzieciok, ostani wy wdole stuj, te złe Gȩśy zazirum cie na simerci.
-WS15	ty mosz Dziecy naj lepij łuczu tiś i ȷest jestś ładny byłes ty nie poszebujesz rani do dmu jści jak i te druge.
+WS15	ty mosz Dziecy naj lepij łuczu tiś i jest jestś ładny byłes ty nie poszebujesz rani do dmu jści jak i te druge.
 WS16	ty jeszcze nie duży dosyci jezdeś żebyś z flaszkum wina wypiuł, ty muśisz pszud jeszcze kawoł urosnunici i powic twoje śostsze
 WS17	jyci ibunici tak i powic twoje śostsze una mo te łahy do jejy matki uszyci i stum szczotkom czysto zrobici.
 WS18	Czy ty jum znosz! potym insze pszydzie i mo lepie na nium patszyci.

--- a/80023_Bosco.csv
+++ b/80023_Bosco.csv
@@ -23,7 +23,7 @@ WS12	Wo geišt, sulu war met-tar chu?
 WS13	As sin šlacht tsīta.
 WS14	Mīs liab chin, plib hia štō, di bēšu gosa bīssan ti ts tot.
 WS15	Düw hašt hit am meísta klērt un béšt a fīna ksin, düw dorfšt kšwéndar wédar di ondru hein gō.
-WS16	Düw béšt noch net grossa knüog fér a flaššu <(auchputallin – Bottiglia)> win üss ts triachan, du muaššt tseršt noch aweng waksa.
+WS16	Düw béšt noch net grossa knüog fér a flaššu <(auchputallin - Bottiglia)> win üss ts triachan, du muaššt tseršt noch aweng waksa.
 WS17	Gong sīšt a sa güat un sag dīr šwaštar, šé sallti   {Rest abgeschnitten}
 WS18	Hattešt no pchannt! da weittis ondasšt chu, um es weitti mit emu bessar.
 WS19	War hat mir min Kofana mit-tum fleišš kštōla?

--- a/I103p_Catzand.csv
+++ b/I103p_Catzand.csv
@@ -6,9 +6,9 @@ Bogentyp: ''
 Erhebung: ''
 Transliterationsprojekt: ''
 Transliterent: ''
-Anmerkungen: "{Anmerkungen: \n– im Bogen wird häufig <(n – nasal)> oder <(n – n)>\
+Anmerkungen: "{Anmerkungen: \n- im Bogen wird häufig <(n - nasal)> oder <(n - n)>\
   \ zur Markierung nasaler Vokale angegeben; wird in ILIAS-Version nicht wiedergegeben\
-  \  \n– an einigen Stellen wird h über g geschrieben, schwer wiederzugeben}"
+  \  \n- an einigen Stellen wird h über g geschrieben, schwer wiederzugeben}"
 ...
 WS01	In de winter vliegen de drôage bloren deu de lucht.
 WS02	’t Ouwt dadelyk op mee seêuwen, dan ôar ‘t weer wéè beter.
@@ -21,32 +21,32 @@ WS08	M’n vreten doen vee zêe, ‘k geloanw da ‘k ze deugelôapen èn <(n na
 WS09	‘k èn <(n- nasal)> bie de vrouwe hewist en ‘k én ’t legen eu gezeeid: ze zei, da se ’t ôak legen eu dochter zou zeggen. 
 WS10	‘k zal ’t nôait mêe doen. 
 WS11	‘k slôan <(n- nasal)> je dadelijk mee den pollepel zond je-n-ôaren, joe-n-ôaß.
-WS12	Na wa ga je, wimmen mee je meegaan <(n – n)>.
+WS12	Na wa ga je, wimmen mee je meegaan <(n - n)>.
 WS13	’t zien slechte tieën.
-WS14	M’n lief Kind, bluuf gie ier benejen stôan <(n – n)>, de bôase ganzen bieten ji dôad.
+WS14	M’n lief Kind, bluuf gie ier benejen stôan <(n - n)>, de bôase ganzen bieten ji dôad.
 WS15	Gie ei vandôage ’t mêeste gelêerd en gi ei zoet <(brôave)> hewist, gie meug êeder noar uus hôan as d’andere. 
 WS16	Gie zie nog nie grôat genoegt om ’n Flesche wien ûut te drienken ge moe-d-êert nog wa ʰgroeien in ʰgrôater ôaren.
 WS17	Noe moeh jon kêe zôa ʰgoed zien in zegen je zuster zeggen, da ze ’t goed voo julder moeder moet klaan daien, in-ne mee d’n bostel uutkusen. 
-WS18	t-je’m gekend â, dan a-t andus gegaan <(n – n)> in ie zou ter beter mee zien. 
+WS18	t-je’m gekend â, dan a-t andus gegaan <(n - n)> in ie zou ter beter mee zien. 
 WS19	Wieⁿ ei-t-er m’n mande mee vlêisch hestolen. 
-WS20	Je dee net asof ze ‘m gevrogen ân <(n – n)> om te kommen dossen, ma z èn ’t zeef hedvaan.
+WS20	Je dee net asof ze ‘m gevrogen ân <(n - n)> om te kommen dossen, ma z èn ’t zeef hedvaan.
 WS21	Tegen vien ei-t-ie da nieuwe veraal verteld.
 WS22	Je moed-ard schreeuwen <(zoepen)>, andeas verstan ie ons nie.
-WS23	Me zien <(n – n)> moeg in <(n – n)> me-n-èn <(n – n)> groâten dust. 
+WS23	Me zien <(n - n)> moeg in <(n - n)> me-n-èn <(n - n)> groâten dust. 
 WS24	t-me histeravond terugkwamen eien d’andeu al in bèdde in te warena vast in slaap.
 WS25	De snêeuw is vannacht bie ons bluven likken, ma vanmorgen is he gesmolten.
-WS26	Achter ons uus stôan <(n – n)> drie môaire appelbôampjes mie zôaje appeltjes. 
-WS27	Kunnen julder nog nie ’s n oaʰgenblikje op ons wachten, dan gôan <(n – n)> me mie julder mee.
-WS28	Julder moeten nie sio kinderachtig zien <(n – n)>.
+WS26	Achter ons uus stôan <(n - n)> drie môaire appelbôampjes mie zôaje appeltjes. 
+WS27	Kunnen julder nog nie ’s n oaʰgenblikje op ons wachten, dan gôan <(n - n)> me mie julder mee.
+WS28	Julder moeten nie sio kinderachtig zien <(n - n)>.
 WS29	Onte berʰgen zien nie zôa ôage, die van julder zien veel ôager. 
-WS30	Oevee pond woste in oewee brôad willen julder èn? <(n – n)> 
+WS30	Oevee pond woste in oewee brôad willen julder èn? <(n - n)> 
 WS31	‘k verstôen <(n-)> julder nie, julder moeten ’n bitje arter prôaten. 
-WS32	Èn <(n – n)> julder op mien tafel ʰgeen <(n – n)> Stikje witte zêepe <(voo mien <(n – n)>)> ʰgevonnèn.
+WS32	Èn <(n - n)> julder op mien tafel ʰgeen <(n - n)> Stikje witte zêepe <(voo mien <(n - n)>)> ʰgevonnèn.
 WS33	Zin broer wil in julderen oß twêe môaie nieuwe uzen bouwen.
 WS34	Da woard kwam uut z’n èrte. 
 WS35	Da was êel ʰgoed van ulder. 
 WS36	Wa-fore veuʰgeltjes zitten din da van boren op ’t muurtje. 
-WS37	De boeren ãan <(n – n)> vuuf ossen in negen koeien in twaalf schaapjes na’t durp gebrocht, die woe-en ze verkôapen.
+WS37	De boeren ãan <(n - n)> vuuf ossen in negen koeien in twaalf schaapjes na’t durp gebrocht, die woe-en ze verkôapen.
 WS38	D’èrbereis zien <(’t Volk is)> vandage allemale buten op ’t land an ’t maaien.
-WS39	ʰGa ma deu, die <(n – n)> brunen ond doe je niks. 
-WS40	’k bin <(n – n)> mee de menschen <(daar achter)> over de weie na’t land kerejen. 
+WS39	ʰGa ma deu, die <(n - n)> brunen ond doe je niks. 
+WS40	’k bin <(n - n)> mee de menschen <(daar achter)> over de weie na’t land kerejen. 


### PR DESCRIPTION
- '36525_Wilshausen' verwendet im Wort 'greˀeser' ein ˀ (Modifier letter glottal stop: ˀ ; 1 Vorkommen im gesamten Storage). 
Da sieht es wirklich sehr nach diesem Zeichen aus, allerdings nicht als eigenständiges Zeichen zwischen dem Buchstaben wie im jetzigen Dokument, sondern eindeutig ÜBER den Buchstaben. Normalerweise verwendet der Bogen an solchen Stellen immer entweder ein ´ oder ein ` (über dem Vokal e). Hier handelt es sich um eine Vokalverbindung 'ee'. In ähnlichen Fällen im Bogen wird ebenfalls einer der zwei Vokale mit einem ` oder ´ versehen (WS8: Feès). Man könnte also 'grèeser' daraus machen, allerdings sieht das im Bogen verwendete Zeichen den restlichen Stellen nicht ähnlich. Es ist auch nicht ganz sicher ob ` oder ´.

- '32050_Mehlingen' verwendet in der Orginalschrift häufig Tilden unter verschiedenen Buchstaben. Der Transliterent verwendet konsequent doppelte Tilden (bspw: w̰̰), obwohl sie im Bogen eindeutig mit einer Tilde untersetzt sind (bspw: ̰w). Ich habe im Dokument alle Doppeltilden durch einfach ersetzt, da dies das gesamte Zeichenprofil (profile.txt) kürzt. Dennoch könnte man theoretisch weiter versuchen zu kürzen, indem man sich fragt, für was die Tilde darunter steht und ob sie etwa eine gleiche Bedeutung haben könnte wie bsw. ein Zirkumflex/Minus/Punkt/o.ä. unter einem Zeichen. Dadurch könnte man die Bögen weiter vereinheitlichen.

- '56777_Strellin' verwendet häufig anstelle von 'z' ein 'ʒ'. Er ist der einzige digitale Bogen im Verzeichnis, der das tut. Allerdings sind auch normale 'z' im Bogen enthalten. Auch im physikalischen Bogen (Orginalschrift) schreibt der Autor für 'z' zwei Varianten: Eines mit Bogen darunter (bsw. in WS3: 'wpjeʒk') und ohne Bogen (bsw WS1: 'wleffze'). Der Autor scheint also einen Unterschied zwischen den beiden z-Varianten zu machen, weswegen ich die 'ʒ' der digitalen Version stehen gelassen habe.

- '16907_Altendorf' weißt als einziger Bogen in der digitalen Form 'ⱱ' (U+2C71 LATIN SMALL LETTER V WITH RIGHT HOOK) auf. Vergleicht man das entsprechende Zeichen im Originalbogen mit Stellen, an denen ein normales v auftritt (bsw. WS1: 'wintⱱ' vs. WS22 'vɒštěə') so sieht man in der Tat einen deutlichen Unterschied. Das interessante hierbei ist jedoch, dass 'vɒštěə' im Originalbogen danach aussieht, als ob ein normal v genau von solch einem 'V WITH RIGHT HOOK'-Zeichen gefolgt wird. An dieser Stelle hat der Transliterent allerdings den Vokal 'ɒ' transkribiert. Mein Vorschlag ist, alle U+2C71 (LATIN SMALL LETTER V WITH RIGHT HOOK) durch Vokale zu ersetzen. Gründe dafür wären zweierlei: 1)Der Kontext, in dem dieses Zeichen auftritt ist vokalisch 2)WS22 'vɒštěə' ist in der jetzigen Version inkonsistent. Ersetzungen durch Vokale würden die Bögen insgesamt vereinheitlichen (kleineres Zeicheninventar 'profile.txt')

- Generell ist mir der Gedanke gekommen, dass man Breve (bsp. 'Ĕ') und Caron (bsp. 'Ě') bzw. inverted Breve und Circumflex immer vereinen könnte, da sie sich extrem ähneln und es im gesamten Inventarprofil zu einem Buchstaben oft beides gibt. Ob man nun alle zu Breve's oder alle zu Carons transformieren sollte, ist eine gute Frage. Vorerst habe ich alle zu Carons gemacht, da es für mich ein gängieres Zeichen zu sein scheint. Ein Argument, welches dagegen sprechen würde beide zu vereinen, wäre, wenn ein einziger Bogen beide Varianten verwenden würde, da dadurch ja offensichtlich ein Unterschied gegeben wäre. Solange ich aber nicht so einen Bogen finde, werde ich Breve und Caron vereinen.
	UPDATE: Bogen '36272' und Bogen '27135' wiesen bei 'u' tatsächlich intern beide Varianten auf, allerdings sah es in den jeweiligen Originalbogen identisch aus (sowohl Breve als auch Caron), weswegen ich es trotzdem vereint habe.

- In ähnlichem Sinne habe ich Macrons (bsp. 'ū') und Combining Overlines (bsp. 'u̅') zusammengefügt.

- In ähnlichem Sinne habe ich COMBINING INVERTED BREVE BELOW (bsp. 'o͜ ') und COMBINING DOUBLE INVERTED BREVE (bsp. 'o͡ ') zusammengefügt. Beide sind in Diphtongkontexten zu finden und beschreiben vermutlich das gleiche. Konsonanten, bei denen man solche Bögen findet, sind häufig nicht Affrikate, sondern eher wenn Konsonanten ohne Pause zusammengefügt werden wie bspw. über ein Wortende hinweg o.ä. Ob man sich hier einheitlich für den Bogen darüber oder den Bogen darunter entscheidet, ist vermutlich ebenfalls Geschmackssache.

- Zum Thema Bogen (Breve) noch ein Vorschlag: es gibt öfters zwei Zeichen in Folge, die beide jeweils ein Minus Sign darunter haben (zB 'r̠i̠'). Im Originalbogen ist dies eigentlich ein einzelner durchgehender Strich, wodurch die beiden Zeichen eigentlich verbunden werden (was in der digitalen Version nicht gut ersichtlich ist). Ich habe diese Stellen ebenfalls durch einen Bogen ersetzt, da vermutlich etwas ähnliches gemeint ist. Soweit ich sehe, gibt es auch keine Skripte, die sowohl solche kombinierten Minusstriche als auch Ligaturbögen verwenden.
	'11855_Hof' macht dies konsequent. Hier habe ich alle einzelnen Stellen durch Ligaturbögen ersetzt (bspw 'a̠f̠' zu 'a͜f'), um vereinzelnte Zeichen wie f̠ im Inventarprofil zu verhindern.

- '23926_Mönchengladbach' hat bei mehreren Zeichen combining Arrowhead (bsp e᷾). Er ist der einzige Bogen, der das macht, macht dies aber auch bei mehreren Zeichen. Im Orginalskript sieht es auch stark danach aus, doch man könnte überlegen, ob das Bedeutungsgleich wie etwa ein ACUTE, GRAVE, o.ä. über einem Zeichen ist und das überschreiben, da der Bogen hier aus dem Muster fällt.

- Geschmackssache: Man könnte also single- und double Quotationmarks als einfache ' und " mergen, oder sie eben als ‘’‚“„” lassen

- '°' zwischen zwei Zeichen als eine Art 'hier müsste eigentlich ein Bindevokal hingehören, der ausgelassen/stark verkürzt wird' könnte auch durch Ligarturbögen o.ä. gekennzeichnet werden

- '33559_Würzburg' verwendet für eine Art Kombination aus t und d (d. h. t mit einem zusätzlichen Bogen wie beim d) das Zeichen 'd̞' (siehe Anmerkungen im digitalen Bogen). Da dies der einzige Bogen ist, der das so macht, habe ich mich für das Zeichen 'đ' entschieden, welches auch von anderen Bogen verwendet wird. Dies ist vielleicht auch nicht die beste Lösung, da dieses Zeichen tw wohl als eine Art englisches th verwendet wird.